### PR TITLE
Only test some Python versions

### DIFF
--- a/.github/workflows/notebooks_with_irdb_download.yml
+++ b/.github/workflows/notebooks_with_irdb_download.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Run on the full matrix, because this is the first interaction
+        # Run all operating systems, because this is the first interaction
         # that users have with ScopeSim / IRDB.
+        # However, only use minimum and maximum supported Python version,
+        # as the IRDB download often fails.
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.11']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The IRDB download keeps failing with errors like
```
urllib.error.ContentTooShortError: <urlopen error File was supposed to be 1450546 bytes but we only got 1450139 bytes. Download failed.>
```
We need to fix that, but now the CI fails most of the time