### PR TITLE
Run notebooks in a separate job

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Notebooks
 
 on:
   push:
@@ -38,7 +38,5 @@ jobs:
           # ScopeSim_Templates.
           pip install .
           pip install .[dev,test]
-      - name: Run Pytest
-        run: pytest --cov=scopesim
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Run notebooks
+        run: ./runnotebooks.sh

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -15,6 +15,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Run every day at 2:00 UTC
+  schedule:
+    - cron: "0 2 * * *"
+
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -39,4 +44,4 @@ jobs:
           pip install .
           pip install .[dev,test]
       - name: Run notebooks
-        run: ./runnotebooks.sh
+        run: ./runnotebooks.sh --checkout-irdb --delete

--- a/.github/workflows/notebooks_with_irdb_clone.yml
+++ b/.github/workflows/notebooks_with_irdb_clone.yml
@@ -1,0 +1,49 @@
+name: Notebooks with IRDB git clone
+
+on:
+  push:
+    branches:
+      - master
+      - dev_master
+      - dev_spectroscopy
+  pull_request:
+    branches:
+      - master
+      - dev_master
+      - dev_spectroscopy
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  # Run every night
+  schedule:
+    - cron: "0 2 * * *"
+
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Run only on a minimal subset of the matrix, as this is ran on many
+        # commits.
+        os: [ubuntu-latest]
+        python-version: ['3.11']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Install this version of ScopeSim. Otherwise the PyPI version of
+          # ScopeSim will be installed when the test-requriments
+          # are installed, because ScopeSim is a dependency of
+          # ScopeSim_Templates.
+          pip install .
+          pip install .[dev,test]
+      - name: Run notebooks
+        run: ./runnotebooks.sh --checkout-irdb --delete

--- a/.github/workflows/notebooks_with_irdb_download.yml
+++ b/.github/workflows/notebooks_with_irdb_download.yml
@@ -1,23 +1,12 @@
-name: Notebooks
+name: Notebooks with IRDB download
 
 on:
-  push:
-    branches:
-      - master
-      - dev_master
-      - dev_spectroscopy
-  pull_request:
-    branches:
-      - master
-      - dev_master
-      - dev_spectroscopy
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # Run every day at 2:00 UTC
+  # Run every night
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "0 3 * * *"
 
 
 jobs:
@@ -25,7 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        # Run on the full matrix, because this is the first interaction
+        # that users have with ScopeSim / IRDB.
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
@@ -44,4 +35,5 @@ jobs:
           pip install .
           pip install .[dev,test]
       - name: Run notebooks
-        run: ./runnotebooks.sh --checkout-irdb --delete
+        # No --checkout-irdb to download the IRDB as a normal end user would.
+        run: ./runnotebooks.sh --delete

--- a/runnotebooks.sh
+++ b/runnotebooks.sh
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
 
+if [[ "${1}x" == "--clone-irdbx" ]] ; then
+  # Cloning IRDB
+  if [[ ! -e irdb ]] ; then
+    git clone https://github.com/AstarVienna/irdb.git
+  fi
+
+  # https://github.com/koalaman/shellcheck/wiki/SC2044
+  find . -iname "*.ipynb" -printf '%h\0' | sort -z | uniq -z | while IFS= read -r -d '' dirnotebooks; do
+    echo "${dirnotebooks}"
+    dirinstpkgs="${dirnotebooks}/inst_pkgs"
+    if [[ (! -e ./docs/source/examples/inst_pkgs) && (! -L ./docs/source/examples/inst_pkgs) ]] ; then
+      echo "Cretaing symlink to irdb: ${dirinstpkgs}"
+      ln -s irdb "${dirinstpkgs}"
+    else
+      echo "Dericetory exists, not creating symlink: ${dirinstpkgs}"
+    fi
+  done
+fi
+
+
 # https://github.com/koalaman/shellcheck/wiki/SC2044
 find . -iname "*.ipynb" -print0 | while IFS= read -r -d '' fnnotebook
 do


### PR DESCRIPTION
Run the notebooks in a separate job. This makes it possible to have ScopeSim use the github workflows in the DevOps project.

Perhaps the notebook jobs can also be moved to the DevOps project later.

Unfortunately it is not possible to test these jobs now, because the dev_master branch does not have them. So maybe just merge it and hope for the best?