### PR TITLE
Oc/apply to cube sources

### DIFF
--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -10,7 +10,8 @@ from astropy import units as u
 from synphot import SourceSpectrum
 from synphot.units import PHOTLAM
 
-from .ter_curves_utils import combine_two_spectra, add_edge_zeros, download_svo_filter
+from .ter_curves_utils import combine_two_spectra, apply_throughput_to_cube
+from .ter_curves_utils import add_edge_zeros, download_svo_filter
 from .effects import Effect
 from ..optics.surface import SpectralSurface
 from ..source.source_utils import make_imagehdu_from_table
@@ -95,10 +96,15 @@ class TERCurve(Effect):
             wave_max = quantify(self.meta["wave_max"], u.um).to(u.AA)
 
             # apply transmission to source spectra
-            for ii, spec in enumerate(obj.spectra):
+            for isp, spec in enumerate(obj.spectra):
                 thru = self.throughput
-                obj.spectra[ii] = combine_two_spectra(spec, thru, "multiply",
-                                                      wave_min, wave_max)
+                obj.spectra[isp] = combine_two_spectra(spec, thru, "multiply",
+                                                       wave_min, wave_max)
+
+            # apply transmission to cube fields
+            for icube, cube in enumerate(obj.cube_fields):
+                thru = self.throughput
+                obj.cube_fields[icube] = apply_throughput_to_cube(cube, thru)
 
             # add the effect background to the source background field
             if self.background_source is not None:

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -95,15 +95,15 @@ class TERCurve(Effect):
             wave_min = quantify(self.meta["wave_min"], u.um).to(u.AA)
             wave_max = quantify(self.meta["wave_max"], u.um).to(u.AA)
 
+            thru = self.throughput
+
             # apply transmission to source spectra
             for isp, spec in enumerate(obj.spectra):
-                thru = self.throughput
                 obj.spectra[isp] = combine_two_spectra(spec, thru, "multiply",
                                                        wave_min, wave_max)
 
             # apply transmission to cube fields
             for icube, cube in enumerate(obj.cube_fields):
-                thru = self.throughput
                 obj.cube_fields[icube] = apply_throughput_to_cube(cube, thru)
 
             # add the effect background to the source background field

--- a/scopesim/effects/ter_curves_utils.py
+++ b/scopesim/effects/ter_curves_utils.py
@@ -3,6 +3,7 @@ from astropy import units as u
 from astropy.table import Table
 from astropy.utils.data import download_file
 from astropy.io import ascii as ioascii
+from astropy.wcs import WCS
 from synphot import SpectralElement, SourceSpectrum, Empirical1D, Observation
 from synphot.units import PHOTLAM
 
@@ -245,6 +246,27 @@ def scale_spectrum(spectrum, filter_name, amplitude):
 
     return spectrum
 
