### PR TITLE
Adds unequal (i.e. 2x1) binning and option to rotate the CCD by integer multiples of 90 degrees

### DIFF
--- a/scopesim/effects/__init__.py
+++ b/scopesim/effects/__init__.py
@@ -16,4 +16,6 @@ from .electronic import *
 from .obs_strategies import *
 from .fits_headers import *
 
+from .rotation import *
+
 # from . import effects_utils

--- a/scopesim/effects/rotation.py
+++ b/scopesim/effects/rotation.py
@@ -1,0 +1,36 @@
+"""Effects related to rotation of the field/CCD
+
+Classes:
+- RotateCCD - Rotates CCD by integer multiples of 90 degrees
+"""
+
+import logging
+import numpy as np
+
+from . import Effect
+from .. import utils
+from ..utils import from_currsys
+from ..base_classes import DetectorBase
+
+
+class RotateCCD(Effect):
+    """
+    Rotates CCD by integer multiples of 90 degrees
+    rotations kwarg is number of counter-clockwise rotations
+
+    """
+    def __init__(self, **kwargs):
+        super(RotateCCD, self).__init__(**kwargs)
+        params = {"z_order": [809]}
+        self.meta.update(params)
+        self.meta.update(kwargs)
+
+        required_keys = ["rotations"]
+        utils.check_keys(self.meta, required_keys, action="error")
+
+    def apply_to(self, obj, **kwargs):
+        if isinstance(obj, DetectorBase):
+            rotations = from_currsys(self.meta["rotations"])
+            obj._hdu.data = np.rot90(obj._hdu.data,rotations)
+
+        return obj

--- a/scopesim/effects/rotation.py
+++ b/scopesim/effects/rotation.py
@@ -13,14 +13,14 @@ from ..utils import from_currsys
 from ..base_classes import DetectorBase
 
 
-class RotateCCD(Effect):
+class Rotate90CCD(Effect):
     """
     Rotates CCD by integer multiples of 90 degrees
     rotations kwarg is number of counter-clockwise rotations
 
     """
     def __init__(self, **kwargs):
-        super(RotateCCD, self).__init__(**kwargs)
+        super(Rotate90CCD, self).__init__(**kwargs)
         params = {"z_order": [809]}
         self.meta.update(params)
         self.meta.update(kwargs)


### PR DESCRIPTION
Default binning for OSIRIS-MAAT will be 2x1 and the new OSIRIS CCD is rotated 90deg with respect to the current one.  To allow us to use the same trace files for both, its simplest to just allow the CCD to be rotated by 90 degrees.