### PR TITLE
Kl/fits effect

### DIFF
--- a/scopesim/detector/detector_array.py
+++ b/scopesim/detector/detector_array.py
@@ -91,6 +91,12 @@ class DetectorArray:
         hdu_list = fits.HDUList([pri_hdu]
                                 + [dtcr.hdu for dtcr in self.detectors])
                                 # + [effects_hdu])
+
+        for effect in self.array_effects:
+            image_plane = effect.apply_to(image_plane, **self.meta)
+
+
+
         self.latest_exposure = hdu_list
 
         return self.latest_exposure

--- a/scopesim/effects/__init__.py
+++ b/scopesim/effects/__init__.py
@@ -13,5 +13,6 @@ from . import ter_curves_utils
 from .detector_list import *
 from .electronic import *
 from .obs_strategies import *
+from .fits_headers import *
 
 # from . import effects_utils

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -404,19 +404,19 @@ class SourceDescriptionFitsKeywords(ExtraFitsKeywords):
             src = opt_train._last_source
             src_dicts = []
             if src is not None:
+                prefix = self.meta['keyword_prefix']
                 for i, field in enumerate(src.fields):
 
+                    src_class = field.__class__.__name__
                     src_dic = {}
                     if isinstance(field, fits.ImageHDU):
                         hdr = field.header
-                        src_dic["type"] = "ImageHDU"
                         for key in hdr:
                             src_dic += [{key: [hdr[key], hdr.comments[key]]}]
                         src_dicts += [src_dic]
 
                     elif isinstance(field, Table):
                         src_dic = deepcopy(field.meta)
-                        src_dic["type"] = "Table"
                         src_dic["length"] = len(field)
                         for j, name in enumerate(field.colnames):
                             src_dic[f"col{j}_name"] = name
@@ -424,9 +424,10 @@ class SourceDescriptionFitsKeywords(ExtraFitsKeywords):
 
                     self.dict_list = [{"ext_number": self.meta["ext_number"],
                                        "keywords": {
+                                           f"{prefix} SRC{i} class": src_class,
                                            f"{prefix} SRC{i}": src_dic}
                                        }]
-                    super_apply_to = super(EffectsMetaKeywords, self).apply_to
+                    super_apply_to = super(SourceDescriptionFitsKeywords, self).apply_to
                     hdul = super_apply_to(hdul=hdul, optical_train=opt_train)
 
         return hdul

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -2,7 +2,7 @@ import yaml
 import numpy as np
 from astropy.io import fits
 from . import Effect
-from ..utils import check_keys
+from ..utils import check_keys, from_currsys
 
 
 class ExtraFitsKeywords(Effect):
@@ -209,6 +209,9 @@ def flatten_dict(dic, base_str="", flat_dict={}, resolve=False):
         if isinstance(val, dict):
             flatten_dict(val, new_str, flat_dict, resolve)
         else:
-            flat_dict[new_str[:-1]] = val
+            new_str = new_str[:-1]
+            flat_dict[new_str] = val
+            if resolve:
+                flat_dict[new_str] = from_currsys(flat_dict[new_str])
 
     return flat_dict

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -6,6 +6,150 @@ from ..utils import check_keys
 
 
 class ExtraFitsKeywords(Effect):
