### PR TITLE
Oc/fix spectral shape 3

### DIFF
--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -210,6 +210,7 @@ class SpectralTrace:
         avg_dlam_per_pix = (wave_max - wave_min) / sub_naxis2
         try:
             xilam = XiLamImage(fov, avg_dlam_per_pix)
+            self.xilam = xilam    # ..todo: remove
         except ValueError:
             print(" ---> ", self.meta['trace_id'], "gave ValueError")
 
@@ -527,7 +528,7 @@ class XiLamImage():
         # arrays of cube coordinates
         cube_xi = d_xi * np.arange(n_xi) + fov.meta['xi_min'].value
         cube_eta = d_eta * (np.arange(n_eta) - (n_eta - 1) / 2)
-        cube_lam = wcs_lam.all_pix2world(np.arange(n_lam), 0)[0]
+        cube_lam = wcs_lam.all_pix2world(np.arange(n_lam), 1)[0]
         cube_lam *= u.Unit(wcs_lam.wcs.cunit[0]).to(u.um)
 
         # Initialise the array to hold the xi-lambda image

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -509,7 +509,7 @@ class FieldOfView(FieldOfViewBase):
         cdelt3 = np.diff(fov_waveset[:2])[0]
         canvas_cube_hdu.header.update({"CDELT3": cdelt3.to(u.um).value,
                                        "CRVAL3": fov_waveset[0].value,
-                                       "CRPIX3": 0,
+                                       "CRPIX3": 1,
                                        "CUNIT3": "um",
                                        "CTYPE3": "WAVE"})
         # ..todo: Add the log wavelength keyword here, if log scale is needed


### PR DESCRIPTION
Hopefully final correction to PSF scaling. The interpolated PSF needs to be scaled by the ratio of the squared pixel scales of input and output (reducing the pixel scale increases the number of pixels needed to map the entire input PSF; scaling the interpolated PSF compensates for that). The input pixel scale for the creation a wavelength-dependent cube scales as wavelength; so wavelength-scaling of the output PSF is implicit.
A few WCS tweaks - these are a bit intransparent, but give correct wavelength-pixel mapping in the image plane in my tests.