### PR TITLE
Kl/addon/spec trace wheel 2

### DIFF
--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -381,7 +381,7 @@ class SlitWheel(Effect):
         path = pth.join(self.meta["path"],
                         from_currsys(self.meta["filename_format"]))
         self.slits = {}
-        for name in self.meta["slit_names"]:
+        for name in from_currsys(self.meta["slit_names"]):
             kwargs["name"] = name
             self.slits[name] = ApertureMask(filename=path.format(name),
                                             **kwargs)

--- a/scopesim/effects/effects_utils.py
+++ b/scopesim/effects/effects_utils.py
@@ -83,7 +83,9 @@ def make_effect(effect_dict, **properties):
 
 
 def is_spectroscope(effects):
-    return any([isinstance(eff, efs.SpectralTraceList) for eff in effects])
+    spec_classes = (efs.SpectralTraceList,
+                    efs.SpectralTraceListWheel)
+    return any([isinstance(eff, spec_classes) for eff in effects])
 
 
 def empty_surface_list(**kwargs):

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -230,6 +230,62 @@ class SpectralTraceList(Effect):
 
 
 class SpectralTraceListWheel(Effect):
+    """
+    A Wheel-Effect object for selecting between multiple gratings/grisms
+
+    See ``SpectralTraceList`` for the trace file format description.
+
+    Parameters
+    ----------
+    trace_list_names : list
+        The list of unique identifiers in the trace filenames
+
+    filename_format : str
+        f-string that directs scopesim to the folder containing the trace files.
+        This can be a !-string if the trace names are shared with other *Wheel
+        effect objects (e.g. a FilterWheel). See examples.
+
+    current_trace_list : str
+        default trace file to use
+
+    kwargs : key-value pairs
+        Addition keywords that are passed to the ``SpectralTraceList`` objects
+        See SpectralTraceList docstring
+
+    Examples
+    --------
+    A simplified YAML file example taken from the OSIRIS instrument package::
+
+        alias: INST
+        name: OSIRIS_LSS
+
+        properties:
+          decouple_detector_from_sky_headers: True
+          grism_names:
+            - R300B
+            - R500B
+            - R1000B
+            - R2500V
+
+        effects:
+          - name: spectral_trace_wheel
+            description: grism wheel contining spectral trace geometries
+            class: SpectralTraceListWheel
+            kwargs:
+              current_trace_list: "!OBS.grating_name"
+              filename_format: "traces/LSS_{}_TRACE.fits"
+              trace_list_names: "!INST.grism_names"
+
+          - name: grating_efficiency
+            description: OSIRIS grating efficiency curves, piggybacking on FilterWheel
+            class: FilterWheel
+            kwargs:
+              minimum_throughput: !!float 0.
+              filename_format: "gratings/{}.txt"
+              current_filter: "!OBS.grating_name"
+              filter_names: "!INST.grism_names"
+
+    """
     def __init__(self, **kwargs):
         required_keys = ["trace_list_names",
                          "filename_format",

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -222,3 +222,41 @@ class SpectralTraceList(Effect):
         msg = 'SpectralTraceList: "{}" : {} traces' \
               ''.format(self.meta.get("name"), len(self.spectral_traces))
         return msg
+
+
+class SpectralTraceListWheel(Effect):
+    def __init__(self):
+        required_keys = ["trace_list_names",
+                         "filename_format",
+                         "current_trace_list"]
+        check_keys(kwargs, required_keys, action="error")
+
+        super(SpectralTraceListWheel, self).__init__(**kwargs)
+
+        params = {"z_order": [70, 270, 670],
+                  "path": "",
+                  "report_plot_include": True,
+                  "report_table_include": True,
+                  "report_table_rounding": 4}
+        self.meta.update(params)
+        self.meta.update(kwargs)
+
+        path = pth.join(self.meta["path"],
+                        from_currsys(self.meta["filename_format"]))
+        self.trace_lists = {}
+        for name in self.meta["trace_list_names"]:
+            kwargs["name"] = name
+            self.trace_lists[name] = SpectralTraceList(filename=path.format(name),
+                                                       **kwargs)
+
+    def apply_to(self, obj, **kwargs):
+        '''Use apply_to of current trace list'''
+        return self.current_trace_list.apply_to(obj, **kwargs)
+
+    @property
+    def current_trace_list(self):
+        trace_list_eff = None
+        trace_list_name = from_currsys(self.meta["current_trace_list"])
+        if trace_list_name is not None:
+            trace_list_eff = self.trace_lists[trace_list_name]
+        return trace_list_eff

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -536,7 +536,8 @@ class FilterWheel(Effect):
         self.filters = {}
         for name in self.meta["filter_names"]:
             kwargs["name"] = name
-            self.filters[name] = FilterCurve(filename=path.format(name), **kwargs)
+            self.filters[name] = FilterCurve(filename=path.format(name),
+                                             **kwargs)
 
         self.table = self.get_table()
 

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -534,7 +534,7 @@ class FilterWheel(Effect):
         path = pth.join(self.meta["path"],
                         from_currsys(self.meta["filename_format"]))
         self.filters = {}
-        for name in self.meta["filter_names"]:
+        for name in from_currsys(self.meta["filter_names"]):
             kwargs["name"] = name
             self.filters[name] = FilterCurve(filename=path.format(name),
                                              **kwargs)
@@ -818,7 +818,7 @@ class ADCWheel(Effect):
         path = pth.join(self.meta["path"],
                         from_currsys(self.meta["filename_format"]))
         self.adcs = {}
-        for name in self.meta["adc_names"]:
+        for name in from_currsys(self.meta["adc_names"]):
             kwargs["name"] = name
             self.adcs[name] = TERCurve(filename=path.format(name),
                                        **kwargs)

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -169,7 +169,7 @@ class OpticsManager:
 
     @property
     def is_spectroscope(self):
-        return bool(len(self.get_all(efs.SpectralTraceList)))
+        return is_spectroscope(self.all_effects)
 
     @property
     def image_plane_headers(self):
@@ -226,6 +226,10 @@ class OpticsManager:
         return self._surfaces_table
 
     @property
+    def all_effects(self):
+        return [eff for opt_eff in self.optical_elements for eff in opt_eff]
+
+    @property
     def system_transmission(self):
 
         wave_unit = u.Unit(rc.__currsys__["!SIM.spectral.wave_unit"])
@@ -260,7 +264,7 @@ class OpticsManager:
         # Hence we need to reconstruct the full effects list
 
         # flat_list = [item for sublist in l for item in sublist]
-        all_effs = [eff for opt_eff in self.optical_elements for eff in opt_eff]
+        all_effs = self.all_effects
 
         elements = [opt_el.meta["name"] for opt_el in self.optical_elements
                     for eff in opt_el.effects]


### PR DESCRIPTION
What?
- Added a SpectralTraceListWheel effect for MAAT
- Allow all **Wheel objects to take a !-string for the **_names list of input files

Why?
MAAT grism effects are split between a 
- FIlterWheel for the grating transmission efficiency for each grism
- SpectralTraceListWheel for the trace geometry of each grism


