### PR TITLE
updated univie server address for downloading package

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,12 @@ ScopeSim_ is on pip::
 
 .. note:: ScopeSim only supports python 3.6 and above
 
+.. warning:: July 2022: The downloadable content server was retired and the data migrated to a new server.
+
+   ScopeSim v0.5.1 and above have been redirected to a new server URL.
+   Please either upgrade to the latest version (``pip install --upgrade scopesim``), or follow these `instructions to update the server URL <https://astarvienna.github.io/server_upgrade_instructions.html>`_ in the config file.
+
+
 .. _ScopeSim:    https://scopesim.readthedocs.io/en/latest/
 .. _`ScopeSim Templates`: https://scopesim-templates.readthedocs.io/en/latest/
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,8 @@ ScopeSim_ is on pip::
 .. warning:: July 2022: The downloadable content server was retired and the data migrated to a new server.
 
    ScopeSim v0.5.1 and above have been redirected to a new server URL.
-   Please either upgrade to the latest version (``pip install --upgrade scopesim``), or follow these `instructions to update the server URL <https://astarvienna.github.io/server_upgrade_instructions.html>`_ in the config file.
+
+   For older verions, please either upgrade to the latest version (``pip install --upgrade scopesim``), or follow these `instructions to update the server URL <https://astarvienna.github.io/server_upgrade_instructions.html>`_ in the config file.
 
 
 .. _ScopeSim:    https://scopesim.readthedocs.io/en/latest/

--- a/scopesim/defaults.yaml
+++ b/scopesim/defaults.yaml
@@ -34,7 +34,7 @@ properties :
 
   file :
     local_packages_path : "./inst_pkgs/"
-    server_base_url : "https://www.univie.ac.at/simcado/InstPkgSvr/"
+    server_base_url : "https://scopesim.univie.ac.at/InstPkgSvr/"
     use_cached_downloads : "update"
     search_path : ["./inst_pkgs/", "./"]
     error_on_missing_file : False


### PR DESCRIPTION
Updated the defaults.yaml file to contain `!SIM.file.server_base_url : "https://scopesim.univie.ac.at/InstPkgSvr/"`. This directs to the new univie scopesim server. The old server was retired on 1st of July 2022. 