### PR TITLE
Oc/fix det modes

### DIFF
--- a/scopesim/tests/tests_effects/test_LinearityCurve.py
+++ b/scopesim/tests/tests_effects/test_LinearityCurve.py
@@ -43,6 +43,12 @@ class TestInit:
         assert "incident" in lincurve.table.colnames
         assert "measured" in lincurve.table.colnames
 
+    def test_initialises_with_vectors(self):
+        lincurve = LinearityCurve(incident=[0, 50, 100],
+                                  measured=[0, 75, 100],
+                                  ndit=2)
+        assert "incident" in lincurve.meta
+        assert "measured" in lincurve.meta
 
 class TestApplyTo:
     @pytest.mark.parametrize("in_flux, out_flux", [(20, 10), (45, 52.5),


### PR DESCRIPTION
Problem: The Geosnap has two modes that differ in full_well and therefore require different linearity curves. Using files did not work because `LinearityCurve` is initialised from a file only once and is not updated when `DetectorModePropertiesSetter` selects a different mode and a different linearity file. 
Solution: `LinearityCurve` can now be initialised by giving kwargs `incident` and `measured` directly. In the Geosnap yaml, `DetectorModePropertiesSetter` sets variable `!DET.linearity.incident` appropriate for each mode, `LinearityCurve` sets kwarg `incident` to `!DET.linearity.incident`, and correspondingly for `measured`. 
Shortcomings: Once finely sampled measured linearity curves become available it becomes unpractical to store the vectors directly in the yaml files. A solution to reinstantiate effects by rereading files should be found (if it is already there I have not found it...).  