### PR TITLE
hash-string seem to be working now. Tests included

### DIFF
--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -318,3 +318,11 @@ Meta-data
 
     def __str__(self):
         return self.__repr__()
+
+    def __getitem__(self, item):
+        if isinstance(item, str) and item[0] == "#":
+            value = self.meta[item[1:]]
+        else:
+            raise ValueError(f"__getitem__ calls must start with '#': {item}")
+
+        return value

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -323,7 +323,11 @@ Meta-data
         if isinstance(item, str) and item[0] == "#":
             if len(item) > 1:
                 if item[-1] == "!":
-                    value = from_currsys(self.meta[item[1:-1]])
+                    key = item[1:-1]
+                    if len(key) > 0:
+                        value = from_currsys(self.meta[key])
+                    else:
+                        value = from_currsys(self.meta)
                 else:
                     value = self.meta[item[1:]]
             else:

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -321,7 +321,13 @@ Meta-data
 
     def __getitem__(self, item):
         if isinstance(item, str) and item[0] == "#":
-            value = self.meta[item[1:]]
+            if len(item) > 1:
+                if item[-1] == "!":
+                    value = from_currsys(self.meta[item[1:-1]])
+                else:
+                    value = self.meta[item[1:]]
+            else:
+                value = self.meta
         else:
             raise ValueError(f"__getitem__ calls must start with '#': {item}")
 

--- a/scopesim/optics/optical_element.py
+++ b/scopesim/optics/optical_element.py
@@ -140,14 +140,53 @@ class OpticalElement:
         self.add_effect(other)
 
     def __getitem__(self, item):
+        """
+        Returns Effects of Effect meta properties
+
+        Parameters
+        ----------
+        item : str, int, Effect-Class
+            Either the name, list index, or Class of an effect.
+            It is possible to get meta entries from a named effect by using:
+            ``#<effect_name>.<meta-key>``
+
+        Returns
+        -------
+        obj : str, float, Effect, list
+            - str, float : if #-string is used to get Effect.meta entries
+            - Effect : if a unique Effect name is given
+            - list : if an Effect-Class is given
+
+        Examples
+        --------
+        ::
+            from scopesim.effect import TERCurve
+            opt_el = opt_elem.OpticalElement(detector_yaml_dict)
+
+            effect_list = opt_el[TERCurve]
+            effect = opt_el[0]
+            effect = opt_el["detector_qe_curve"]
+            meta_value = opt_el["#detector_qe_curve.filename"]
+
+        """
         obj = None
         if isclass(item):
             obj = self.get_all(item)
         elif isinstance(item, int):
             obj = self.effects[item]
         elif isinstance(item, str):
-            obj = [eff for eff in self.effects
-                   if eff.meta["name"] == item]
+            if item[0] == "#" and "." in item:
+                eff, meta = item.replace("#", "").split(".")
+                obj = self[eff][f"#{meta}"]
+            else:
+                obj = [eff for eff in self.effects
+                       if eff.meta["name"] == item]
+
+        if isinstance(obj, list) and len(obj) == 1:
+            obj = obj[0]
+        # if obj is None or len(obj) == 0:
+        #     logging.warning(f'No result for key: "{item}". '
+        #                     f'Did you mean "#{item}"?')
 
         return obj
 

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -312,10 +312,22 @@ Summary of Effects in Optical Elements:
         elif isinstance(item, int):
             obj = self.optical_elements[item]
         elif isinstance(item, str):
-            obj = [opt_el for opt_el in self.optical_elements
-                   if opt_el.meta["name"] == item]
-            for opt_el in self.optical_elements:
-                obj += opt_el[item]
+            # check for hash-string for getting Effect.meta values
+            if item[0] == "#" and "." in item:
+                opt_el_name = item.replace("#", "").split(".")[0]
+                new_item = item.replace(f"{opt_el_name}.", "")
+                obj = self[opt_el_name][new_item]
+            else:
+                # get all optical elements that match "item"
+                obj = [opt_el for opt_el in self.optical_elements
+                       if opt_el.meta["name"] == item]
+
+                # add all effects that match "item"
+                for opt_el in self.optical_elements:
+                    effs = opt_el[item]
+                    if not isinstance(effs, list):
+                        effs = [effs]
+                    obj += effs
 
         if isinstance(obj, list) and len(obj) == 1:
             obj = obj[0]
@@ -333,14 +345,14 @@ Summary of Effects in Optical Elements:
             obj.meta.update(value)
 
     def __repr__(self):
-        msg = "\nOpticsManager contains {} OpticalElements \n" \
-              "".format(len(self.optical_elements))
+        msg = f"\nOpticsManager contains {len(self.optical_elements)} " \
+              f"OpticalElements \n"
         for ii, opt_el in enumerate(self.optical_elements):
-            msg += '[{}] "{}" contains {} effects \n' \
-                   ''.format(ii, opt_el.meta["name"], len(opt_el.effects))
+            msg += f'[{ii}] "{opt_el.meta["name"]}" contains ' \
+                   f'{len(opt_el.effects)} effects \n'
 
         return msg
 
     def __str__(self):
         name = self.meta.get("name", self.meta.get("filename", "<empty>"))
