### PR TITLE
add getitem and setitem to SpectralTraceList

### DIFF
--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -261,6 +261,12 @@ class SpectralTraceList(Effect):
                f"{len(self.spectral_traces)} traces")
         return msg
 
+    def __getitem__(self, item):
+        return self.spectral_traces[item]
+
+    def __setitem__(self, key, value):
+        self.spectral_traces[key] = value
+
 
 class SpectralTraceListWheel(Effect):
     """

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -196,22 +196,6 @@ class SpectralTraceList(Effect):
 
         return obj
 
-    def get_waveset(self, pixel_size=None):
-        if pixel_size is None:
-            pixel_size = self.meta["pixel_scale"] / self.meta["plate_scale"]
-
-        wavesets = [spt.get_pixel_wavelength_edges(pixel_size)
-                    for spt in self.spectral_traces]
-
-        return wavesets
-
-    def get_fov_headers(self, sky_header, **kwargs):
-        fov_headers = []
-        for spt in self.spectral_traces:
-            fov_headers += spt.fov_headers(sky_header=sky_header, **kwargs)
-
-        return fov_headers
-
 
     @property
     def footprint(self):

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -409,7 +409,7 @@ class SpectralTrace:
             plt.gca().set_aspect("equal")
 
     def __repr__(self):
-        msg = ("<SpectralTrace> \"{self.meta['trace_id']}\" : "
+        msg = (f"<SpectralTrace> \"{self.meta['trace_id']}\" : "
                f"[{self.wave_min:.4f}, {self.wave_max:.4f}]um : "
                f"Ext {self.meta['extension_id']} : "
                f"Aperture {self.meta['aperture_id']} : "

--- a/scopesim/tests/tests_effects/test_SpectralTraceList.py
+++ b/scopesim/tests/tests_effects/test_SpectralTraceList.py
@@ -2,17 +2,13 @@
 import os
 import pytest
 
-import numpy as np
 from astropy.io import fits
-from astropy.wcs import WCS
 
-from matplotlib import pyplot as plt
 
 from scopesim.effects.spectral_trace_list import SpectralTraceList
-from scopesim.optics.fov_manager import FovVolumeList
+from scopesim.effects.spectral_trace_list_utils import SpectralTrace
 from scopesim.tests.mocks.py_objects import trace_list_objects as tlo
 from scopesim.tests.mocks.py_objects import header_objects as ho
-from scopesim.base_classes import PoorMansHeader
 from scopesim import rc
 
 MOCK_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
@@ -57,114 +53,13 @@ class TestInit:
         # assert that dispersion axis taken correctly from header keyword
         assert list(spt.spectral_traces.values())[2].dispersion_axis == 'y'
 
+    def test_getitem_returns_spectral_trace(self, full_trace_list):
+        slist = SpectralTraceList(hdulist=full_trace_list)
+        assert isinstance(slist['Sheared'], SpectralTrace)
 
-###           The following tests are skipped           ###
-@pytest.mark.skip(reason="Ignoring old Spectroscopy integration tests")
-class TestGetFOVHeaders:
-    @pytest.mark.usefixtures("full_trace_list", "slit_header")
-    def test_gets_the_headers(self, full_trace_list, slit_header):
-        spt = SpectralTraceList(hdulist=full_trace_list)
-        params = {"pixel_scale": 0.015, "plate_scale": 0.26666,
-                  "wave_min": 0.7, "wave_max": 2.5}
-        hdrs = spt.get_fov_headers(slit_header, **params)
-
-        # assert all([isinstance(hdr, fits.Header) for hdr in hdrs])
-        assert all([isinstance(hdr, PoorMansHeader) for hdr in hdrs])
-        # ..todo:: add in some better test of correctness
-
-        if PLOTS:
-            # pixel coords
-            for hdr in hdrs[::50]:
-                xp = [0, hdr["NAXIS1"], hdr["NAXIS1"], 0]
-                yp = [0, 0, hdr["NAXIS2"], hdr["NAXIS2"]]
-                wcs = WCS(hdr, key="D")
-                # world coords
-                xw, yw = wcs.all_pix2world(xp, yp, 1)
-                plt.fill(xw / hdr["CDELT1D"], yw / hdr["CDELT2D"], alpha=0.2)
-            plt.show()
-
-    def test_gets_headers_from_real_file(self):
-        slit_hdr = ho._long_micado_slit_header()
-        # slit_hdr = ho._short_micado_slit_header()
-        wave_min = 1.0
-        wave_max = 1.3
-        spt = SpectralTraceList(filename="TRACE_15arcsec.fits",
-                                s_colname="xi",
-                                wave_colname="lam",
-                                spline_order=1)
-        params = {"wave_min": wave_min, "wave_max": wave_max,
-                  "pixel_scale": 0.004, "plate_scale": 0.266666667}
-        hdrs = spt.get_fov_headers(slit_hdr, **params)
-        assert isinstance(spt, SpectralTraceList)
-
-        print(len(hdrs))
-
-        if PLOTS:
-            spt.plot(wave_min, wave_max)
-
-            # pixel coords
-            for hdr in hdrs[::300]:
-                xp = [0, hdr["NAXIS1"], hdr["NAXIS1"], 0]
-                yp = [0, 0, hdr["NAXIS2"], hdr["NAXIS2"]]
-                wcs = WCS(hdr, key="D")
-                # world coords
-                xw, yw = wcs.all_pix2world(xp, yp, 1)
-                plt.plot(xw, yw, alpha=0.2)
-            plt.show()
-
-
-# class TestApplyTo:
-#     def test_fov_setup_base_returns_only_extracted_fov_limits(self):
-#         fname = r"F:\Work\irdb\MICADO\TRACE_MICADO.fits"
-#         spt = SpectralTraceList(filename=fname, s_colname='xi')
-#
-#         fvl = FovVolumeList()
-#         fvl = spt.apply_to(fvl)
-#
-#         assert len(fvl) == 17
-
-
-################################################################################
-
-
-def test_set_pc_matrix(rotation_ang=0, shear_ang=10):
-    n = 100
-    im = np.arange(n**2).reshape(n, n)
-    hdu = fits.ImageHDU(im)
-    hdr_dict = {"CTYPE1": "LINEAR",
-                "CTYPE2": "LINEAR",
-                "CUNIT1": "deg",
-                "CUNIT2": "deg",
-                "CDELT1": 1,
-                "CDELT2": 1,
-                "CRVAL1": 0,
-                "CRVAL2": 0,
-                "CRPIX1": 0,
-                "CRPIX2": 0}
-    hdu.header.update(hdr_dict)
-
-    c = np.cos(rotation_ang / 57.29578) * 2
-    s = np.sin(rotation_ang / 57.29578) * 2
-    t = np.tan(shear_ang / 57.29578)
-
-    n = 5
-    pc_dict = {"PC1_1": c + t*s,
-               "PC1_2": -s + t*c,
-               "PC2_1": s,
-               "PC2_2": c}
-    det = np.sqrt(np.abs(pc_dict["PC1_1"] * pc_dict["PC2_2"] - \
-                         pc_dict["PC1_2"] * pc_dict["PC2_1"]))
-    for key in pc_dict:
-        pc_dict[key] /= det
-    hdu.header.update(pc_dict)
-    w = WCS(hdu)
-
-    xd = np.array([0, 10, 10, 0])
-    yd = np.array([0, 0, 10, 10])
-    xs, ys = w.all_pix2world(xd, yd, 1)
-
-    if PLOTS:
-        plt.figure(figsize=(6, 6))
-        plt.plot(xd, yd, "o-")
-        plt.plot(xs, ys, "o-")
-        plt.show()
+    def test_setitem_appends_correctly(self, full_trace_list):
+        slist = SpectralTraceList(hdulist=full_trace_list)
+        n_trace = len(slist.spectral_traces)
+        spt = tlo.trace_1()
+        slist["New trace"] = spt
+        assert len(slist.spectral_traces) == n_trace + 1

--- a/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
+++ b/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
@@ -6,7 +6,6 @@
 import pytest
 
 import numpy as np
-from scopesim import rc
 from scopesim.effects.spectral_trace_list_utils import SpectralTrace
 from scopesim.effects.spectral_trace_list_utils import Transform2D, power_vector
 from scopesim.tests.mocks.py_objects import trace_list_objects as tlo

--- a/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
+++ b/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
@@ -3,7 +3,6 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=invalid-name
 # pylint: disable=too-few-public-methods
-import os
 import pytest
 
 import numpy as np
@@ -11,11 +10,6 @@ from scopesim import rc
 from scopesim.effects.spectral_trace_list_utils import SpectralTrace
 from scopesim.effects.spectral_trace_list_utils import Transform2D, power_vector
 from scopesim.tests.mocks.py_objects import trace_list_objects as tlo
-
-MOCK_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                         "../mocks/MICADO_SPEC/"))
-if MOCK_PATH not in rc.__search_path__:
-    rc.__search_path__ += [MOCK_PATH]
 
 class TestSpectralTrace:
     """Tests not covered in test_SpectralTraceList.py"""

--- a/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
+++ b/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
@@ -1,14 +1,28 @@
 """Unit tests for spectral_trace_list_utils.py"""
 
-# pylint: disable=no-self-use
 # pylint: disable=missing-function-docstring
 # pylint: disable=invalid-name
-
+# pylint: disable=too-few-public-methods
+import os
 import pytest
 
 import numpy as np
-
+from scopesim import rc
+from scopesim.effects.spectral_trace_list_utils import SpectralTrace
 from scopesim.effects.spectral_trace_list_utils import Transform2D, power_vector
+from scopesim.tests.mocks.py_objects import trace_list_objects as tlo
+
+MOCK_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                         "../mocks/MICADO_SPEC/"))
+if MOCK_PATH not in rc.__search_path__:
+    rc.__search_path__ += [MOCK_PATH]
+
+class TestSpectralTrace:
+    """Tests not covered in test_SpectralTraceList.py"""
+    def test_initialises_with_table(self):
+        trace_tbl = tlo.trace_1()
+        spt = SpectralTrace(trace_tbl)
+        assert isinstance(spt, SpectralTrace)
 
 class TestPowerVec:
     """Test function power_vector()"""


### PR DESCRIPTION
This should be harmless.  It is now possible to subset a `SpectralTraceList` directly instead of having to go throught the `spectral_traces` attribute:
```
In [8]: slist['ORDER_3_1']
Out[8]: <SpectralTrace> "ORDER_3_1" : [1.8700, 2.4900]um : Ext 2 : Aperture 0 : ImagePlane 0
```
