### PR TITLE
Oc/fix fov utils

### DIFF
--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -440,7 +440,9 @@ class FieldOfView(FieldOfViewBase):
             eq = u.spectral_density(fov_waveset)
             flux_scale_factor = u.Unit(field_unit).to("ph s-1 cm-2 AA-1",
                                                       equivalencies=eq)
-            field_data *= flux_scale_factor
+
+            # OC [2021-12-14] add extra dimensions for layer-wise multiplication of the cube
+            field_data *= flux_scale_factor[:, None, None]
             field_hdu = fits.ImageHDU(data=field_data, header=field.header)
             canvas_cube_hdu = imp_utils.add_imagehdu_to_imagehdu(field_hdu,
                                                     canvas_cube_hdu,


### PR DESCRIPTION
An exception was raised when the source did not cover the entire observed wavelength range. More specifically, the exception was raised when the wavelength range of an FOV had no points in common with the wavelength set of the source. Now, the function `extract_area_from_imagehdu()` returns `None` in this case. 
In `make_cube_hdu` a 1D array `flux_scale_factor` had to be broadcast to 3D to multiply `field_data` cube.