### PR TITLE
Kl/hotfix special header keywords

### DIFF
--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -116,13 +116,12 @@ class ExtraFitsKeywords(Effect):
     For a list, ScopeSim will add the keywords to all extensions matching the
     specified type/name/number
 
-    The number of the extension can be used in a value by using the "++"
-    character. That is, the "++" character is replaced by the extension number.
-    "++" is choosen because it is not allowed to be used in FITS values, and
-    it is the "ideograph counter for ships, vessels CJK", which seems
-    appropriate.
+    The number of the extension can be used in a value by using the "++" string.
+    That is, keyword values with "++" with have the extension number inserted
+    where the "++" is.
 
-    The above example will result in the following keyword added to:
+    The above example (``EXTNAME: "DET++.DATA"``) will result in the following
+    keyword added only to extensions 1 and 2:
 
     - PrimaryHDU (ext 0)::
 

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -107,7 +107,7 @@ class ExtraFitsKeywords(Effect):
               ESO:
                 DET:
                   DIT: [5, '[s] exposure length']   # example of adding a comment
-            EXTNAME: "DET§.DATA"                    # example of extension specific qualifier
+            EXTNAME: "DET++.DATA"                   # example of extension specific qualifier
 
     The keywords can be added to one or more extensions, based on one of the
     following ``ext_`` qualifiers: ``ext_name``, ``ext_number``, ``ext_type``
@@ -116,9 +116,9 @@ class ExtraFitsKeywords(Effect):
     For a list, ScopeSim will add the keywords to all extensions matching the
     specified type/name/number
 
-    The number of the extension can be used in a value by using the "§"
-    character. That is, the "§" character is replaced by the extension number.
-    "§" is choosen because it is not allowed to be used in FITS values, and
+    The number of the extension can be used in a value by using the "++"
+    character. That is, the "++" character is replaced by the extension number.
+    "++" is choosen because it is not allowed to be used in FITS values, and
     it is the "ideograph counter for ships, vessels CJK", which seems
     appropriate.
 
@@ -271,7 +271,7 @@ class ExtraFitsKeywords(Effect):
                 exts = get_relevant_extensions(dic, hdul)
                 for i in exts:
                     resolved_with_counters = {
-                        k: v.replace("§", str(i)) if isinstance(v, str) else v
+                        k: v.replace("++", str(i)) if isinstance(v, str) else v
                         for k, v in resolved.items()
                     }
                     hdul[i].header.update(resolved_with_counters)
@@ -520,6 +520,12 @@ class SourceDescriptionFitsKeywords(ExtraFitsKeywords):
                                        }]
                     super_apply_to = super(SourceDescriptionFitsKeywords, self).apply_to
                     hdul = super_apply_to(hdul=hdul, optical_train=opt_train)
+
+            # catch the function call
+            for hdu in hdul:
+                for key in hdu.header:
+                    if "function_call" in key:
+                        hdu.header[f"FN{key.split()[1]}"] = hdu.header.pop(key)
 
         return hdul
 


### PR DESCRIPTION
Two quick updates to the `ExtraFitsKeywords` classes so that they are don't break MicadoWise:

- special characters that add incremental index numbers to header values
  
  These have been changed from `§` to `++` because the `§` was causing an additional invisible character to be inserted that astropy didn't like when writing the HDUs to disk

- source object `function call` keywords have their own single keyword format: "FNSRCn"

  This is because `HIERARCH` keywords cannot be over 80 characters (for an unknown reason). HIERARCH is not compatible with CONTINUE. Therefore the function calls, (often over 80 characters) have been given their own non-HIERARCH header keyword (`FNSRCn` = "function-call source N") so that we can take advantage of the CONTINUE keyword.

The corresponding line in the MICADO IRDB package has been changed to match this: https://github.com/AstarVienna/irdb/pull/86