### PR TITLE
Run tests also on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9']
 
     steps:


### PR DESCRIPTION
People do use our code also on Windows, so it would be good to support it 'officially', and therefore should test it too.

It seems to work. But not sure about the IRDB, since it has symlinks.