### PR TITLE
Increase number of points in st_spectrum and ab_spectrum for use in M…

### DIFF
--- a/scopesim/source/source_templates.py
+++ b/scopesim/source/source_templates.py
@@ -154,14 +154,18 @@ def vega_spectrum(mag=0):
 
 
 def st_spectrum(mag=0):
-    waves = np.geomspace(100, 300000, 5000)
+    # ..todo: the waves vector is a bit random, in particular its length, but sets the resolution of
+    #         the final spectrum in scopesim. Can this be make more general?
+    waves = np.geomspace(100, 300000, 50000)
     sp = ConstFlux1D(amplitude=mag*u.STmag)
 
     return SourceSpectrum(Empirical1D, points=waves, lookup_table=sp(waves))
 
 
 def ab_spectrum(mag=0):
-    waves = np.geomspace(100, 300000, 5000)
+    # ..todo: the waves vector is a bit random, in particular its length, but sets the resolution of
+    #         the final spectrum in scopesim. Can this be make more general?
+    waves = np.geomspace(100, 300000, 50000)
     sp = ConstFlux1D(amplitude=mag * u.ABmag)
 
     return SourceSpectrum(Empirical1D, points=waves, lookup_table=sp(waves))


### PR DESCRIPTION
Quick hack to save the resolution of the atmospheric transmission in METIS LSS. The original waveset of just 5000 points between 0.1 um and 30 um in `ab_spectrum` and `st_spectrum` caused the atmospheric transmission spectrum to be downsampled to this waveset (with loss of resolution) before being linearly upsampled to the required waveset in the FieldOfView object. The new waveset of 50000 points is sufficient for METIS LSS, but it won't be for the LMS. Ultimately, a more general solution needs to be found.