+    """
+    Extra FITS header keywords to be added to the pipeline FITS files
+
+    These keywords are ONLY for keywords that should be MANUALLY ADDED to the
+    headers after a simulation is read-out by the detector.
+
+    Simulation parameters (Effect kwargs values, etc) will be added automatically
+    by ScopeSim in a different function, but following this format.
+
+    The dictionaries should be split into different HIERARCH lists:
+
+    - HIERARCH ESO
+     For ESO specific keywords
+    - HIERARCH SIM
+     For ScopeSim specific keywords, like simulation parameters
+    - HIERARCH MIC
+     For MICADO specific keywords, (unsure what these would be yet)
+
+    More HIERARCH style keywords can also be added as needed for other use-cases
+
+    Parameters
+    ----------
+    filename : str, optional
+        Name of a .yaml nested dictionary file. See below for examples
+
+    header_dict : nested dicts
+        A series of nested python dictionaries following the format of the
+        examples below. This keyword allows these dicts to be definied directly
+        in the Effect yaml file, rather than in a seperate header keywords file.
+
+
+    Yaml file format
+    ----------------
+    This document is a yaml document.
+    Hence all new keywords should be specified in the form of yaml nested
+    dictionaries.
+    As each ``astropy.HDUList`` contains one or more extensions, the inital level is
+    reserved for a list of keyword groups.
+    For example::
+
+    - ext_type: PrimaryHDU
+      keywords:
+        HIERARCH:
+          ESO:
+            ATM:
+              TEMPERAT: -5
+
+    - ext_number: [1, 2]
+      keywords:
+        HIERARCH:
+          ESO:
+            DET:
+              DIT: [5, '[s] exposure length']   # example of adding a comment
+
+    The keywords can be added to one or more extensions, based on one of the
+    following ``ext_`` qualifiers: ``ext_name``, ``ext_number``, ``ext_type``
+
+    Each of these ``ext_`` qualifiers can be a ``str`` or a ``list``.
+    For a list, ScopeSim will add the keywords to all extensions matching the
+    specified type/name/number
+
+    The above example will result in the following keyword added to:
+
+    - PrimaryHDU (ext 0):
+
+      header['HIERARCH ESO ATM TEMPERAT'] = -5
+
+    - Extensions 1 and 2 (regardless of type):
+
+      header['HIERARCH ESO DET DIT'] = (5, '[s] exposure length')
+
+    Resolved and un-resolved keywords
+    ---------------------------------
+    ScopeSim uses bang-strings to resolve global parameters.
+    E.g: ``from_currsys('!ATMO.temperature')`` will resolve to a float
+    These bang-strings will be resolved automatically in the ``keywords`` dictionary
+    section.
+
+    If the keywords bang-string should instead remain unresolved and the string
+    added verbatim to the header, we use the ``unresolved_keywords`` dictionary
+    section.
+
+    Additionally, new functionality will be added to ScopeSim to resolve the
+    kwargs/meta parameters of Effect objects.
+    The format for this will be to use a new type: the hash-string.
+    This will have this format::
+
+      #<optical_element_name>.<effect_name>.<kwarg_name>
+
+    For example, the temperature of the MICADO detector array can be accessed by::
+
+      '#MICADO_DET.full_detector_array.temperature'
+
+    In the context of the yaml file this would look like
+
+    - ext_type: PrimaryHDU
+      keywords:
+        HIERARCH:
+          ESO:
+            DET
+              TEMPERAT: '#MICADO_DET.full_detector_array.temperature'
+
+    Obviously some though needs to be put into how exactly we list the simulation
+    parameters in a coherent manner.
+    But this is 'Zukunftsmusik'.
+    For now we really just want an interface that can add the ESO header keywords,
+    which can also be expanded in the future for our own purposes.
+
+    Below is an example of some extra keywords for MICADO headers::
+
+        - ext_type: PrimaryHDU
+          keywords:
+            HIERARCH:
+              ESO:
+                ATM:
+                  TEMPERAT: '!ATMO.temperature'   # will be resolved via from_currsys
+                  PWV: '!ATMO.pwv'
+                  SEEING: 1.2
+                DAR:
+                  VALUE: '#<effect_name>.<kwarg_name>'   # will be resolved via effects
+                DPR:
+                  TYPE: 'some_type'
+              SIM:
+                random_simulation_keyword: some_value
+              MIC:
+                micado_specific: ['keyword', 'keyword comment']
+
+          unresolved_keywords:
+            HIERARCH:
+              ESO:
+                ATM:
+                  TEMPERAT: '!ATMO.temperature'   # will be left as a string
+
+        - ext_type: ImageHDU
+          keywords:
+            HIERARCH:
+              SIM:
+                hello: world
+                hallo: welt
+                grias_di: woed
+                zdrasviute: mir
+                salud: el mundo
+
+    """
     def __init__(self, **kwargs):
         params = {"header_dict": None,
                   "filename": None}

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -1,0 +1,70 @@
+import yaml
+import numpy as np
+from astropy.io import fits
+from . import Effect
+from ..utils import check_keys
+
+
+class ExtraFitsKeywords(Effect):
+    def __init__(self, **kwargs):
+        params = {"header_dict": None,
+                  "filename": None}
+        self.meta["z_order"] = [999]
+        self.meta.update(params)
+        self.meta.update(kwargs)
+
+        self.dict_list = []
+        filename = self.meta["filename"]
+        if filename is not None:
+            with open(filename) as f:
+                # possible multiple yaml docs in a file
+                # --> returns list even for a single doc
+                dics = [dic for dic in yaml.full_load_all(f)]
+                for dic in dics:
+                    # format says yaml file contains list of dicts
+                    if isinstance(dic, list):
+                        self.dict_list += dic
+                    # catch case where user forgets the list
+                    elif isinstance(dic, dict):
+                        self.dict_list += [dic]
+
+        if self.meta["header_dict"] is not None:
+            self.dict_list += [self.meta["header_dict"]]
+
+    def apply_to(self, hdul, **kwargs):
+        if isinstance(hdul, fits.HDUList):
+            for dic in self.dict_list:
+                resolved = flatten_dict(dic.get("keywords", {}), resolve=Ture)
+                unresolved = flatten_dict(dic.get("unresolved_keywords", {}))
+                exts = get_relevant_extensions(dic, hdul)
+                for i in exts:
+                    hdul[i].header.update(resolved)
+                    hdul[i].header.update(unresolved)
+
+        return hdlu
+
+
+def get_relevant_extensions(dic, hdul):
+    exts = []
+    if dic.get("ext_name") is not None:
+        exts += [i for i, hdu in enumerate(hdul)
+                 if hdu.header["EXTNAME"] == dic["ext_name"]]
+    elif dic.get("ext_number") is not None:
+        ext_n = np.array(dic["ext_number"])
+        exts += list(ext_n[ext_n<len(hdul)])
+    elif dic.get("ext_type") is not None:
+        cls = tuple([getattr(fits, cls_str) for cls_str in dic["ext_type"]])
+        exts += [i for i, hdu in enumerate(hdul) if isinstance(hdu, cls)]
+
+    return exts
+
+
+def flatten_dict(dic, base_str="", flat_dict={}, resolve=False):
+    for key, val in dic.items():
+        new_str = base_str + f"{key} "
+        if isinstance(val, dict):
+            flatten_dict(val, new_str, flat_dict, resolve)
+        else:
+            flat_dict[new_str[:-1]] = val
+
+    return flat_dict

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -222,7 +222,9 @@ def get_relevant_extensions(dic, hdul):
         ext_n = np.array(dic["ext_number"])
         exts += list(ext_n[ext_n<len(hdul)])
     elif dic.get("ext_type") is not None:
