### PR TITLE
Fix FITS keywords

### DIFF
--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -5,7 +5,7 @@ from astropy.io import fits
 from astropy import units as u
 from astropy.table import Table
 from . import Effect
-from ..utils import check_keys, from_currsys
+from ..utils import check_keys, from_currsys, find_file
 
 
 class ExtraFitsKeywords(Effect):
@@ -208,7 +208,8 @@ class ExtraFitsKeywords(Effect):
 
         tmp_dicts = []
         if self.meta["filename"] is not None:
-            with open(self.meta["filename"]) as f:
+            yaml_file = find_file(self.meta["filename"])
+            with open(yaml_file) as f:
                 # possible multiple yaml docs in a file
                 # --> returns list even for a single doc
                 tmp_dicts += [dic for dic in yaml.full_load_all(f)]

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -385,6 +385,13 @@ class EffectsMetaKeywords(ExtraFitsKeywords):
         opt_train = kwargs.get("optical_train")
         if isinstance(hdul, fits.HDUList) and opt_train is not None:
             for i, eff_name in enumerate(opt_train.effects["name"]):
+                # Check for spaces
+                if " " in eff_name:
+                    # E.g. 'filter_wheel_1 : [open]'
+                    assert eff_name.startswith("filter_wheel") or eff_name.startswith("pupil_wheel"),\
+                        f"Unknown effect name with space: {eff_name}"
+                    eff_name = eff_name.split()[0]
+
                 # get a resolved meta dict from the effect
                 eff_meta = deepcopy(opt_train[f"#{eff_name}.!"])
 

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -1,5 +1,6 @@
 import yaml
 from copy import deepcopy
+import datetime
 import numpy as np
 from astropy.io import fits
 from astropy import units as u
@@ -326,6 +327,9 @@ def flatten_dict(dic, base_key="", flat_dict={},
 
             if isinstance(value, (list, np.ndarray)):
                 value = f"{value.__class__.__name__}:{str(list(value))}"
+
+            if isinstance(value, (datetime.time, datetime.date, datetime.datetime)):
+                value = value.isoformat()
 
             # Add the flattened KEYWORD = (value, comment) to the header dict
             if len(comment) > 0:


### PR DESCRIPTION
Fixes the FITS keywords:
- datetime keywords work
- the yaml file can be found
- filter/pupil wheel keywords work

The [commented-out keyword effects in MICADO in the dev_micado branch of the irdb](https://github.com/AstarVienna/irdb/blob/1234332c5ea1bbef17c3933c9f4f0c1a41614141/MICADO/MICADO_H4RG.yaml) work with these changes: 