### PR TITLE
added functions for example_data

### DIFF
--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -51,7 +51,9 @@ from .optics.optical_train import OpticalTrain
 from .commands.user_commands import UserCommands
 from .source.source import Source
 
-from .server.database import list_packages, download_package
+from .server.database import (list_packages, download_package,
+                              list_example_data,
+                              download_example_data)
 
 ################################################################################
 #                          VERSION INFORMATION                                 #

--- a/scopesim/server/__init__.py
+++ b/scopesim/server/__init__.py
@@ -1,1 +1,4 @@
-from .database import download_package, list_packages
+from .database import (download_package,
+                       list_packages,
+                       download_example_data,
+                       list_example_data)


### PR DESCRIPTION
- new functions `list_example_data` and `download_example_data`. These look into `InstPkgServer/example_data` on the univie server. 
- `get_server_element` has been modified to accept a list of `unique_str`. This is used to look for `.fits`, `.txt` and `.dat` files in example data. 

Pull request should go into master for the SimMETIS release, needs to be merged into dev_master later on.