### PR TITLE
Kl/bugfix/thin slit confusing dispersion direction

### DIFF
--- a/docs/source/faqs/bind_to_local_irdb.rst
+++ b/docs/source/faqs/bind_to_local_irdb.rst
@@ -33,7 +33,7 @@ At the beginning of any script or jupyter notebook we can run the following comm
 This is by far the simplest method, but it requires this lone of code in every script::
 
     import scopesim
-    scopesim.rc.__config__["!SIm.file.local_packages_path"] = "<path/to/IRDB>"
+    scopesim.rc.__config__["!SIM.file.local_packages_path"] = "<path/to/IRDB>"
 
 
 By editing the ScopeSim config file

--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -87,7 +87,7 @@ class DetectorList(Effect):
             active_detectors : [1, 3]
             image_plane_id : 0
 
-    where the file detecotr_list.dat contains the following information
+    where the file detector_list.dat contains the following information
     ::
 
         # x_cen_unit : mm

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -109,6 +109,11 @@ class SpectralTrace:
         xi_arr = self.table[self.meta['s_colname']]
         lam_arr = self.table[self.meta['wave_colname']]
 
+        wi0, wi1 = lam_arr.argmin(), lam_arr.argmax()
+        x_disp_length = np.diff([x_arr[wi0], x_arr[wi1]])
+        y_disp_length = np.diff([y_arr[wi0], y_arr[wi1]])
+        self.dispersion_axis = "x" if x_disp_length > y_disp_length else "y"
+
         self.wave_min = quantify(np.min(lam_arr), u.um).value
         self.wave_max = quantify(np.max(lam_arr), u.um).value
 
@@ -203,8 +208,11 @@ class SpectralTrace:
         #         - The dispersion direction is selected by the direction of the
         #           gradient of lam(x, y). This works if the lam-axis is well
         #           aligned with x or y. Needs to be tested for MICADO.
-        dlam_by_dx, dlam_by_dy = self.xy2lam.gradient()
-        if np.abs(dlam_by_dx(0, 0)) > np.abs(dlam_by_dy(0, 0)):
+
+
+        # dlam_by_dx, dlam_by_dy = self.xy2lam.gradient()
+        # if np.abs(dlam_by_dx(0, 0)) > np.abs(dlam_by_dy(0, 0)):
+        if self.dispersion_axis == "x":
             avg_dlam_per_pix = (wave_max - wave_min) / sub_naxis1
         else:
             avg_dlam_per_pix = (wave_max - wave_min) / sub_naxis2
@@ -259,6 +267,7 @@ class SpectralTrace:
         image = xilam.interp(xi_fpa, lam_fpa, grid=False) * ijmask
 
         # Scale to ph / s / pixel
+        dlam_by_dx, dlam_by_dy = self.xy2lam.gradient()
         dlam_per_pix = pixsize * np.sqrt(dlam_by_dx(ximg_fpa, yimg_fpa)**2 +
                                          dlam_by_dy(ximg_fpa, yimg_fpa)**2)
         image *= pixscale * dlam_per_pix        # [arcsec/pix] * [um/pix]
@@ -414,7 +423,6 @@ class SpectralTrace:
         return msg
 
 
-
 class XiLamImage():
     """
     Class to compute a rectified 2D spectrum
@@ -459,7 +467,8 @@ class XiLamImage():
             # overlaps with the wavelength range covered by the cube
             if lam0.min() < cube_lam.max() and lam0.max() > cube_lam.min():
                 plane = fov.cube.data[:, i, :].T
-                plane_interp = RectBivariateSpline(cube_xi, cube_lam, plane)
+                plane_interp = RectBivariateSpline(cube_xi, cube_lam, plane,
+                                                   kx=1, ky=1)
                 self.image += plane_interp(cube_xi, lam0)
 
         self.image *= d_eta     # ph/s/um/arcsec2 --> ph/s/um/arcsec

--- a/scopesim/version.py
+++ b/scopesim/version.py
@@ -1,6 +1,14 @@
-version = '0.5.3'
-date    = '2022-09-29 12:00:00 GMT'
+version = '0.5.4'
+date    = '2022-10-06 16:00:00 GMT'
 yaml_descriptions = """
+- version : 0.5.4
+  date : 2022-10-06
+  comment : Hotfix for header keyword generators
+  github_pr_url : https://github.com/AstarVienna/ScopeSim/pull/166
+  changes :
+  - incremental special characters for header keywords changed from `§`to `++`
+  - source object function calls are now given their own FITS header keyword FNSRCn (function-call source N) due to astropy not liking the combination of HIERARCH and CONTINUE keywords
+
 - version : 0.5.3
   date : 2022-09-29
   comment : Minor upgrade to Spec modes and to FITS keywords


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9432898/195091305-903073b1-40ff-4481-9741-cb5d187407c7.png)

MAAT was finding that some traces were doubled up and offset in the final image, but there was no obvious reason for this.

I tracked it down to the way the dispersion direction was automatically determined in `<SpectralTrace>.map_spectra_to_focal_plane()`- see around line 210 in spectral_trace_list_utils.py.

The problem was that for slits apertures that are very thin (i.e.  2 pixels), the xy2lam gradient function was not reliable. 
This resulted in an inconsistent determination of the trace's dispersion direction.
If the wrong dispersion direction was chosen, the determination of `avg_dlam_per_pix` was way too big (i.e. by using the smaller NAXIS value), and thus the wavelength shift applied to the multiple pixel-lines within the slit was way too large. Hence the double lines seen in the image.

My solution is to determine the direction of the dispersion (along x or y) in the __init__ method by finding the argmin and argmax of the wavelengths in the trace table, then assuming that the dispersion runs along the axis that has the largest difference in corresponding x(wave) or y(wave) coords. 

This will only not work for the cases where the traces are close to 45 degrees, or for arcs that are wider than they are high. But in these two cases, the gradient method would also struggle. 

![image](https://user-images.githubusercontent.com/9432898/195094442-ea0e2f7b-fa63-4558-8ba6-05dfe7ff21c5.png)
