### PR TITLE
Oc/check fov coverage

### DIFF
--- a/scopesim/optics/fov_utils.py
+++ b/scopesim/optics/fov_utils.py
@@ -324,10 +324,6 @@ def extract_area_from_imagehdu(imagehdu, fov_volume):
         mask = ((hdu_waves > fov_waves[0] - 0.5 * wdel) *
                 (hdu_waves <= fov_waves[1] + 0.5 * wdel))  # need to go [+/-] half a bin
 
-        # if min(hdu_waves) > min(fov_waves) or max(hdu_waves) < max(fov_waves):
-        #     raise ValueError(f"FOV waveset is not a subset of cube waveset: "
-        #                      f"{fov_waves} --> {hdu_waves}")
-
         # OC [2021-12-14] if fov range is not covered by the source return nothing
         if not np.any(mask):
             print("FOV {} um - {} um: not covered by Source".format(fov_waves[0], fov_waves[1]))

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -84,7 +84,6 @@ class OpticalTrain:
         self.yaml_dicts = None
         self._last_source = None
 
-
         if cmds is not None:
             self.load(cmds)
 
@@ -247,11 +246,8 @@ class OpticalTrain:
             cube.header['CUNIT2'] = 'deg'
 
             # Put on fov wavegrid
-            # ..todo: This assumes that we have only one fov. Generalise?
-            fov = self.fov_manager.fovs[0]
-            wave_min = fov.meta["wave_min"]        # Quantity [um]
-            wave_max = fov.meta["wave_max"]
-
+            wave_min = min([fov.meta["wave_min"] for fov in self.fov_manager.fovs])
+            wave_max = max([fov.meta["wave_max"] for fov in self.fov_manager.fovs])
             wave_unit = u.Unit(from_currsys("!SIM.spectral.wave_unit"))
             dwave = from_currsys("!SIM.spectral.spectral_bin_width")  # Not a quantity
             fov_waveset = np.arange(wave_min.value, wave_max.value, dwave) * wave_unit


### PR DESCRIPTION
Wavelength limits for `prepare_source` (upsampling of cube source) are now determined from all FieldOfViews, not just the first one. The problem arose in METIS img_n, which has three fovs determined by three PSFs in the N2 filter range. 
The solution is related to issue #99 but should not be considered the final solution as it assumes that the wavelength ranges of the fovs form a contiguous interval.