### PR TITLE
Draft: Run markdown link checker on push

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -1,0 +1,14 @@
+name: Check Markdown links
+
+on:
+  push:
+  schedule:
+    - # Run every day at 5:00 UTC
+    - cron: "0 5 * * *"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
First attempt to fix #172 by checking all the markdown links automatically. Apparently there more problems:

https://github.com/AstarVienna/ScopeSim/actions/runs/4478214696/jobs/7870705859
 
```
FILE: ./README.md
ERROR: 2 dead links found!
[✖] www.univie.ac.at/simcado → Status: 400
[✖] docs/source/_static/scopesim_basic_intro.ipynb → Status: 400

FILE: ./docs/joss_paper/anisocado_full_text.md
ERROR: 2 dead links found!
[✖] Ks-band_psf_grid.png → Status: 400
[✖] [https://github.com/astronomyk/scopesim}](https://github.com/astronomyk/scopesim%7D) → Status: 404

FILE: ./docs/joss_paper/paper.md
ERROR: 1 dead links found!
[✖] path → Status: 400
```
