### PR TITLE
Oc/fits headers

### DIFF
--- a/scopesim/detector/detector_array.py
+++ b/scopesim/detector/detector_array.py
@@ -84,17 +84,20 @@ class DetectorArray:
 
         # 5. Generate a HDUList with the ImageHDUs and any extras:
         pri_hdu = make_primary_hdu(self.meta)
-        effects_hdu = make_effects_hdu(self.array_effects + self.dtcr_effects)
 
-        hdu_list = fits.HDUList([pri_hdu] +
-                                [dtcr.hdu for dtcr in self.detectors] +
-                                [effects_hdu])
+        # ..todo: effects_hdu unnecessary as long as make_effects_hdu does not do anything
+        # effects_hdu = make_effects_hdu(self.array_effects + self.dtcr_effects)
+
+        hdu_list = fits.HDUList([pri_hdu]
+                                + [dtcr.hdu for dtcr in self.detectors])
+                                # + [effects_hdu])
         self.latest_exposure = hdu_list
 
         return self.latest_exposure
 
 
 def make_primary_hdu(meta):
+    """Create the primary header from meta data"""
     new_meta = utils.stringify_dict(meta)
     prihdu = fits.PrimaryHDU()
     prihdu.header.update(new_meta)

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from copy import deepcopy
 from shutil import copyfileobj
 
@@ -304,7 +305,13 @@ class OpticalTrain:
             hdul = detector_array.readout(self.image_planes, array_effects,
                                          dtcr_effects, **kwargs)
 
-            hdul = self.write_header(hdul)
+            try:
+                hdul = self.write_header(hdul)
+            except Exception as error:
+                print("\nWarning: header update failed, data will be saved with incomplete header.")
+                print("Reason: ", sys.exc_info()[0], error)
+                print("")
+
             if filename is not None and isinstance(filename, str):
                 fname = filename
                 if len(self.detector_arrays) > 1:
@@ -317,7 +324,7 @@ class OpticalTrain:
 
     def write_header(self, hdulist):
         """Writes meaningful header to simulation product"""
-
+        hdulist[3].header
         # Primary hdu
         pheader = hdulist[0].header
         pheader['DATE'] = datetime.now().isoformat(timespec='seconds')

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -324,7 +324,7 @@ class OpticalTrain:
 
     def write_header(self, hdulist):
         """Writes meaningful header to simulation product"""
-        hdulist[3].header
+
         # Primary hdu
         pheader = hdulist[0].header
         pheader['DATE'] = datetime.now().isoformat(timespec='seconds')

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -1,3 +1,4 @@
+import os
 from copy import deepcopy
 from shutil import copyfileobj
 
@@ -316,11 +317,15 @@ class OpticalTrain:
 
     def write_header(self, hdulist):
         """Writes meaningful header to simulation product"""
-        print(hdulist)
-        # Primary hdul
+
+        # Primary hdu
         pheader = hdulist[0].header
         pheader['DATE'] = datetime.now().isoformat(timespec='seconds')
         pheader['ORIGIN'] = 'Scopesim ' + version
+        pheader['INSTRUME'] = from_currsys("!OBS.instrument")
+        pheader['INSTMODE'] = ", ".join(from_currsys("!OBS.modes"))
+        pheader['TELESCOP'] = from_currsys("!TEL.telescope")
+        pheader['LOCATION'] = from_currsys("!ATMO.location")
 
         # Source information taken from first only.
         # ..todo: What if source is a composite?
@@ -336,8 +341,112 @@ class OpticalTrain:
                 except KeyError:
                     pheader['SOURCE'] = "ImageHDU"
 