-        if not isinstance(dic["ext_type"], list):
+        if isinstance(dic["ext_type"], list):
+            ext_type_list = dic["ext_type"]
+        else:
             ext_type_list = [dic["ext_type"]]
         cls = tuple([getattr(fits, cls_str) for cls_str in ext_type_list])
         exts += [i for i, hdu in enumerate(hdul) if isinstance(hdu, cls)]

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -309,7 +309,7 @@ class OpticalTrain:
 
             fits_effects = self.optics_manager.get_all(ExtraFitsKeywords)
             for effect in fits_effects:
-                hdul = effect.apply_to(hdul, optics_manager=self.optics_manager)
+                hdul = effect.apply_to(hdul, optical_train=self)
 
             try:
                 hdul = self.write_header(hdul)

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -21,6 +21,7 @@ from ..detector import DetectorArray
 from ..source.source import Source
 from ..utils import from_currsys
 from ..version import version
+from .. import effects
 from .. import rc
 from . import fov_utils as fu
 
@@ -305,6 +306,10 @@ class OpticalTrain:
             dtcr_effects = self.optics_manager.detector_effects
             hdul = detector_array.readout(self.image_planes, array_effects,
                                          dtcr_effects, **kwargs)
+
+            fits_effects = self.optics_manager.get_all(ExtraFitsKeywords)
+            for effect in fits_effects:
+                hdul = effect.apply_to(hdul, optics_manager=self.optics_manager)
 
             try:
                 hdul = self.write_header(hdul)