+def apply_throughput_to_cube(cube, thru):
+    """
+    Apply throughput curve to a spectroscopic cube
+
+    Parameters
+    ----------
+    cube : ImageHDU
+         three-dimensional image, dimension 0 (in python convention) is the
+         spectral dimension. WCS is required.
+    thru : synphot.SpectralElement, synphot.SourceSpectrum
+
+    Returns
+    -------
+    cube : ImageHDU, header unchanged, data multiplied with wavelength-dependent
+         throughput
+    """
+    wcs = WCS(cube.header).spectral
+    wave_cube = wcs.all_pix2world(np.arange(cube.data.shape[0]), 0)[0]
+    wave_cube = (wave_cube * u.Unit(wcs.wcs.cunit[0])).to(u.AA)
+    cube.data *= thru(wave_cube).value[:, None, None]
+    return cube
 
 def combine_two_spectra(spec_a, spec_b, action, wave_min, wave_max):
     """

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -290,6 +290,7 @@ class FieldOfView(FieldOfViewBase):
         for field in self.cube_fields:
             # cube_fields come in with units of photlam/arcsec2, need to convert to ph/s
             # We need to the voxel volume (spectral and solid angle) for that.
+            # ..todo: implement branch for use_photlam is True
             spectral_bin_width = (field.header['CDELT3'] *
                                   u.Unit(field.header['CUNIT3'])).to(u.Angstrom)
             pixarea = (field.header['CDELT1'] * u.Unit(field.header['CUNIT1']) *

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -467,9 +467,15 @@ class FieldOfView(FieldOfViewBase):
         for field in self.image_fields:
             # Cube should be in PHOTLAM arcsec-2 for SpectralTrace mapping
             # Assumption is that ImageHDUs have units of PHOTLAM arcsec-2
+            # ImageHDUs have photons/second/pixel.
             # ..todo: Add a catch to get ImageHDU with BUNITs
             canvas_image_hdu = fits.ImageHDU(data=np.zeros((naxis2, naxis1)),
                                              header=self.header)
+            pixarea = (field.header['CDELT1'] * u.Unit(field.header['CUNIT1']) *
+                       field.header['CDELT2'] * u.Unit(field.header['CUNIT2'])).to(u.arcsec**2)
+
+            #field.data = field.data / pixarea.value
+            field.data = field.data / fov_pixarea
             canvas_image_hdu = imp_utils.add_imagehdu_to_imagehdu(field,
                                                     canvas_image_hdu,
                                                     spline_order=spline_order)

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -101,15 +101,14 @@ class FieldOfView(FieldOfViewBase):
 
         spec_refs = []
         volume = self.volume()
-        for i in range(len(fields_in_fov)):
-            fld = fields_in_fov[i]
+        for ifld, fld in enumerate(fields_in_fov):
             if isinstance(fld, Table):
-                fields_in_fov[i] = fu.extract_area_from_table(fld, volume)
-                spec_refs += list(np.unique(fields_in_fov[i] ["ref"]))
+                fields_in_fov[ifld] = fu.extract_area_from_table(fld, volume)
+                spec_refs += list(np.unique(fields_in_fov[ifld] ["ref"]))
 
             elif isinstance(fld, fits.ImageHDU):
                 if fld.header["NAXIS"] in (2, 3):
-                    fields_in_fov[i] = fu.extract_area_from_imagehdu(fld, volume)
+                    fields_in_fov[ifld] = fu.extract_area_from_imagehdu(fld, volume)
                 if fld.header["NAXIS"] == 2 or fld.header.get("BG_SRC"):
                     ref = fld.header.get("SPEC_REF")
                     if ref is not None:

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -288,7 +288,9 @@ class FieldOfView(FieldOfViewBase):
 
         # 2. Find Cube fields
         for field in self.cube_fields:
-            image = np.sum(field.data, axis=0)
+            bin_width = (field.header['CDELT3'] * u.Unit(field.header['CUNIT3'])).to(u.Angstrom)
+            print(f"Bin width: {bin_width}")
+            image = np.sum(field.data, axis=0) * bin_width.value
             tmp_hdu = fits.ImageHDU(data=image, header=field.header)
             canvas_image_hdu = imp_utils.add_imagehdu_to_imagehdu(
                 tmp_hdu,
@@ -348,7 +350,7 @@ class FieldOfView(FieldOfViewBase):
 
         .. note:: ``self.make_cube()`` does NOT store anything in ``self.cube``
 
-            self.cube and self.make_cube() are deliberately keep seperately
+            self.cube and self.make_cube() are deliberately kept seperately
             so that self.cube will not be accidently overwritten by a rogue
             call from an Effect object.
 

--- a/scopesim/optics/fov_utils.py
+++ b/scopesim/optics/fov_utils.py
@@ -296,8 +296,10 @@ def extract_area_from_imagehdu(imagehdu, fov_volume):
 
     xp, yp = imp_utils.val2pix(hdr, np.array([x0s, x1s]), np.array([y0s, y1s]))
     (x0p, x1p), (y0p, y1p) = np.round(xp).astype(int), np.round(yp).astype(int)
-    if x0p == x1p: x1p += 1
-    if y0p == y1p: y1p += 1
+    if x0p == x1p:
+        x1p += 1
+    if y0p == y1p:
+        y1p += 1
 
     new_hdr = imp_utils.header_from_list_of_xy([x0s, x1s], [y0s, y1s],
                                                pixel_scale=hdr["CDELT1"])

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -683,8 +683,8 @@ def add_imagehdu_to_imagehdu(image_hdu, canvas_hdu, spline_order=1,
                                 wcs_suffix=wcs_suffix, spline_order=spline_order,
                                 conserve_flux=conserve_flux)
 
-    xcen_im = new_hdu.header["NAXIS1"] // 2
-    ycen_im = new_hdu.header["NAXIS2"] // 2
+    xcen_im = (new_hdu.header["NAXIS1"] - 1) / 2 #// 2
+    ycen_im = (new_hdu.header["NAXIS2"] - 1) / 2 #// 2
 
     xsky0, ysky0 = pix2val(new_hdu.header, xcen_im, ycen_im, wcs_suffix)
     xpix0, ypix0 = val2pix(canvas_hdu.header, xsky0, ysky0, wcs_suffix)
@@ -692,7 +692,8 @@ def add_imagehdu_to_imagehdu(image_hdu, canvas_hdu, spline_order=1,
     # again, I need to add this transpose operation - WHY????
     # Image plane tests need the transpose operation, but FOV broadcast tests don't. Weird
     canvas_hdu.data = overlay_image(new_hdu.data, canvas_hdu.data,
-                                    coords=(xpix0, ypix0))
+                                    coords=(xpix0+1, ypix0+1))
+                                    #coords=(xpix0, ypix0))
 
     return canvas_hdu
 

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -222,6 +222,7 @@ class OpticalTrain:
             pixarea = (header['CDELT1'] * u.Unit(header['CUNIT1'].lower()) *
                        header['CDELT2'] * u.Unit(header['CUNIT2'].lower())).to(u.arcsec**2)
             cube.data = data / pixarea.value    # cube is per arcsec2
+            cube.header['BUNIT'] = 'PHOTLAM/arcsec2'    # ..todo: make this more explicit?
 
             # Put on fov wavegrid
             # ..todo: This assumes that we have only one fov. Generalise?

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -206,7 +206,6 @@ class OpticalTrain:
         when the source data are sampled on a coarser grid than used internally, or if the source
         data are sampled on irregular wavelengths.
         """