-        # hdulist[0].header = pheader
-        # Image hdul   ..todo: currently only one, update for detector arrays
+        # Image hdul
+        # ..todo: currently only one, update for detector arrays
+        # ..todo: normalise filenames - some need from_currsys, some need os.path.basename
+        #         this should go into a function so as to reduce clutter here.
+        iheader = hdulist[1].header
+        iheader['EXPTIME'] = from_currsys("!OBS.exptime"), "[s]"
+        iheader['DIT'] = from_currsys("!OBS.dit"), "[s]"
+        iheader['NDIT'] = from_currsys("!OBS.ndit"), "[s]"
+        iheader['BUNIT'] = 'e', 'per EXPTIME'
+        iheader['PIXSCALE'] = from_currsys("!INST.pixel_scale"), "[arcsec]"
+
+        # A simple WCS
+        iheader['CTYPE1'] = 'LINEAR'
+        iheader['CTYPE2'] = 'LINEAR'
+        iheader['CRPIX1'] = (iheader['NAXIS1'] + 1) / 2
+        iheader['CRPIX2'] = (iheader['NAXIS2'] + 1) / 2
+        iheader['CRVAL1'] = 0.
+        iheader['CRVAL2'] = 0.
+        iheader['CDELT1'] = iheader['PIXSCALE']
+        iheader['CDELT2'] = iheader['PIXSCALE']
+        iheader['CUNIT1'] = 'arcsec'
+        iheader['CUNIT2'] = 'arcsec'
+
+        for eff in self.optics_manager.detector_setup_effects:
+            efftype = type(eff).__name__
+
+            if efftype == "DetectorList" and eff.include:
+                iheader['DETECTOR'] = eff.meta['detector']
+
+        for eff in self.optics_manager.detector_array_effects:
+            efftype = type(eff).__name__
+
+            if (efftype == "DetectorModePropertiesSetter" and
+                eff.include):
+                # ..todo: can we write this into currsys?
+                iheader['DET_MODE'] = (eff.meta['detector_readout_mode'],
+                                       "detector readout mode")
+                iheader['MINDIT'] = from_currsys("!DET.mindit"), "[s]"
+                iheader['FULLWELL'] = from_currsys("!DET.full_well"), "[s]"
+                iheader['RON'] = from_currsys("!DET.readout_noise"), "[e]"
+                iheader['DARK'] = from_currsys("!DET.dark_current"), "[e/s]"
+
+        ifilter = 1   # Counts filter wheels
+        islit = 1     # Counts slit wheels
+        isurface = 1  # Counts surface lists
+        for eff in self.optics_manager.source_effects:
+            efftype = type(eff).__name__
+
+            if efftype == "ADCWheel" and eff.include:
+                iheader['ADC'] = eff.current_adc.meta['name']
+
+            if efftype == "FilterWheel" and eff.include:
+                iheader[f'FILTER{ifilter}'] = (eff.current_filter.meta['name'],
+                                               eff.meta['name'])
+                ifilter += 1
+
+            if efftype == "SlitWheel" and eff.include:
+                iheader[f'SLIT{islit}'] = (eff.current_slit.meta['name'],
+                                           eff.meta['name'])
+                islit += 1
+
+            if efftype == "PupilTransmission" and eff.include:
+                iheader['PUPTRANS'] = (from_currsys("!OBS.pupil_transmission"),
+                                       "cold stop, pupil transmission")
+
+            if efftype == "SkycalcTERCurve" and eff.include:
+                iheader['ATMOSPHE'] = "Skycalc", "atmosphere model"
+                iheader['LOCATION'] = eff.meta['location']
+                iheader['AIRMASS'] = eff.meta['airmass']
+                iheader['TEMPERAT'] = eff.meta['temperature'], '[degC]'
+                iheader['HUMIDITY'] = eff.meta['humidity']
+                iheader['PRESSURE'] = eff.meta['pressure'], '[hPa]'
+                iheader['PWV'] = eff.meta['pwv'], "precipitable water vapour"
+
+            if efftype == "AtmosphericTERCurve" and eff.include:
+                iheader['ATMOSPHE'] = eff.meta['filename'], "atmosphere model"
+                # ..todo: expand if necessary
+
+            if efftype == "SurfaceList" and eff.include:
+                iheader[f'SURFACE{isurface}'] = (eff.meta['filename'],
+                                                 eff.meta['name'])
+                isurface += 1
+
+            if efftype == "QuantumEfficiencyCurve" and eff.include:
+                iheader['QE'] = os.path.basename(eff.meta['filename']), eff.meta['name']
+
+        for eff in self.optics_manager.fov_effects:
+            efftype = type(eff).__name__
+
+            # ..todo: needs to be handled with isinstance(eff, PSF)
+            if efftype == "FieldConstantPSF" and eff.include:
+                iheader["PSF"] = eff.meta['filename'], "point spread function"
+
+            if efftype == "SpectralTraceList" and eff.include:
+                iheader["SPECTRAC"] = (from_currsys(eff.meta['filename']),
+                                       "spectral trace definition")
+                if "CTYPE1" in eff.meta:
+                    for key in ['WCSAXES', 'CTYPE1', 'CTYPE2', 'CRPIX1', 'CRPIX2', 'CRVAL1',
+                                'CRVAL2', 'CDELT1', 'CDELT2', 'CUNIT1', 'CUNIT2']:
+                        iheader[key] = eff.meta[key]
+
+        for eff in self.optics_manager.detector_effects:
+            efftype = type(eff).__name__
+
+            if efftype == "LinearityCurve" and eff.include:
+                iheader['DETLIN'] = from_currsys(eff.meta['filename'])
 
         return hdulist
 

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -32,6 +32,7 @@
 # [WCS = CRPIXn, CRVALn = (0,0), CTYPEn, CDn_m, NAXISn, CUNITn
 """
 
+import os
 import pickle
 import logging
 from copy import deepcopy
@@ -192,6 +193,7 @@ class Source(SourceBase):
             fits_type = utils.get_fits_type(filename)
             data = fits.getdata(filename)
             hdr = fits.getheader(filename)
+            hdr['FILENAME'] = os.path.basename(filename)
             if fits_type == "image":
                 image = fits.ImageHDU(data=data, header=hdr)
                 if spectra is not None:
@@ -222,8 +224,8 @@ class Source(SourceBase):
         if not image_hdu.header.get("BG_SRC"):
             image_hdu.header["CRVAL1"] = 0
             image_hdu.header["CRVAL2"] = 0
-            image_hdu.header["CRPIX1"] = image_hdu.header["NAXIS1"] / 2
-            image_hdu.header["CRPIX2"] = image_hdu.header["NAXIS2"] / 2
+            image_hdu.header["CRPIX1"] = (image_hdu.header["NAXIS1"] + 1) / 2
+            image_hdu.header["CRPIX2"] = (image_hdu.header["NAXIS2"] + 1) / 2
             # .. todo:: find where the actual problem is with negative CDELTs
             # .. todo:: --> abs(pixel_scale) in header_from_list_of_xy
             if image_hdu.header["CDELT1"] < 0:
@@ -243,7 +245,7 @@ class Source(SourceBase):
         else:
             image_hdu.header["SPEC_REF"] = ""
             logging.warning("No spectrum was provided. SPEC_REF set to ''. "
-                          "This could cause problems later")
+                            "This could cause problems later")
             raise NotImplementedError
 
         for i in [1, 2]:
@@ -316,6 +318,7 @@ class Source(SourceBase):
             with fits.open(cube) as hdul:
                 data = hdul[ext].data
                 header = hdul[ext].header
+                header['FILENAME'] = os.path.basename(cube)
                 wcs = WCS(cube)
 
         try:


### PR DESCRIPTION
New method `OpticalTrain.write_header(hdul)`. This is called in `readout()` and adds lots of information to the fits headers (general info to primary hdu, specific info for to first extension). Pull request also removes table extension (second extension) as it does not yet serve any purpose. 

Caveats;
- `write_header` only works one image extension, needs a loop for detector arrays
- seems to work on all instrument modes in METIS, but needs more testing with different source types
- some todos in the code
- the code is pretty ugly
- Information on the source can be improved (currently only filename if that's available)

`write_header` is called within `try:... except:` to avoid failure of an entire simulation just because there's an error in populating the fits header.