### PR TITLE
Guess when reading ASCII table in DataContainer, fixes IRDB ELT tests

### DIFF
--- a/scopesim/effects/data_container.py
+++ b/scopesim/effects/data_container.py
@@ -103,7 +103,7 @@ class DataContainer:
 
     def _load_ascii(self):
         self.table = ioascii.read(self.meta["filename"],
-                                  format="basic", guess=False)
+                                  format="basic", guess=True)
         hdr_dict = utils.convert_table_comments_to_dict(self.table)
         if isinstance(hdr_dict, dict):
             self.headers += [hdr_dict]


### PR DESCRIPTION
This now works:
```
DataContainer(filename="TER_ELT_5_mirror.dat")
```
which is done in the ELT tests of the IRDB.

Required to pass all IRDB tests: https://github.com/AstarVienna/irdb/pull/47