### PR TITLE
Allow astropy Units to be values in FITS headers.

### DIFF
--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -350,6 +350,11 @@ def flatten_dict(dic, base_key="", flat_dict=None,
                 comment = f"[{str(value.unit)}] " + comment
                 value = value.value
 
+            # Convert e.g.  Unit(mag) to just "mag". Not sure how this will
+            # work when deserializing though.
+            if isinstance(value, u.Unit):
+                value = str(value)
+
             if isinstance(value, (list, np.ndarray)):
                 value = f"{value.__class__.__name__}:{str(list(value))}"
                 max_len = 80 - len(flat_key)

--- a/scopesim/tests/tests_effects/test_fits_headers.py
+++ b/scopesim/tests/tests_effects/test_fits_headers.py
@@ -176,21 +176,30 @@ class TestGetRelevantExtensions:
 
 class TestFlattenDict:
     def test_works(self):
-        dic = {"HIERARCH":
-                   {"ESO":
-                        {"ATM":
-                             {"PWV": 1.0, "AIRMASS": 2.0},
-                         "DPR": {"TYPE": "DARK"}},
-                    "SIM": {
-                        "area": ("!TEL.area", "area")}
+        dic = {
+            "HIERARCH": {
+                "ESO": {
+                    "ATM": {
+                        "PWV": 1.0,
+                        "AIRMASS": 2.0,
+                    },
+                    "DPR": {
+                        "TYPE": "DARK",
                     }
-               }
+                },
+                "SIM": {
+                    "area": ("!TEL.area", "area"),
+                    "SRC0": {"scaling_unit": u.mag},
+                },
+           },
+        }
         flat_dict = fh.flatten_dict(dic)
         assert flat_dict["HIERARCH ESO ATM PWV"] == 1.0
         assert flat_dict["HIERARCH ESO ATM AIRMASS"] == 2.0
         assert flat_dict["HIERARCH ESO DPR TYPE"] == "DARK"
         assert flat_dict["HIERARCH SIM area"][0] == "!TEL.area"
         assert flat_dict["HIERARCH SIM area"][1] == "area"
+        assert flat_dict["HIERARCH SIM SRC0 scaling_unit"] == "mag"
 
     def test_resolves_bang_strings(self):
         dic = {"SIM": {"random_seed": "!SIM.random.seed"}}


### PR DESCRIPTION
This just replaces e.g. u.mag with the string "mag". Not sure how this needs to be parsed when deserializing the FITS headers back into Source objects, but that is not yet supported it seems.

Fixes some of the MICADO notebooks on the IRDB.