### PR TITLE
Oc/adcwheel

### DIFF
--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -401,6 +401,7 @@ class SlitWheel(Effect):
         '''Change the current slit'''
         if not slitname or slitname in self.slits.keys():
             self.meta['current_slit'] = slitname
+            self.include = slitname
         else:
             raise ValueError("Unknown slit requested: " + slitname)
 

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -598,13 +598,11 @@ class ADCWheel(Effect):
         '''Use apply_to of current adc'''
         return self.current_adc.apply_to(obj, **kwargs)
 
-    def fov_grid(self, **kwargs):
-        return self.current_adc.fov_grid(**kwargs)
-
     def change_adc(self, adcname=None):
         """Change the current ADC"""
         if not adcname or adcname in self.adcs.keys():
             self.meta['current_adc'] = adcname
+            self.include = adcname
         else:
             raise ValueError("Unknown ADC requested: " + adcname)
 
@@ -628,7 +626,6 @@ class ADCWheel(Effect):
         """Create a table of ADCs with maximimum througput"""
         names = list(self.adcs.keys())
         adcs = self.adcs.values()
-        print(adcs)
         tmax = np.array([adc.data['transmission'].max() for adc in adcs])
 
         tbl = Table(names=["name", "max_transmission"],

--- a/scopesim/tests/mocks/files/TER_ADC_const_10.dat
+++ b/scopesim/tests/mocks/files/TER_ADC_const_10.dat
@@ -1,0 +1,16 @@
+# name : ADC spectral response
+# author : Oliver Czoske
+# source : Roy van Boekel
+# date_created : 2022-01-05
+# date_modified : 2022-01-05
+# status : simple estimate
+# type : adc:transmission
+# wavelength_unit : um
+# description : combined throughput of all surfaces of the ADC
+# changes :
+#
+  wavelength    transmission    reflection   emissivity
+  2.49          0               0            0
+  2.50          0.1             0            0
+  14.50         0.1             0            0
+  14.51         0               0            0

--- a/scopesim/tests/mocks/files/TER_ADC_const_90.dat
+++ b/scopesim/tests/mocks/files/TER_ADC_const_90.dat
@@ -1,0 +1,16 @@
+# name : ADC spectral response
+# author : Oliver Czoske
+# source : Roy van Boekel
+# date_created : 2022-01-05
+# date_modified : 2022-01-05
+# status : simple estimate
+# type : adc:transmission
+# wavelength_unit : um
+# description : combined throughput of all surfaces of the ADC
+# changes :
+#
+  wavelength    transmission    reflection   emissivity
+  2.49          0               0            0
+  2.50          0.9             0            0
+  14.50         0.9             0      	     0
+  14.51         0               0            0

--- a/scopesim/tests/tests_effects/test_adcwheel.py
+++ b/scopesim/tests/tests_effects/test_adcwheel.py
@@ -1,0 +1,51 @@
+'''Tests for class ADCWheel'''
+import os
+import pytest
+
+from scopesim import rc
+from scopesim.effects import TERCurve, ADCWheel
+
+FILES_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                          "../mocks/files/"))
+if FILES_PATH not in rc.__search_path__:
+    rc.__search_path__ += [FILES_PATH]
+
+@pytest.fixture(name="adcwheel", scope="class")
+def fixture_adcwheel():
+    '''Instantiate an ADCWheel'''
+    return ADCWheel(adc_names=["const_90", "const_10"],
+                    filename_format="TER_ADC_{}.dat",
+                    current_adc="const_90")
+
+# pylint: disable=no-self-use, missing-class-docstring,
+# pylint: disable=missing-function-docstring
+class TestADCWheel:
+    def test_initialises_correctly(self, adcwheel):
+        assert isinstance(adcwheel, ADCWheel)
+
+    def test_has_transmission_curves(self, adcwheel):
+        assert len(adcwheel.table) == 2
+
+    def test_current_adc_is_ter_curve(self, adcwheel):
+        assert isinstance(adcwheel.current_adc, TERCurve)
+
+    def test_current_adc_has_fov_grid_method(self, adcwheel):
+        assert hasattr(adcwheel.current_adc, "fov_grid")
+
+    def test_change_to_known_adc(self, adcwheel):
+        adcwheel.change_adc('const_10')
+        assert adcwheel.current_adc.meta['name'] == 'const_10'
+
+    def test_change_to_unknown_adc(self, adcwheel):
+        with pytest.raises(ValueError):
+            adcwheel.change_adc('X')
+
+    def test_reports_current_adc_false(self):
+        adcwheel = ADCWheel(adc_names=["const_90", "const_10"],
+                            filename_format="TER_ADC_{}.dat",
+                            current_adc=False)
+        assert not adcwheel.current_adc
+
+    def test_changes_to_false(self, adcwheel):
+        adcwheel.change_adc(False)
+        assert not adcwheel.current_adc


### PR DESCRIPTION
A wheel for atmospheric dispersion correctors has been implemented to enable switching between several fixed ADCs (as foreseen for METIS). The ADCs are currently implemented as TERCurves, i.e. as purely transmissive elements. The wheel structure should be still useful when we have a proper ADC class with residual differential refraction.
There's also a small change to `SlitWheel.change_slit()`: When changing to `False`, `SlitWheel.include` must also be set to `False`, otherwise it will complain about `False` not having a method `apply_to()`. 