-        ### Normalise cube sources -- ..todo: should this be done on the copy in observe?
         # Convert to PHOTLAM per arcsec2
         # ..todo: this is not sufficiently general
         for cube in source.cube_fields:

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -157,6 +157,8 @@ class OpticalTrain:
         # ..todo:: check if orig_source is a pointer, or a data array
         source = orig_source.make_copy()
 
+        source.prepare_for_observation(self.cmds)
+
         # [1D - transmission curves]
         for effect in self.optics_manager.source_effects:
             source = effect.apply_to(source)

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -162,9 +162,9 @@ class OpticalTrain:
 
         self.set_focus(**kwargs)    # put focus back on current instrument package
 
-        # ..todo:: check if orig_source is a pointer, or a data array
+        # Make a copy of the Source and prepare for observation (convert to
+        # internally used units, sample to internal wavelength grid)
         source = orig_source.make_copy()
-
         source = self.prepare_source(source)
 
         # [1D - transmission curves]
@@ -202,27 +202,49 @@ class OpticalTrain:
 
         The method is currently applied to cube fields only.
         The source data are converted to internally used units (PHOTLAM).
-        The source data are interpolated to the waveset used by the FieldOfView. This is necessary
-        when the source data are sampled on a coarser grid than used internally, or if the source
-        data are sampled on irregular wavelengths.
+        The source data are interpolated to the waveset used by the FieldOfView
+        This is necessary when the source data are sampled on a coarser grid
+        than used internally, or if the source data are sampled on irregular
+        wavelengths.
+        For cube fields, the method assumes that the wavelengths at which the
+        cube is sampled is provided explicitely as attribute `wave` if the cube
+        ImageHDU.
         """
         # Convert to PHOTLAM per arcsec2
         # ..todo: this is not sufficiently general
-        for cube in source.cube_fields:
-            header, data = cube.header, cube.data
-            wcs_spec = WCS(header).spectral
-            cube_wave = (wcs_spec.all_pix2world(np.arange(data.shape[0]), 0)[0]
-                         * u.Unit(wcs_spec.wcs.cunit[0]))
-            data = data * u.Unit(header['BUNIT'])
-            data = data.to(PHOTLAM,
-                           equivalencies=u.spectral_density(cube_wave[:, None, None]))
 
-            ##Normalise to 1 arcsec2
-            # ..todo: lower needed because "DEG" is not understood, this is ugly
-            pixarea = (header['CDELT1'] * u.Unit(header['CUNIT1'].lower()) *
-                       header['CDELT2'] * u.Unit(header['CUNIT2'].lower())).to(u.arcsec**2)
-            cube.data = data / pixarea.value    # cube is per arcsec2
+        for cube in source.cube_fields:
+            header, data, wave = cube.header, cube.data, cube.wave
+
+            # Need to check whether BUNIT is per arcsec2 or per pixel
+            inunit = u.Unit(header['BUNIT'])
+            data = data.astype(np.float32) * inunit
+            factor = 1
+            for un, power in zip(inunit.bases, inunit.powers):
+                if (un**power).is_equivalent(u.arcsec**(-2)):
+                    conversion =(un**power).to(u.arcsec**(-2)) / un**power
+                    data *= conversion
+                    factor = u.arcsec**(-2)
+
+            data = data.to(PHOTLAM,
+                           equivalencies=u.spectral_density(wave[:, None, None]))
+
+            if factor == 1:    # Normalise to 1 arcsec2 if not a spatial density
+                # ..todo: lower needed because "DEG" is not understood, this is ugly
+                pixarea = (header['CDELT1'] * u.Unit(header['CUNIT1'].lower()) *
+                           header['CDELT2'] * u.Unit(header['CUNIT2'].lower())).to(u.arcsec**2)
+                data = data / pixarea.value    # cube is per arcsec2
+
+            data = (data * factor).value
+
             cube.header['BUNIT'] = 'PHOTLAM/arcsec2'    # ..todo: make this more explicit?
+
+            # The imageplane_utils like to have the spatial WCS in units of "deg". Ensure
+            # that the cube is passed on accordingly
+            cube.header['CDELT1'] = header['CDELT1'] * u.Unit(header['CUNIT1'].lower()).to(u.deg)
+            cube.header['CDELT2'] = header['CDELT2'] * u.Unit(header['CUNIT2'].lower()).to(u.deg)
+            cube.header['CUNIT1'] = 'deg'
+            cube.header['CUNIT2'] = 'deg'
 
             # Put on fov wavegrid
             # ..todo: This assumes that we have only one fov. Generalise?
@@ -234,21 +256,20 @@ class OpticalTrain:
             dwave = from_currsys("!SIM.spectral.spectral_bin_width")  # Not a quantity
             fov_waveset = np.arange(wave_min.value, wave_max.value, dwave) * wave_unit
             fov_waveset = fov_waveset.to(u.um)
+            print(f"Interpolating from {data.shape} to {fov_waveset.shape}")
+            cube.data = np.zeros((fov_waveset.shape[0], data.shape[1], data.shape[2]),
+                                 dtype=np.float32)
+            for j in range(data.shape[1]):
+                cube_interp = interp1d(wave.to(u.um).value, data[:, j, :], axis=0, kind="linear",
+                                       bounds_error=False, fill_value=0)
+                cube.data[:, j, :] = cube_interp(fov_waveset.value)
+            print("Interpolation done")
 
-            cube_waveset = fu.get_cube_waveset(header,
-                                               return_quantity=True)
-            # ..todo: Deal with this bounds_error in a more elegant way
-            cube_interp = interp1d(cube_waveset.to(u.um).value,
-                                   cube.data, axis=0, kind="linear",
-                                   bounds_error=False, fill_value=0)
-
-            cube.data = cube_interp(fov_waveset.value)
             cube.header['CTYPE3'] = 'WAVE'
             cube.header['CRPIX3'] = 1
             cube.header['CRVAL3'] = wave_min.value
             cube.header['CDELT3'] = dwave
             cube.header['CUNIT3'] = wave_unit.name
-
         return source
 
     def readout(self, filename=None, **kwargs):

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -358,29 +358,6 @@ class Source(SourceBase):
 
         self.fields += [cube_hdu]
 
-    def prepare_for_observation(self, params):
-        """
-        Convert source to internally used units
-        """
-        ### Normalise cube sources -- ..todo: should this be done on the copy in observe?
-        # Convert to PHOTLAM per arcsec2
-        # ..todo: this is not sufficiently general
-        for cube in self.cube_fields:
-            header, data = cube.header, cube.data
-            wcs_spec = WCS(header).spectral
-            cube_wave = (wcs_spec.all_pix2world(np.arange(data.shape[0]), 0)[0]
-                         * u.Unit(wcs_spec.wcs.cunit[0]))
-            data = data * u.Unit(header['BUNIT'])
-            data = data.to(PHOTLAM,
-                           equivalencies=u.spectral_density(cube_wave[:, None, None]))
-
-            ##Normalise to 1 arcsec2
-            pixarea = (header['CDELT1'] * u.Unit(header['CUNIT1']) *
-                       header['CDELT2'] * u.Unit(header['CUNIT2'])).to(u.arcsec**2)
-            cube.data = data / pixarea.value    # cube is per arcsec2
-
-
-
     @property
     def table_fields(self):
         """List of fields that are defined through tables"""

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -350,11 +350,15 @@ class Source(SourceBase):
         if header["CTYPE3"].lower() not in ["freq", 'wave', "awav", 'wavelength']:
             raise ValueError("Only ['FREQ','WAVE','AWAV', 'WAVELENGTH'] are supported")
 
+        ### Normalise cube sources -- ..todo: should this be done on the copy in observe?
         # Convert to PHOTLAM per arcsec2
         # ..todo: this is not sufficiently general
         wcs_spec = WCS(header).spectral
-        cube_wave = wcs_spec.all_pix2world(np.arange(data.shape[0]), 0)[0] * u.Unit(wcs_spec.wcs.cunit[0])
-        data = (data * u.Unit(bunit)).to(PHOTLAM, equivalencies=u.spectral_density(cube_wave[:, None, None]))
+        cube_wave = (wcs_spec.all_pix2world(np.arange(data.shape[0]), 0)[0]
+                     * u.Unit(wcs_spec.wcs.cunit[0]))
+        data = data * u.Unit(bunit)
+        data = data.to(PHOTLAM,
+                       equivalencies=u.spectral_density(cube_wave[:, None, None])))
 
         #Normalise to 1 arcsec2
         pixarea = (header['CDELT1'] * u.Unit(header['CUNIT1']) *

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -277,30 +277,33 @@ class Source(SourceBase):
             f"You can bypass this check by passing an astropy Unit to the flux parameter:\n" \
             f">>> Source(image_hdu=..., flux=u.Unit(bunit), ...)"
 
-        ang_i = -1
-        phys_types = [base.physical_type for base in bunit.bases]
-        if "solid angle" in phys_types or "angle" in phys_types:
-            ang_i = np.argwhere([(pt == "solid angle" or pt == "angle")
-                                 for pt in phys_types])[0][0]
-            solid_angle = bunit.bases[ang_i] ** bunit.powers[ang_i]
-            scale_factor = solid_angle.to(u.arcsec**-2)
-
-        else:
-            hdr = image_hdu.header
-            pixel_area = hdr["CDELT1"] * u.Unit(hdr["CUNIT1"]) * \
-                         hdr["CDELT2"] * u.Unit(hdr["CUNIT2"])
-            scale_factor = (1 / pixel_area).to(u.arcsec**-2).value
-
-        image_hdu.data *= scale_factor
-        image_hdu.header["SOLIDANG"] = "arcsec-2"
-
-        flux_unit = u.Unit("")
-        for i in range(len(bunit.bases)):
-            if i != ang_i:
-                flux_unit *= (bunit.bases[i] ** bunit.powers[i])
-
-        value = 0 if flux_unit in [u.mag, u.ABmag] else 1
-        self._from_imagehdu_and_flux(image_hdu, value*flux_unit)
+        # ang_i = -1
+        # phys_types = [base.physical_type for base in bunit.bases]
+        # if "solid angle" in phys_types or "angle" in phys_types:
+        #     ang_i = np.argwhere([(pt == "solid angle" or pt == "angle")
+        #                          for pt in phys_types])[0][0]
+        #     solid_angle = bunit.bases[ang_i] ** bunit.powers[ang_i]
+        #     scale_factor = solid_angle.to(u.arcsec**-2)
+        #
+        # else:
+        #     hdr = image_hdu.header
+        #     pixel_area = hdr["CDELT1"] * u.Unit(hdr["CUNIT1"]) * \
+        #                  hdr["CDELT2"] * u.Unit(hdr["CUNIT2"])
+        #     scale_factor = (1 / pixel_area).to(u.arcsec**-2).value
+        #     print("scale_factor:", scale_factor)
+        #
+        # image_hdu.data *= scale_factor
+        # image_hdu.header["SOLIDANG"] = "arcsec-2"
+        #
+        # flux_unit = u.Unit("")
+        # for i in range(len(bunit.bases)):
+        #     if i != ang_i:
+        #         flux_unit *= (bunit.bases[i] ** bunit.powers[i])
+        #
+        # value = 0 if flux_unit in [u.mag, u.ABmag] else 1
+        # self._from_imagehdu_and_flux(image_hdu, value*flux_unit)
+        value = 0 if bunit in [u.mag, u.ABmag] else 1
+        self._from_imagehdu_and_flux(image_hdu, value * bunit)
 
     def _from_arrays(self, x, y, ref, weight, spectra):
         if weight is None:

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -359,7 +359,7 @@ class Source(SourceBase):
         #Normalise to 1 arcsec2
         pixarea = (header['CDELT1'] * u.Unit(header['CUNIT1']) *
                    header['CDELT2'] * u.Unit(header['CUNIT2'])).to(u.arcsec**2)
-        data /= pixarea.value
+        data /= pixarea.value    # cube is per arcsec2
         target_cube = data.value
         target_hdr = header.copy()
         target_hdr["BUNIT"] = bunit

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -277,31 +277,6 @@ class Source(SourceBase):
             f"You can bypass this check by passing an astropy Unit to the flux parameter:\n" \
             f">>> Source(image_hdu=..., flux=u.Unit(bunit), ...)"
 
-        # ang_i = -1
-        # phys_types = [base.physical_type for base in bunit.bases]
-        # if "solid angle" in phys_types or "angle" in phys_types:
-        #     ang_i = np.argwhere([(pt == "solid angle" or pt == "angle")
-        #                          for pt in phys_types])[0][0]
-        #     solid_angle = bunit.bases[ang_i] ** bunit.powers[ang_i]
-        #     scale_factor = solid_angle.to(u.arcsec**-2)
-        #
-        # else:
-        #     hdr = image_hdu.header
-        #     pixel_area = hdr["CDELT1"] * u.Unit(hdr["CUNIT1"]) * \
-        #                  hdr["CDELT2"] * u.Unit(hdr["CUNIT2"])
-        #     scale_factor = (1 / pixel_area).to(u.arcsec**-2).value
-        #     print("scale_factor:", scale_factor)
-        #
-        # image_hdu.data *= scale_factor
-        # image_hdu.header["SOLIDANG"] = "arcsec-2"
-        #
-        # flux_unit = u.Unit("")
-        # for i in range(len(bunit.bases)):
-        #     if i != ang_i:
-        #         flux_unit *= (bunit.bases[i] ** bunit.powers[i])
-        #
-        # value = 0 if flux_unit in [u.mag, u.ABmag] else 1
-        # self._from_imagehdu_and_flux(image_hdu, value*flux_unit)
         value = 0 if bunit in [u.mag, u.ABmag] else 1
         self._from_imagehdu_and_flux(image_hdu, value * bunit)
 

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -350,27 +350,36 @@ class Source(SourceBase):
         if header["CTYPE3"].lower() not in ["freq", 'wave', "awav", 'wavelength']:
             raise ValueError("Only ['FREQ','WAVE','AWAV', 'WAVELENGTH'] are supported")
 
-        ### Normalise cube sources -- ..todo: should this be done on the copy in observe?
-        # Convert to PHOTLAM per arcsec2
-        # ..todo: this is not sufficiently general
-        wcs_spec = WCS(header).spectral
-        cube_wave = (wcs_spec.all_pix2world(np.arange(data.shape[0]), 0)[0]
-                     * u.Unit(wcs_spec.wcs.cunit[0]))
-        data = data * u.Unit(bunit)
-        data = data.to(PHOTLAM,
-                       equivalencies=u.spectral_density(cube_wave[:, None, None]))
-
-        #Normalise to 1 arcsec2
-        pixarea = (header['CDELT1'] * u.Unit(header['CUNIT1']) *
-                   header['CDELT2'] * u.Unit(header['CUNIT2'])).to(u.arcsec**2)
-        data /= pixarea.value    # cube is per arcsec2
-        target_cube = data.value
+        target_cube = data
         target_hdr = header.copy()
         target_hdr["BUNIT"] = bunit
 
         cube_hdu = fits.ImageHDU(data=target_cube, header=target_hdr)
 
         self.fields += [cube_hdu]
+
+    def prepare_for_observation(self, params):
+        """
+        Convert source to internally used units
+        """
+        ### Normalise cube sources -- ..todo: should this be done on the copy in observe?
+        # Convert to PHOTLAM per arcsec2
+        # ..todo: this is not sufficiently general
+        for cube in self.cube_fields:
+            header, data = cube.header, cube.data
+            wcs_spec = WCS(header).spectral
+            cube_wave = (wcs_spec.all_pix2world(np.arange(data.shape[0]), 0)[0]
+                         * u.Unit(wcs_spec.wcs.cunit[0]))
+            data = data * u.Unit(header['BUNIT'])
+            data = data.to(PHOTLAM,
+                           equivalencies=u.spectral_density(cube_wave[:, None, None]))
+
+            ##Normalise to 1 arcsec2
+            pixarea = (header['CDELT1'] * u.Unit(header['CUNIT1']) *
+                       header['CDELT2'] * u.Unit(header['CUNIT2'])).to(u.arcsec**2)
+            cube.data = data / pixarea.value    # cube is per arcsec2
+
+
 
     @property
     def table_fields(self):

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -526,18 +526,28 @@ class Source(SourceBase):
                              "".format(type(new_source)))
 
     def plot(self):
+        """
+        Plot the location of source components
+
+        Source components instantiated from 2d or 3d ImageHDUs are represented by their
+        spatial footprint. Source components instantiated from tables are shown as points.
+        """
+        # pylint: disable=import-outside-toplevel
         import matplotlib.pyplot as plt
-        clrs = "rgbcymk" * (len(self.fields) // 7 + 1)
-        for c, field in zip(clrs, self.fields):
+
+        colours = "rgbcymk" * (len(self.fields) // 7 + 1)
+        for col, field in zip(colours, self.fields):
             if isinstance(field, Table):
-                plt.plot(field["x"], field["y"], c+".")
+                plt.plot(field["x"], field["y"], col+".")
             elif isinstance(field, (fits.ImageHDU, fits.PrimaryHDU)):
-                x, y = imp_utils.calc_footprint(field.header)
-                x *= 3600   # Because ImageHDUs are always in CUNIT=DEG
-                y *= 3600
-                x = list(x) + [x[0]]
-                y = list(y) + [y[0]]
-                plt.plot(x, y, c)
+                xpts, ypts = imp_utils.calc_footprint(field.header)
+                xpts *= 3600   # Because ImageHDUs are always in CUNIT=DEG
+                ypts *= 3600
+                xpts = list(xpts) + [xpts[0]]
+                ypts = list(ypts) + [ypts[0]]
+                plt.plot(xpts, ypts, col)
+                plt.xlabel("x [arcsec]")
+                plt.ylabel("y [arcsec]")
         plt.gca().set_aspect("equal")
 
     def make_copy(self):

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -358,7 +358,7 @@ class Source(SourceBase):
                      * u.Unit(wcs_spec.wcs.cunit[0]))
         data = data * u.Unit(bunit)
         data = data.to(PHOTLAM,
-                       equivalencies=u.spectral_density(cube_wave[:, None, None])))
+                       equivalencies=u.spectral_density(cube_wave[:, None, None]))
 
         #Normalise to 1 arcsec2
         pixarea = (header['CDELT1'] * u.Unit(header['CUNIT1']) *

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -63,7 +63,7 @@ class Source(SourceBase):
     in memory as a single Source object.
 
     The spatial descriptions are kept in the ``<Source>.fields`` list,
-    while the spectral descriptions are in ``<Source>.spectra`` list.
+    while the spectral descriptions are in the ``<Source>.spectra`` list.
 
     The spatial description can be built from any combination of:
 
@@ -73,9 +73,8 @@ class Source(SourceBase):
     * on disk FITS files
     * on disk ASCII tables
 
-    while the spectral descriptions can be passed as either
-    ``synphot.SourceSpectrum`` objects, or a set of two equal length arrays
-    for wavelength and flux.
+    The spectral descriptions can be passed as either ``synphot.SourceSpectrum``
+    objects, or a set of two equal length arrays for wavelength and flux.
 
     .. hint:: Initialisation parameter combinations include:
 
@@ -148,10 +147,10 @@ class Source(SourceBase):
 
         self.bandpass = None
 
-        valid = validate_source_input(lam=lam, x=x, y=y, ref=ref, weight=weight,
-                                      spectra=spectra, table=table, cube=cube,
-                                      ext=ext, image_hdu=image_hdu, flux=flux,
-                                      filename=filename)
+        validate_source_input(lam=lam, x=x, y=y, ref=ref, weight=weight,
+                              spectra=spectra, table=table, cube=cube,
+                              ext=ext, image_hdu=image_hdu, flux=flux,
+                              filename=filename)
 
         if spectra is not None:
             spectra = convert_to_list_of_spectra(spectra, lam)
@@ -340,11 +339,11 @@ class Source(SourceBase):
         try:
             bunit = header['BUNIT']
             u.Unit(bunit)
-        except KeyError as e:
+        except KeyError:
             bunit = "erg / (s cm2 arcsec2)"
-            logging.warning(f"Keyword 'BUNIT' not found, setting to {bunit} by default")
-        except ValueError as e:
-            print("'BUNIT' keyword is malformed", e)
+            logging.warning("Keyword 'BUNIT' not found, setting to %s by default", bunit)
+        except ValueError as errcode:
+            print("'BUNIT' keyword is malformed:", errcode)
             raise
 
         if header["CTYPE3"].lower() not in ["freq", 'wave', "awav", 'wavelength']:
@@ -360,17 +359,20 @@ class Source(SourceBase):
 
     @property
     def table_fields(self):
+        """List of fields that are defined through tables"""
         fields = [field for field in self.fields if isinstance(field, Table)]
         return fields
 
     @property
     def image_fields(self):
+        """List of fields that are defined through two-dimensional images"""
         fields = [field for field in self.fields if
                   isinstance(field, fits.ImageHDU) and field.header["NAXIS"] == 2]
         return fields
 
     @property
     def cube_fields(self):
+        """List of fields that are defined through three-dimensional cubes"""
         fields = [field for field in self.fields if
                   isinstance(field, fits.ImageHDU) and field.header["NAXIS"] == 3]
         return fields

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -563,18 +563,18 @@ class Source(SourceBase):
 
     def __repr__(self):
         msg = ""
-        for ii in range(len(self.fields)):
-            if isinstance(self.fields[ii], Table):
-                tbl_len = len(self.fields[ii])
-                num_spec = set(self.fields[ii]["ref"])
-                msg += "[{}]: Table with {} rows, referencing spectra {} \n" \
-                       "".format(ii, tbl_len, num_spec)
-            elif isinstance(self.fields[ii], (fits.ImageHDU, fits.PrimaryHDU)):
-                im_size = self.fields[ii].data.shape if self.fields[ii].data is not None else "<empty>"
+        for ifld, fld in enumerate(self.fields):
+            if isinstance(fld, Table):
+                tbl_len = len(fld)
+                num_spec = set(fld["ref"])
+                msg += f"[{ifld}]: Table with {tbl_len} rows, referencing spectra {num_spec} \n"
+            elif isinstance(fld, (fits.ImageHDU, fits.PrimaryHDU)):
+                im_size = fld.data.shape if fld.data is not None else "<empty>"
                 num_spec = "-"
-                if self.fields[ii].header["SPEC_REF"] != "":
-                    num_spec = self.fields[ii].header["SPEC_REF"]
-                msg += "[{}]: ImageHDU with size {}, referencing spectrum {}" \
-                       "\n".format(ii, im_size, num_spec)
+                msg += f"[{ifld}]: ImageHDU with size {im_size}"
+                if "SPEC_REF" in self.fields[ifld].header:
+                    num_spec = self.fields[ifld].header["SPEC_REF"]
+                    msg += f", referencing spectrum {num_spec}"
+                msg += "\n"
 
         return msg


### PR DESCRIPTION
These changes ensure that all input methods result in the same output fluxes, both in imaging and spectroscopy (test notebooks exist, can be converted to automatic tests later). Some of the changes are a bit of a fudge - in the long run it's probably the function `rescale_imagehdu` in `image_plane_utils.py` that needs to check units of the imagehdu and adapt its behaviour depending on whether the images have (spatially) integral values, such as Jy, or spatial densities, e.g. Jy/arcsec2.