### PR TITLE
add filters and slits to wheels

### DIFF
--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -443,11 +443,9 @@ class SlitWheel(Effect):
 
         self.table = self.get_table()
 
-
     def apply_to(self, obj, **kwargs):
         """Use apply_to of current_slit"""
         return self.current_slit.apply_to(obj, **kwargs)
-
 
     def fov_grid(self, which="edges", **kwargs):
         return self.current_slit.fov_grid(which=which, **kwargs)
@@ -459,6 +457,21 @@ class SlitWheel(Effect):
             self.include = slitname
         else:
             raise ValueError("Unknown slit requested: " + slitname)
+
+    def add_slit(self, newslit, name=None):
+        """
+        Add a slit to the SlitWheel
+
+        Parameters
+        ==========
+        newslit : Slit
+        name : string
+           Name to be used for the new slit. If `None`, a name from
+           the newslit object is used.
+        """
+        if name is None:
+            name = newslit.display_name
+        self.slits[name] = newslit
 
     @property
     def current_slit(self):

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -1,3 +1,4 @@
+'''Transmission, emissivity, reflection curves'''
 import numpy as np
 from astropy import units as u
 from os import path as pth
@@ -355,7 +356,7 @@ class FilterCurve(TERCurve):
         ``TC_filter_{}.dat``
 
     Can either be created using the standard 3 options:
-    - ``filename``: direct filename of the filer curve
+    - ``filename``: direct filename of the filter curve
     - ``table``: an ``astropy.Table``
     - ``array_dict``: a dictionary version of a table: ``{col_name1: values, }``
 
@@ -487,10 +488,10 @@ class TopHatFilterCurve(FilterCurve):
         red = kwargs["red_cutoff"]
         peak = kwargs["transmission"]
         wing = kwargs.get("wing_transmission", 0)
-        
+
         waveset = [wave_min, 0.999*blue, blue, red, red*1.001, wave_max]
         transmission = [wing, wing, peak, peak, wing, wing]
-        
+
         tbl = Table(names=["wavelength", "transmission"],
                     data=[waveset, transmission])
         super(TopHatFilterCurve, self).__init__(table=tbl,
@@ -600,6 +601,21 @@ class FilterWheel(Effect):
             self.meta['current_filter'] = filtername
         else:
             raise ValueError("Unknown filter requested: " + filtername)
+
+    def add_filter(self, newfilter, name=None):
+        """
+        Add a filter to the FilterWheel
+
+        Parameters
+        ==========
+        newfilter : FilterCurve
+        name : string
+           Name to be used for the new filter. If `None` a name from
+           the newfilter object is used.
+        """
+        if name is None:
+            name = newfilter.display_name
+        self.filters[name] = newfilter
 
     @property
     def current_filter(self):

--- a/scopesim/tests/tests_effects/test_TERCurve.py
+++ b/scopesim/tests/tests_effects/test_TERCurve.py
@@ -133,6 +133,16 @@ class TestFilterWheelInit:
         with pytest.raises(ValueError):
             fwheel.change_filter('X')
 
+    def test_add_filter_to_wheel(self, fwheel):
+        num_filt_old = len(fwheel.filters)
+        newfilter = tc.TopHatFilterCurve(transmission=0.9, blue_cutoff=1.,
+                                         red_cutoff=2., name='blank')
+        fwheel.add_filter(newfilter, name='blank')
+        assert len(fwheel.filters) == num_filt_old + 1
+
+        fwheel.change_filter("blank")
+        assert fwheel.current_filter.display_name == "blank"
+
     def test_plots_all_filters(self, fwheel):
         if PLOTS:
             fwheel.plot()

--- a/scopesim/tests/tests_effects/test_slitwheel.py
+++ b/scopesim/tests/tests_effects/test_slitwheel.py
@@ -49,3 +49,17 @@ class TestSlitWheel:
     def test_changes_to_false(self, swheel):
         swheel.change_slit(False)
         assert not swheel.current_slit
+
+    def test_add_slit_to_wheel(self, swheel):
+        num_slit_old = len(swheel.slits)
+        kwargs = {"array_dict": {"x": [-2, -1, 1, 2],
+                                 "y": [-1, -2, 2, 1]},
+                  "x_unit": "arcsec",
+                  "y_unit": "arcsec"}
+        newslit = ApertureMask(name="newslit", **kwargs)
+
+        swheel.add_slit(newslit, name='newslit')
+        assert len(swheel.slits) == num_slit_old + 1
+
+        swheel.change_slit('newslit')
+        assert swheel.current_slit.display_name == "newslit"


### PR DESCRIPTION
#175 Methods `add_filter` and `add_slit` have been created for `FilterWheel` and `SlitWheel`, along with test functions. Note that filters are replaced (rather than added) if `name` already exists in the `filters`/`slits` dictionaries. 