### PR TITLE
Turn AutoExposure into a detector_array_effect

### DIFF
--- a/scopesim/detector/detector_array.py
+++ b/scopesim/detector/detector_array.py
@@ -14,11 +14,12 @@ class DetectorArray:
         self.meta = {}
         self.meta.update(kwargs)
         self.detector_list = detector_list
-        self.effects = []
+        self.array_effects = []
+        self.dtcr_effects = []
         self.detectors = []
         self.latest_exposure = None
 
-    def readout(self, image_planes, effects=[], **kwargs):
+    def readout(self, image_planes, array_effects=[], dtcr_effects=[], **kwargs):
         """
         Read out the detector array into a FITS file
 
@@ -27,8 +28,11 @@ class DetectorArray:
         image_planes : list of ImagePlane objects
             The correct image plane is automatically chosen from the list
 
-        effects : list of Effect objects
-            A list of detector related effects
+        array_effects : list of Effect objects
+            A list of effects related to the detector array
+
+        dtcr_effects : list of Effect objects
+            A list of effects related to the detectors
 
         Returns
         -------
@@ -50,13 +54,18 @@ class DetectorArray:
         # - add ImageHDUs
         # - add ASCIITableHDU with Effects meta data in final table extension
 
-        self.effects = effects
+        self.array_effects = array_effects
+        self.dtcr_effects = dtcr_effects
         self.meta.update(kwargs)
 
         # 0. Get the image plane that corresponds to this detector array
         image_plane_id = self.detector_list.meta["image_plane_id"]
         image_plane = [implane for implane in image_planes if
                        implane.id == image_plane_id][0]
+
+        # 0a. Apply detector array effects (apply to the entire image plane)
+        for effect in self.array_effects:
+            image_plane = effect.apply_to(image_plane, **self.meta)
 
         # 1. make a series of Detectors for each row in a DetectorList object
         self.detectors = [Detector(hdr, **self.meta)
@@ -67,7 +76,7 @@ class DetectorArray:
             detector.extract_from(image_plane)
 
             # 3. apply all effects (to all Detectors)
-            for effect in self.effects:
+            for effect in self.dtcr_effects:
                 detector = effect.apply_to(detector)
 
             # 4. add necessary header keywords
@@ -75,7 +84,7 @@ class DetectorArray:
 
         # 5. Generate a HDUList with the ImageHDUs and any extras:
         pri_hdu = make_primary_hdu(self.meta)
-        effects_hdu = make_effects_hdu(self.effects)
+        effects_hdu = make_effects_hdu(self.array_effects + self.dtcr_effects)
 
         hdu_list = fits.HDUList([pri_hdu] +
                                 [dtcr.hdu for dtcr in self.detectors] +

--- a/scopesim/effects/electronic.py
+++ b/scopesim/effects/electronic.py
@@ -30,7 +30,8 @@ class AutoExposure(Effect):
     """
     Determine DIT and NDIT automatically from ImagePlane
 
-    DIT is determined such that the maximum value in the ``ImagePlane`` fills
+    DIT is determined such that the maximum value in the incident photon flux
+    (including astronomical source, sky and thermal backgrounds) fills
     the full well of the detector (``!DET.full_well``) to a given fraction
     (``!OBS.autoexposure.fill_frac``). NDIT is determined such that
     ``DIT`` * ``NDIT`` results in the requested exposure time.
@@ -53,8 +54,12 @@ class AutoExposure(Effect):
 
     """
     def __init__(self, **kwargs):
+        """
+        The effect is the first detector effect, hence essentially operates
+        on the `ImagePlane`, mapped to the detector array.
+        """
         super().__init__(**kwargs)
-        params = {"z_order": [760]}    # ..todo: change
+        params = {"z_order": [901]}
         self.meta.update(params)
         self.meta.update(kwargs)
 
@@ -62,11 +67,13 @@ class AutoExposure(Effect):
         check_keys(self.meta, required_keys, action="error")
 
     def apply_to(self, obj, **kwargs):
-        if isinstance(obj, ImagePlaneBase):
+        if isinstance(obj, (ImagePlaneBase, DetectorBase)):
             implane_max = np.max(obj.data)
-            exptime = from_currsys("!OBS.exptime")
+            #print("implane_max:", implane_max)
+            exptime = kwargs.get('exptime', from_currsys("!OBS.exptime"))
             if exptime is None:
                 exptime = from_currsys("!OBS.dit") * from_currsys("!OBS.ndit")
+            print("Requested exposure time: {:.3f} s".format(exptime))
             full_well = from_currsys(self.meta["full_well"])
             fill_frac = from_currsys(self.meta["fill_frac"])
             dit = fill_frac * full_well / implane_max
@@ -84,7 +91,8 @@ class AutoExposure(Effect):
                 # ..todo: turn into proper warning
 
             print("Exposure parameters:")
-            print("DIT: {:.3f} s     NDIT: {}".format(dit, ndit))
+            print("                DIT: {:.3f} s  NDIT: {}".format(dit, ndit))
+            print("Total exposure time: {:.3f} s".format(dit * ndit))
 
             rc.__currsys__['!OBS.dit'] = dit
             rc.__currsys__['!OBS.ndit'] = ndit

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -207,9 +207,10 @@ class OpticalTrain:
 
         hdus = []
         for i, detector_array in enumerate(self.detector_arrays):
+            array_effects = self.optics_manager.detector_array_effects
             dtcr_effects = self.optics_manager.detector_effects
-            hdu = detector_array.readout(self.image_planes, dtcr_effects,
-                                         **kwargs)
+            hdu = detector_array.readout(self.image_planes, array_effects,
+                                         dtcr_effects, **kwargs)
 
             if filename is not None and isinstance(filename, str):
                 fname = filename

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -183,6 +183,10 @@ class OpticsManager:
         return headers
 
     @property
+    def detector_array_effects(self):
+        return self.get_z_order_effects(900)
+
+    @property
     def detector_effects(self):
         return self.get_z_order_effects(800)
 
@@ -340,5 +344,3 @@ Summary of Effects in Optical Elements:
     def __str__(self):
         name = self.meta.get("name", self.meta.get("filename", "<empty>"))
         return '{}: "{}"'.format(type(self).__name__, name)
-
-


### PR DESCRIPTION
At the last meeting with LB and RvB it was requested that `OpticalTrain.readout()` should accept exposure time as an argument. To do this `AutoExposure` had to become a detector effect. However, `AutoExposure` needs to apply to the entire `DetectorArray`, rather than the indvidual `Detector` objects. I have therefore created a new effects list, `detector_array_effects`, identified by `z_order` 900-999.  Logically they come before the `detector_effects` (800-899), but I have abstained from renumbering everything for the time being. 
Review requested as this seems to be a somewhat larger change to Scopesim's operations.