-        return '{}: "{}"'.format(type(self).__name__, name)
+        return f'{type(self).__name__}: "{name}"'

--- a/scopesim/tests/mocks/py_objects/yaml_objects.py
+++ b/scopesim/tests/mocks/py_objects/yaml_objects.py
@@ -54,13 +54,13 @@ def _inst_yaml_dict():
     text = """
 # INSTRUMENT OPTICS
 object : instrument
+alias: INST
 name : micado_wide_field
 inst_pkg_name : micado
 
 properties :
     temperature : -190
     pixel_scale : 0.004
-    
 
 effects :
 -   name : micado_surface_list
@@ -89,6 +89,7 @@ def _detector_yaml_dict():
     text = """
 # Detector array
 object : detector
+alias : DET
 name : micado_detector_array
 inst_pkg_name : micado
 

--- a/scopesim/tests/tests_effects/test_Effects.py
+++ b/scopesim/tests/tests_effects/test_Effects.py
@@ -51,6 +51,17 @@ class TestEffectReport:
         assert "The dimensions of the MICADO central detector" in rst_str
 
 
+class TestGet:
+    def test_returns_meta_value_for_hash_string(self):
+        det_list = eo._detector_list()
+        assert det_list["#image_plane_id"] == 0
+
+    def test_raises_error_without_hash(self):
+        det_list = eo._detector_list()
+        with pytest.raises(ValueError):
+            det_list["image_plane_id"] == 0
+
+
 @pytest.mark.usefixtures("surf_list_file")
 class TestSurfaceListInit:
     def test_initialises_with_nothing(self):

--- a/scopesim/tests/tests_optics/test_OpticalElement.py
+++ b/scopesim/tests/tests_optics/test_OpticalElement.py
@@ -4,6 +4,7 @@ from scopesim import rc
 from scopesim.optics import optical_element as opt_elem
 from scopesim.effects import GaussianDiffractionPSF
 from scopesim.commands import UserCommands
+from scopesim.effects import Effect
 
 from scopesim.tests.mocks.py_objects.yaml_objects import _atmo_yaml_dict, \
     _detector_yaml_dict
@@ -57,6 +58,26 @@ class TestOpticalElementGetZOrderEffects:
                                                detector_yaml_dict):
         opt_el = opt_elem.OpticalElement(detector_yaml_dict)
         assert len(opt_el.get_z_order_effects(z_orders)) == n
+
+
+@pytest.mark.usefixtures("detector_yaml_dict")
+class TestGetItem:
+    def test_returns_effect_for_normal_string(self, detector_yaml_dict):
+        opt_el = opt_elem.OpticalElement(detector_yaml_dict)
+        eff = opt_el["detector_qe_curve"]
+        assert isinstance(eff, Effect)
+
+    def test_returns_effect_for_normal_string(self, detector_yaml_dict):
+        opt_el = opt_elem.OpticalElement(detector_yaml_dict)
+        value = opt_el["#detector_qe_curve.filename"]
+        assert value == "TER_blank.dat"
+
+    @pytest.mark.parametrize("key", [("detector_qe_curve.filename"),
+                                     ("#detector_qe_curve")])
+    def test_pass_silently_when_not_valid_hash_string(self, detector_yaml_dict,
+                                                     key):
+        opt_el = opt_elem.OpticalElement(detector_yaml_dict)
+        assert len(opt_el[key]) == 0
 
 
 @pytest.mark.usefixtures("detector_yaml_dict")


### PR DESCRIPTION
@oczoske @hugobuddel some new functionality for you to play with 😉 

hash-string seem to be working now for an `OpticalTrain `object. 

They shouldn't screw anything else up, as `__getitem__` is not used in general inside `scopesim`. It is only for the user-friendliness aspect

## New functionality
for `<OpticalTrain>.__getitem__`, also know as `micado["effect-name"]`

- `#<effect>.` : display the full `.meta `dictionary of an `Effect`
`#<effect>.<param>` : display the current value of a parameter from the `meta `dictionary
`#<effect>.<param>!` : resolve the parameter through `from_currsys()`

Standard use
```
micado.effects --> summary table
micado["MICADO_DET"] --> OpticalElement containing a list of Effects
micado["full_detector_array"] --> Effect
```
#-string use for returning the Effect.meta dictionary
```
micado["#full_detector_array."] --> full .meta dict    
micado["#full_detector_array.dit"] --> certain parameter from .meta   
micado["#full_detector_array.dit!"] --> resolves !-str parameter from .meta via from_currsys()    
```

Examples:
```
>>> micado["full_detector_array"]
DetectorList: "full_detector_array"
>>> micado["#full_detector_array."]
{ ... }
>>> micado["#full_detector_array.dit"]
'!OBS.dit'
>>> micado["#full_detector_array.dit!"]
60
```

As a side note, using just `.!` will push the whole meta dict through `from_currsys`, resulting in all entries being resolved
```
>>> micado["#full_detector_array.!"]
{ ... }   # all !-str entries resolved
```

Lastly, it is to be seen whether these little changes will actually be useful at all... 
