### PR TITLE
`psf_utils.rescale_kernel`: fix for negative shifts

### DIFF
--- a/scopesim/effects/psf_utils.py
+++ b/scopesim/effects/psf_utils.py
@@ -122,11 +122,11 @@ def rescale_kernel(image, scale_factor, spline_order=None):
     if dy > 0:
         image = image[2*dy:, :]
     elif dy < 0:
-        image = image[:2*abs(dy), :]
+        image = image[:2*dy, :]
     if dx > 0:
         image = image[:, 2*dx:]
     elif dx < 0:
-        image = image[:, 2*abs(dx):]
+        image = image[:, :2*dx]
 
     sum_new_image = np.sum(image)
     image *= sum_image / sum_new_image


### PR DESCRIPTION
In `psf_utils.rescale_kernel()`, the shifts `dx` and `dy` typically have small absolute values. When a shift is negative, e.g. `dy = -1`, the previous code cuts the image to `image[:2*abs(dy), :]`, i.e. `image[:2, ]`. This makes the image very narrow in the y direction... The intended functionality is to cut 2 rows from the top, this is achieved by the new code `image[:2*dy, :]`, i.e. `image[:-2, :]`. The x direction was also wrong for negative `dx`, the current code is symmetric in both directions.