### PR TITLE
Add support for astropy 4.3

### DIFF
--- a/scopesim/optics/surface_utils.py
+++ b/scopesim/optics/surface_utils.py
@@ -135,7 +135,9 @@ def is_flux_binned(unit):
     """
     unit = unit**1
     flag = False
-    if u.bin in unit._bases or "flux density" not in unit.physical_type:
+    # unit.physical_type is a string in astropy<=4.2 and a PhysicalType
+    # class in astropy==4.3 and thus has to be cast to a string first.
+    if u.bin in unit._bases or "flux density" not in str(unit.physical_type):
         flag = True
 
     return flag


### PR DESCRIPTION
Closes #65

See https://docs.astropy.org/en/latest/changelog.html#changelog

> **astropy.units**
> The physical_type attributes of each unit are now objects of the (new) astropy.units.physical.PhysicalType class instead of strings

This breaks `is_flux_binned()` in `surface_utils.py`.

Which in turn causes `make_emission_from_array()` to do some extra normalization.

Which in turn changes units like `ph / (arcsec2 m2 s um)` to `ph / (m2 s um2)`, that is, with a `um2` instead of just a `um`. This in turn makes Synphot unhappy, because the `physical_type` of this new unit is unknown and not a `photon flux density wav`.