--- a/scopesim/tests/tests_effects/test_fits_headers.py
+++ b/scopesim/tests/tests_effects/test_fits_headers.py
@@ -1,0 +1,61 @@
+import pytest
+from pytest import raises
+from astropy.io import fits
+import numpy as np
+
+from scopesim.effects import ExtraFitsKeywords
+from scopesim.effects import fits_headers as fh
+
+
+@pytest.fixture(scope="function")
+def comb_hdul():
+    pri = fits.PrimaryHDU(header=fits.Header({"EXTNAME": "PriHDU"}))
+    im = fits.ImageHDU(header=fits.Header({"EXTNAME": "ImHDU"}))
+    tbl = fits.BinTableHDU(header=fits.Header({"EXTNAME": "BinTblHDU"}))
+    hdul = fits.HDUList([pri, im, tbl])
+
+    return hdul
+
+
+@pytest.mark.usefixtures("comb_hdul")
+class TestGetRelevantExtensions:
+    def test_works_for_ext_name(self, comb_hdul):
+        dic = {"ext_name": "PriHDU"}
+        exts = fh.get_relevant_extensions(dic, comb_hdul)
+        answer = [0]
+
+        assert np.all([ans in exts for ans in answer])
+        assert len(exts) == len(answer)
+
+    def test_works_for_ext_number(self, comb_hdul):
+        dic = {"ext_number": [1, 2, 3]}
+        exts = fh.get_relevant_extensions(dic, comb_hdul)
+        answer = [1, 2]
+
+        assert np.all([ans in exts for ans in answer])
+        assert len(exts) == len(answer)
+
+    def test_works_for_ext_type(self, comb_hdul):
+        dic = {"ext_type": ["ImageHDU", "PrimaryHDU"]}
+        exts = fh.get_relevant_extensions(dic, comb_hdul)
+        answer = [0, 1]
+
+        assert np.all([ans in exts for ans in answer])
+        assert len(exts) == len(answer)
+
+
+class TestFlattenDict:
+    def test_works(self):
+        dic = {"HIERARCH":
+                   {"ESO":
+                        {"ATM":
+                             {"PWV": 1.0, "AIRMASS": 2.0},
+                         "DPR": {"TYPE": "DARK"}},
+                    "SIM": {"area": "!TEL.area"}
+                    }
+               }
+        flat_dict = fh.flatten_dict(dic)
+        assert flat_dict["HIERARCH ESO ATM PWV"] == 1.0
+        assert flat_dict["HIERARCH ESO ATM AIRMASS"] == 2.0
+        assert flat_dict["HIERARCH ESO DPR TYPE"] == "DARK"
+        assert flat_dict["HIERARCH SIM area"] == "!TEL.area"

--- a/scopesim/tests/tests_effects/test_fits_headers.py
+++ b/scopesim/tests/tests_effects/test_fits_headers.py
@@ -4,7 +4,7 @@ from pytest import raises
 from astropy.io import fits
 import numpy as np
 
-from scopesim.effects import ExtraFitsKeywords, EffectsMetaKeywords
+from scopesim.effects import ExtraFitsKeywords, EffectsMetaKeywords, SourceDescriptionFitsKeywords
 from scopesim.effects import fits_headers as fh
 import scopesim as sim
 
@@ -77,7 +77,6 @@ class TestExtraFitsKeywordsInit:
         assert isinstance(eff, ExtraFitsKeywords)
 
 
-# @pytest.mark.usefixtures("simplecado_opt")
 @pytest.mark.usefixtures("comb_hdul")
 class TestExtraFitsKeywordsApplyTo:
     def test_works_if_no_resolve_or_opticaltrain(self, comb_hdul):
@@ -201,6 +200,7 @@ class TestFlattenDict:
         assert flat_dict["SIM dark_current"] == 0.1
 
 
+@pytest.mark.usefixtures("comb_hdul")
 @pytest.mark.usefixtures("yaml_string")
 @pytest.mark.usefixtures("simplecado_opt")
 class TestEffectsMetaKeywordsApplyTo:
@@ -225,4 +225,14 @@ class TestEffectsMetaKeywordsApplyTo:
 
 
 @pytest.mark.usefixtures("simplecado_opt")
+@pytest.mark.usefixtures("comb_hdul")
 class TestSourceDescriptionFitsKeywordsApplyTo:
+    def test_works(self, simplecado_opt, comb_hdul):
+        from scopesim.source.source_templates import star
+        simplecado_opt._last_source = star() + star()
+        eff = SourceDescriptionFitsKeywords()
+        hdul = eff.apply_to(comb_hdul, optical_train=simplecado_opt)
+        pri_hdr = hdul[0].header
+
+        for key in pri_hdr:
+            print(key, pri_hdr[key])

--- a/scopesim/tests/tests_effects/test_fits_headers.py
+++ b/scopesim/tests/tests_effects/test_fits_headers.py
@@ -203,7 +203,7 @@ class TestFlattenDict:
 
 @pytest.mark.usefixtures("yaml_string")
 @pytest.mark.usefixtures("simplecado_opt")
-class TestEffectsMetaKeywordsInit:
+class TestEffectsMetaKeywordsApplyTo:
     def test_effect_meta_in_header(self, yaml_string, simplecado_opt, comb_hdul):
         eff = EffectsMetaKeywords()
         hdul = eff.apply_to(comb_hdul, optical_train=simplecado_opt)
@@ -222,3 +222,7 @@ class TestEffectsMetaKeywordsInit:
         assert "GOKU EFF0 class" not in pri_hdr
         assert sec_hdr["GOKU EFF0 class"] == "DetectorList"
         assert sec_hdr["GOKU EFF0 array_dict pixsize"] == "list:[0.015]"
+
+
+@pytest.mark.usefixtures("simplecado_opt")
+class TestSourceDescriptionFitsKeywordsApplyTo:

--- a/scopesim/tests/tests_effects/test_fits_headers.py
+++ b/scopesim/tests/tests_effects/test_fits_headers.py
@@ -160,10 +160,12 @@ class TestGetRelevantExtensions:
         assert np.all([ans in exts for ans in answer])
         assert len(exts) == len(answer)
 
-    def test_works_for_ext_type(self, comb_hdul):
-        dic = {"ext_type": ["ImageHDU", "PrimaryHDU"]}
+    @pytest.mark.parametrize("ext_type, answer",
+                             [("PrimaryHDU", [0]),
+                              (["ImageHDU", "PrimaryHDU"], [0, 1])])
+    def test_works_for_ext_type(self, comb_hdul, ext_type, answer):
+        dic = {"ext_type": ext_type}
         exts = fh.get_relevant_extensions(dic, comb_hdul)
-        answer = [0, 1]
 
         assert np.all([ans in exts for ans in answer])
         assert len(exts) == len(answer)
@@ -188,9 +190,9 @@ class TestFlattenDict:
         assert flat_dict["HIERARCH SIM area"][1] == "area"
 
     def test_resolves_bang_strings(self):
-        dic = {"SIM": {"area": "!TEL.area"}}
+        dic = {"SIM": {"random_seed": "!SIM.random.seed"}}
         flat_dict = fh.flatten_dict(dic, resolve=True)
-        assert flat_dict["SIM area"] == 0
+        assert flat_dict["SIM random_seed"] == None
 
     @pytest.mark.usefixtures("simplecado_opt")
     def test_resolves_hash_strings(self, simplecado_opt):


### PR DESCRIPTION
All tests working
`!-string` resolve from `currsys`
`#-strings` resolve from the passed `OpticalTrain `or `OpticsManager `object

@hugobuddel all yours ;)

Follow this recipe for the yaml file:

    - ext_type: PrimaryHDU
      keywords:
        HIERARCH:
          ESO:
            TEL:
              area: ["!TEL.area", "default = 0"]
              pixel_scale: "!INST.pixel_scale"
              its_over: 9000
            DAR:
              VALUE: '#dark_current.value'   # will be resolved via effects
            DPR:
              TYPE: 'some_type'
          SIM:
            random_simulation_keyword: some_value
          MIC:
            micado_specific: ['keyword', 'keyword comment']
    
      unresolved_keywords:
        HIERARCH:
          ESO:
            ATM:
              TEMPERAT: '!ATMO.temperature'   # will be left as a string
    
    - ext_type: ImageHDU
      keywords:
        HIERARCH:
          SIM:
            hello: world
            hallo: welt
            grias_di: woed
            zdrasviute: mir
            salud: el mundo
