### PR TITLE
Cleanup of ter_curves.py

### DIFF
--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -438,6 +438,7 @@ class FilterCurve(TERCurve):
     @property
     def fwhm(self):
         wave = self.surface.wavelength
+        # noinspection PyProtectedMember
         thru = self.surface._get_ter_property("transmission", fmt="array")
         mask = thru >= 0.5
         if any(mask):
@@ -450,6 +451,7 @@ class FilterCurve(TERCurve):
     @property
     def centre(self):
         wave = self.surface.wavelength
+        # noinspection PyProtectedMember
         thru = self.surface._get_ter_property("transmission", fmt="array")
         num = np.trapz(thru * wave**2, x=wave)
         den = np.trapz(thru * wave, x=wave)

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -1,25 +1,20 @@
 """Transmission, emissivity, reflection curves"""
-import numpy as np
-from astropy import units as u
 import logging
 from pathlib import Path
 
+import numpy as np
+import skycalc_ipy
+from astropy import units as u
 from astropy.io import fits
 from astropy.table import Table
-from astropy import units as u
 
-from synphot import SourceSpectrum
-from synphot.units import PHOTLAM
-import skycalc_ipy
-
+from .effects import Effect
+from .ter_curves_utils import add_edge_zeros
 from .ter_curves_utils import combine_two_spectra, apply_throughput_to_cube
 from .ter_curves_utils import download_svo_filter, download_svo_filter_list
-from .ter_curves_utils import add_edge_zeros
-from .effects import Effect
-from ..optics.surface import SpectralSurface
-from ..source.source_utils import make_imagehdu_from_table
-from ..source.source import Source
 from ..base_classes import SourceBase, FOVSetupBase
+from ..optics.surface import SpectralSurface
+from ..source.source import Source
 from ..utils import from_currsys, quantify, check_keys, find_file
 
 

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -24,7 +24,7 @@ class TERCurve(Effect):
 
     Must contain a wavelength column, and one or more of the following:
     ``transmission``, ``emissivity``, ``reflection``.
-    Additionally in the header there
+    Additionally, in the header there
     should be the following keywords: wavelength_unit
 
     kwargs that can be passed::
@@ -45,7 +45,7 @@ class TERCurve(Effect):
             wavelength_unit: um
             emission_unit: ph s-1 m-2 um-1
             rescale_emission:
-                filter_name: "Paranal/HAWKI.Ks"
+                filter_name: "Paranal/HAWK.Ks"
                 value: 15.5
                 unit: ABmag
 
@@ -697,10 +697,10 @@ class TopHatFilterWheel(FilterWheel):
     filter_names: list of string
 
     transmissions: list of floats
-        [0..1] Peak transmissions inside the cuttoff limits
+        [0..1] Peak transmissions inside the cutoff limits
 
     wing_transmissions: list of floats
-        [0..1] Wing transmissions outside the cuttoff limits
+        [0..1] Wing transmissions outside the cutoff limits
 
     blue_cutoffs: list of floats
         [um]
@@ -763,7 +763,7 @@ class SpanishVOFilterWheel(FilterWheel):
        This use ``astropy.download_file(..., cache=True)``.
 
     The filter transmission curves probably won't change, but if you notice
-    discrepancies, try clearing the astopy cache::
+    discrepancies, try clearing the astropy cache::
 
         >> from astropy.utils.data import clear_download_cache
         >> clear_download_cache()
@@ -924,7 +924,7 @@ class ADCWheel(Effect):
         return getattr(self.current_adc, item)
 
     def get_table(self):
-        """Create a table of ADCs with maximimum througput"""
+        """Create a table of ADCs with maximum throughput"""
         names = list(self.adcs.keys())
         adcs = self.adcs.values()
         tmax = np.array([adc.data["transmission"].max() for adc in adcs])

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -830,13 +830,6 @@ class PupilTransmission(TERCurve):
         self.params = {"wave_min": "!SIM.spectral.wave_min",
                        "wave_max": "!SIM.spectral.wave_max"}
         self.params.update(kwargs)
-        self.make_ter_curve(transmission)
-
-    def update_transmission(self, transmission, **kwargs):
-        self.params.update(kwargs)
-        self.make_ter_curve(transmission)
-
-    def make_ter_curve(self, transmission):
         wave_min = from_currsys(self.params["wave_min"]) * u.um
         wave_max = from_currsys(self.params["wave_max"]) * u.um
         transmission = from_currsys(transmission)
@@ -844,6 +837,9 @@ class PupilTransmission(TERCurve):
         super().__init__(wavelength=[wave_min, wave_max],
                          transmission=[transmission, transmission],
                          emissivity=[0., 0.], **self.params)
+
+    def update_transmission(self, transmission, **kwargs):
+        self.__init__(transmission, **kwargs)
 
 
 class ADCWheel(Effect):

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -342,7 +342,7 @@ class SkycalcTERCurve(AtmosphericTERCurve):
 
         try:
             tbl = self.skycalc_conn.get_sky_spectrum(return_type="table")
-        except:
+        except ConnectionError:
             msg = "Could not connect to skycalc server"
             logging.exception(msg)
             raise ValueError(msg)

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -554,9 +554,7 @@ class SpanishVOFilterCurve(FilterCurve):
         kwargs["name"] = kwargs["filter_name"]
         kwargs["svo_id"] = filt_str
 
-        raise_error = kwargs.get("error_on_wrong_name", True)
-        tbl = download_svo_filter(filt_str, return_style="table",
-                                  error_on_wrong_name=raise_error)
+        tbl = download_svo_filter(filt_str, return_style="table")
         super(SpanishVOFilterCurve, self).__init__(table=tbl, **kwargs)
 
 

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -143,9 +143,17 @@ class TERCurve(Effect):
         if self._background_source is None:
             # add a single pixel ImageHDU for the extended background with a
             # size of 1 degree
-            bg_cell_width = from_currsys(self.meta["bg_cell_width"])
+            # bg_cell_width = from_currsys(self.meta["bg_cell_width"])
+
             flux = self.emission
             bg_hdu = fits.ImageHDU()
+            # TODO: The make_imagehdu_from_table below has been replaced with
+            #       the empty ImageHDU above in fbca416. That change might,
+            #       have been fine (or not?), but now there is no use anywhere
+            #       in the code of make_imagehdu_from_table or bg_cell_width,
+            #       so maybe these need to be removed?
+            # bg_hdu = make_imagehdu_from_table([0], [0], [1], bg_cell_width * u.arcsec)
+
             bg_hdu.header.update({"BG_SRC": True,
                                   "BG_SURF": self.display_name,
                                   "CUNIT1": "ARCSEC",

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -178,6 +178,8 @@ class TERCurve(Effect):
             "x" plots throughput. "t","e","r" plot trans/emission/refl
         wavelength : list, np.ndarray
         ax : matplotlib.Axis
+        new_figure : start a new figure (or add to the existing one)
+        label : the label to use (ignored)
         kwargs
 
         Returns
@@ -275,8 +277,11 @@ class SkycalcTERCurve(AtmosphericTERCurve):
         self.meta.update(kwargs)
 
         self.skycalc_table = None
+        self.skycalc_conn = None
 
         if self.include is True:
+            # Only query the database if the effect is actually included.
+            # Sets skycalc_conn and skycalc_table.
             self.load_skycalc_table()
 
     @property
@@ -593,7 +598,6 @@ class FilterWheel(Effect):
 
         self.table = self.get_table()
 
-
     def apply_to(self, obj, **kwargs):
         """Use apply_to of current filter"""
         return self.current_filter.apply_to(obj, **kwargs)
@@ -809,7 +813,7 @@ class SpanishVOFilterWheel(FilterWheel):
         self.meta.update(kwargs)
 
         obs, inst = self.meta["observatory"], self.meta["instrument"]
-        inc, exc =  self.meta["include_str"], self.meta["exclude_str"]
+        inc, exc = self.meta["include_str"], self.meta["exclude_str"]
         filter_names = download_svo_filter_list(obs, inst, short_names=True,
                                                 include=inc, exclude=exc)
 

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -87,6 +87,8 @@ class TERCurve(Effect):
         if self.meta["ignore_wings"]:
             data = add_edge_zeros(data, "wavelength")
         if data is not None:
+            # Assert that get_data() did not give us an image.
+            assert isinstance(data, Table), "TER Curves must be tables."
             self.surface.table = data
             self.surface.table.meta.update(self.meta)
 
@@ -94,6 +96,7 @@ class TERCurve(Effect):
 
     def apply_to(self, obj, **kwargs):
         if isinstance(obj, SourceBase):
+            assert isinstance(obj, Source), "Only Source supported."
             self.meta = from_currsys(self.meta)
             wave_min = quantify(self.meta["wave_min"], u.um).to(u.AA)
             wave_max = quantify(self.meta["wave_max"], u.um).to(u.AA)
@@ -114,6 +117,8 @@ class TERCurve(Effect):
                 obj.append(self.background_source)
 
         if isinstance(obj, FOVSetupBase):
+            from ..optics.fov_manager import FovVolumeList
+            assert isinstance(obj, FovVolumeList), "Only FovVolumeList supported."
             wave = self.surface.throughput.waveset
             thru = self.surface.throughput(wave)
             valid_waves = np.argwhere(thru > 0)

--- a/scopesim/effects/ter_curves_utils.py
+++ b/scopesim/effects/ter_curves_utils.py
@@ -57,8 +57,7 @@ def get_filter_effective_wavelength(filter_name):
     return eff_wave
 
 
-def download_svo_filter(filter_name, return_style="synphot",
-                        error_on_wrong_name=True):
+def download_svo_filter(filter_name, return_style="synphot"):
     """
     Query the SVO service for the true transmittance for a given filter
 
@@ -78,9 +77,6 @@ def download_svo_filter(filter_name, return_style="synphot",
         - array: np.ndarray [wave, trans], where wave is in Angstrom
         - vo_table : astropy.table.Table - original output from SVO service
 
-    error_on_wrong_name : bool
-        Default True. Raises an exception if filter_name is as incorrect SVO ID
-
     Returns
     -------
     filt_curve : See return_style
@@ -96,18 +92,9 @@ def download_svo_filter(filter_name, return_style="synphot",
     if not path:
         path = download_file(url, cache=True)
 
-    try:
-        tbl = Table.read(path, format='votable')
-        wave = u.Quantity(tbl['Wavelength'].data.data, u.Angstrom, copy=False)
-        trans = tbl['Transmission'].data.data
-    except:
-        if error_on_wrong_name:
-            raise ValueError(f"{filter_name} is an incorrect SVO identiier")
-
-        logging.warning(("'%s' was not found in the SVO. Defaulting to a "
-                        "unity transmission curve."), filter_name)
-        wave = [3e3, 3e5] << u.Angstrom
-        trans = np.array([1., 1.])
+    tbl = Table.read(path, format='votable')
+    wave = u.Quantity(tbl['Wavelength'].data.data, u.Angstrom, copy=False)
+    trans = tbl['Transmission'].data.data
 
     if return_style == "synphot":
         filt = SpectralElement(Empirical1D, points=wave, lookup_table=trans)

--- a/scopesim/effects/ter_curves_utils.py
+++ b/scopesim/effects/ter_curves_utils.py
@@ -107,6 +107,8 @@ def download_svo_filter(filter_name, return_style="synphot"):
         filt = [wave.value, trans]
     elif return_style == "vo_table":
         filt = tbl
+    else:
+        raise ValueError("return_style %s unknown.", return_style)
 
     return filt
 
@@ -193,6 +195,8 @@ def get_zero_mag_spectrum(system_name="AB"):
         spec = ab_spectrum()
     elif system_name.lower() in ["st", "hst"]:
         spec = st_spectrum()
+    else:
+        raise ValueError("system_name %s is unknown", system_name)
 
     return spec
 
@@ -373,6 +377,8 @@ def combine_two_spectra(spec_a, spec_b, action, wave_min, wave_max):
         # plt.show()
     elif "add" in action.lower():
         spec_c = spec_a(wave) + spec_b(wave)
+    else:
+        raise ValueError("action %s unknown", action)
 
     new_source = SourceSpectrum(Empirical1D, points=wave, lookup_table=spec_c)
     new_source.meta.update(spec_b.meta)

--- a/scopesim/effects/ter_curves_utils.py
+++ b/scopesim/effects/ter_curves_utils.py
@@ -1,4 +1,3 @@
-import logging
 from pathlib import Path
 
 import numpy as np
@@ -44,6 +43,7 @@ FILTER_DEFAULTS = {"U": "Generic/Bessell.U",
 PATH_HERE = Path(__file__).parent
 PATH_SVO_DATA = PATH_HERE.parent / "data" / "svo"
 
+
 def get_filter_effective_wavelength(filter_name):
     if isinstance(filter_name, str):
         filter_name = from_currsys(filter_name)
@@ -83,6 +83,8 @@ def download_svo_filter(filter_name, return_style="synphot"):
         Astronomical filter object.
 
     """
+    # The SVO is only accessible over http, not over https.
+    # noinspection HttpUrlsUsage
     url = f"http://svo2.cab.inta-csic.es/theory/fps3/fps.php?ID={filter_name}"
     path = find_file(
         filter_name,
@@ -143,6 +145,8 @@ def download_svo_filter_list(observatory, instrument, short_names=False,
         A list of filter names
 
     """
+    # The SVO is only accessible over http, not over https.
+    # noinspection HttpUrlsUsage
     base_url = "http://svo2.cab.inta-csic.es/theory/fps3/fps.php?"
     url = base_url + f"Facility={observatory}&Instrument={instrument}"
     fn = f"{observatory}/{instrument}"
@@ -182,7 +186,7 @@ def get_filter(filter_name):
     else:
         try:
             filt = download_svo_filter(filter_name)
-        except:
+        except ConnectionError:
             filt = None
 
     return filt
@@ -315,6 +319,7 @@ def scale_spectrum(spectrum, filter_name, amplitude):
 
     return spectrum
 
+
 def apply_throughput_to_cube(cube, thru):
     """
     Apply throughput curve to a spectroscopic cube
@@ -336,6 +341,7 @@ def apply_throughput_to_cube(cube, thru):
     wave_cube = (wave_cube * u.Unit(wcs.wcs.cunit[0])).to(u.AA)
     cube.data *= thru(wave_cube).value[:, None, None]
     return cube
+
 
 def combine_two_spectra(spec_a, spec_b, action, wave_min, wave_max):
     """
@@ -367,7 +373,7 @@ def combine_two_spectra(spec_a, spec_b, action, wave_min, wave_max):
     wave = ([wave_min.value] + list(wave_val[mask]) + [wave_max.value]) * u.AA
     if "mult" in action.lower():
         spec_c = spec_a(wave) * spec_b(wave)
-        ## Diagnostic plots - not for general use
+        # Diagnostic plots - not for general use
         # from matplotlib import pyplot as plt
         # plt.plot(wave, spec_a(wave), label="spec_a")
         # plt.plot(wave, spec_b(wave), label="spec_b")

--- a/scopesim/effects/ter_curves_utils.py
+++ b/scopesim/effects/ter_curves_utils.py
@@ -384,7 +384,7 @@ def combine_two_spectra(spec_a, spec_b, action, wave_min, wave_max):
     elif "add" in action.lower():
         spec_c = spec_a(wave) + spec_b(wave)
     else:
-        raise ValueError("action %s unknown", action)
+        raise ValueError(f"action {action} unknown")
 
     new_source = SourceSpectrum(Empirical1D, points=wave, lookup_table=spec_c)
     new_source.meta.update(spec_b.meta)

--- a/scopesim/source/source_templates.py
+++ b/scopesim/source/source_templates.py
@@ -15,8 +15,6 @@ from .source_utils import make_img_wcs_header
 from .source import Source
 from .. import rc
 
-__all__ = ["empty_sky", "star", "star_field"]
-
 
 def empty_sky(flux=0):
     """

--- a/scopesim/tests/tests_effects/test_TERCurve.py
+++ b/scopesim/tests/tests_effects/test_TERCurve.py
@@ -21,6 +21,7 @@ PLOTS = False
 # pylint: disable=no-self-use, missing-class-docstring
 # pylint: disable=missing-function-docstring
 
+
 class TestTERCurveApplyTo:
     def test_adds_bg_to_source_if_source_has_no_bg(self):
 
@@ -103,6 +104,7 @@ def _filter_wheel():
     return tc.FilterWheel(**{"filter_names": ["Ks", "Br-gamma"],
                              "filename_format": "TC_filter_{}.dat",
                              "current_filter": "Br-gamma"})
+
 
 class TestFilterWheelInit:
     def test_initialises_correctly(self, fwheel):

--- a/scopesim/tests/tests_effects/test_TERCurve.py
+++ b/scopesim/tests/tests_effects/test_TERCurve.py
@@ -96,14 +96,6 @@ class TestSpanishVOFilterCurveInit:
                                        filter_name=filt_name)
         assert isinstance(filt, tc.FilterCurve)
 
-    def test_returns_unity_transmission_for_wrong_name(self):
-        filt = tc.SpanishVOFilterCurve(observatory=None,
-                                       instrument=None,
-                                       filter_name=None,
-                                       error_on_wrong_name=False)
-        assert isinstance(filt, tc.FilterCurve)
-        assert np.all([t == 1 for t in filt.data["transmission"]])
-
 
 @pytest.fixture(name="fwheel", scope="class")
 def _filter_wheel():

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -14,7 +14,6 @@ import yaml
 import numpy as np
 from astropy import units as u
 from astropy.io import fits
-from astropy.io import ascii as ioascii
 from astropy.table import Column, Table
 
 from . import rc
@@ -129,7 +128,7 @@ def moffat(r, alpha, beta):
     -------
     eta
     """
-    return (beta - 1)/(np.pi * alpha**2) * (1 + (r/alpha)**2)**(-beta)
+    return (beta - 1) / (np.pi * alpha ** 2) * (1 + (r / alpha) ** 2) ** (-beta)
 
 
 def poissonify(arr):
@@ -172,12 +171,14 @@ def nearest(arr, val):
 
     return np.argmin(abs(arr - val))
 
+
 def power_vector(val, degree):
     """Return the vector of powers of val up to a degree"""
     if degree < 0 or not isinstance(degree, int):
         raise ValueError("degree must be a positive integer")
 
-    return np.array([val**exp for exp in range(degree + 1)])
+    return np.array([val ** exp for exp in range(degree + 1)])
+
 
 def deriv_polynomial2d(poly):
     """Derivatives (gradient) of a Polynomial2D model
@@ -202,8 +203,8 @@ def deriv_polynomial2d(poly):
         i = int(match.group(1))
         j = int(match.group(2))
         cij = getattr(poly, pname)
-        pname_x = "c%d_%d" % (i-1, j)
-        pname_y = "c%d_%d" % (i, j-1)
+        pname_x = "c%d_%d" % (i - 1, j)
+        pname_y = "c%d_%d" % (i, j - 1)
         setattr(dpoly_dx, pname_x, i * cij)
         setattr(dpoly_dy, pname_y, j * cij)
 
@@ -268,7 +269,7 @@ def seq(start, stop, step=1):
         increment of the sequence, defaults to 1
 
     """
-    feps = 1e-10     # value used in R seq.default
+    feps = 1e-10  # value used in R seq.default
 
     delta = stop - start
     if delta == 0 and stop == 0:
@@ -309,7 +310,7 @@ def add_mags(mags):
     """
     Returns a combined magnitude for a group of py_objects with ``mags``
     """
-    return -2.5*np.log10((10**(-0.4*np.array(mags))).sum())
+    return -2.5 * np.log10((10 ** (-0.4 * np.array(mags))).sum())
 
 
 def dist_mod_from_distance(d):
@@ -326,7 +327,7 @@ def distance_from_dist_mod(mu):
     d = 10**(1 + mu / 5)
     """
 
-    d = 10**(1 + mu / 5)
+    d = 10 ** (1 + mu / 5)
     return d
 
 
@@ -355,7 +356,7 @@ def telescope_diffraction_limit(aperture_size, wavelength, distance=None):
 
     """
 
-    diff_limit = (((wavelength*u.um)/(aperture_size*u.m))*u.rad).to(u.arcsec).value
+    diff_limit = (((wavelength * u.um) / (aperture_size * u.m)) * u.rad).to(u.arcsec).value
 
     if distance is not None:
         diff_limit *= distance / u.pc.to(u.AU)
@@ -436,7 +437,6 @@ def set_logger_level(which="console", level="ERROR"):
         ["ON", "OFF", "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"]
 
     """
-
 
     hdlr_name = f"scopesim_{which}_logger"
     level = {"ON": "INFO", "OFF": "CRITICAL"}.get(level.upper(), level)
@@ -519,7 +519,7 @@ def find_file(filename, path=None, silent=False):
                     for trydir in path if trydir is not None]
 
     for fname in trynames:
-        if fname.exists():   # success
+        if fname.exists():  # success
             # strip leading ./
             # Path should take care of this automatically!
             # while fname[:2] == './':
@@ -529,7 +529,6 @@ def find_file(filename, path=None, silent=False):
             # HACK: Turn Path object back into string, because not everything
             #       that depends on this function can handle Path objects (yet)
             return str(fname)
-            
 
     # no file found
     msg = f"File cannot be found: {filename}"
@@ -570,7 +569,7 @@ def airmass2zendist(airmass):
     zenith distance in degrees
     """
 
-    return np.rad2deg(np.arccos(1/airmass))
+    return np.rad2deg(np.arccos(1 / airmass))
 
 
 def convert_table_comments_to_dict(tbl):
@@ -647,8 +646,10 @@ def insert_into_ordereddict(dic, new_entry, pos):
 
 
 def empty_type(x):
-    type_dict = {int: 0, float: 0., bool: False, str: " ",
-                 list: [], tuple: (), dict: {}}
+    type_dict = {
+        int: 0, float: 0., bool: False, str: " ",
+        list: [], tuple: (), dict: {}
+    }
     if "<U" in str(x):
         x = str
 
@@ -713,7 +714,6 @@ def quantify(item, unit):
     return quant
 
 
-
 def extract_type_from_unit(unit, unit_type):
     """
     Extract ``astropy`` physical type from a compound unit
@@ -733,11 +733,11 @@ def extract_type_from_unit(unit, unit_type):
 
     """
 
-    unit = unit**1
+    unit = unit ** 1
     extracted_units = u.Unit("")
     for base, power in zip(unit._bases, unit._powers):
-        if unit_type == (base**abs(power)).physical_type:
-            extracted_units *= base**power
+        if unit_type == (base ** abs(power)).physical_type:
+            extracted_units *= base ** power
 
     new_unit = unit / extracted_units
 
@@ -762,13 +762,13 @@ def extract_base_from_unit(unit, base_unit):
 
     """
 
-    unit = unit**1
+    unit = unit ** 1
     extracted_units = u.Unit("")
     for base, power in zip(unit._bases, unit._powers):
         if base == base_unit:
-            extracted_units *= base**power
+            extracted_units *= base ** power
 
-    new_unit = unit * extracted_units**-1
+    new_unit = unit * extracted_units ** -1
 
     return new_unit, extracted_units
 
@@ -966,9 +966,11 @@ def interp2(x_new, x_orig, y_orig):
     return y_new
 
 
-def write_report(text, filename=None, output=["rst"]):
+def write_report(text, filename=None, output=None):
     """ Writes a report string to file in latex or rst format"""
-    if isinstance(output, str):
+    if output is None:
+        output = ["rst"]
+    elif isinstance(output, str):
         output = [output]
 
     if filename is not None:
@@ -1009,13 +1011,15 @@ def return_latest_github_actions_jobs_status(owner_name="AstarVienna", repo_name
     dic = response.json()
     params_list = []
     for job in dic["jobs"]:
-        params = {"name": job['name'],
-                  "status": job['status'],
-                  "conclusion": job['conclusion'],
-                  "started_at": job['started_at'],
-                  "completed_at": job['completed_at'],
-                  "url": job['html_url'],
-                  "badge_url": None}
+        params = {
+            "name": job['name'],
+            "status": job['status'],
+            "conclusion": job['conclusion'],
+            "started_at": job['started_at'],
+            "completed_at": job['completed_at'],
+            "url": job['html_url'],
+            "badge_url": None
+        }
 
         key = "Python_" + job['name'].split()[-1][:-1]
         value = "passing" if job['conclusion'] == "success" else "failing"

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -19,24 +19,6 @@ from astropy.table import Column, Table
 from . import rc
 
 
-def msg(cmds, message, level=3):
-    """
-    Prints a message based on the level of verbosity given in cmds
-
-    Parameters
-    ----------
-    cmds : UserCommands
-        just for the SIM_VERBOSE and SIM_MESSAGE_LEVEL keywords
-    message : str
-        message to be printed
-    level : int, optional
-        all messages with level <= SIM_MESSAGE_LEVEL are printed. I.e. level=5
-        messages are not important, level=1 are very important
-    """
-    if cmds["SIM_VERBOSE"] == "yes" and level <= cmds["SIM_MESSAGE_LEVEL"]:
-        print(message)
-
-
 def unify(x, unit, length=1):
     """
     Convert all types of input to an astropy array/unit pair
@@ -108,7 +90,7 @@ def parallactic_angle(ha, de, lat=-24.589167):
     lat = np.deg2rad(lat)
 
     eta = np.arctan2(np.cos(lat) * np.sin(ha),
-                     np.sin(lat) * np.cos(de) - \
+                     np.sin(lat) * np.cos(de) -
                      np.cos(lat) * np.sin(de) * np.cos(ha))
 
     return np.rad2deg(eta)

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -561,13 +561,13 @@ def convert_table_comments_to_dict(tbl):
         try:
             comments_str = "\n".join(tbl.meta["comments"])
             comments_dict = yaml.full_load(comments_str)
-        except:
+        except yaml.error.YAMLError:
             logging.warning("Couldn't convert <table>.meta['comments'] to dict")
             comments_dict = tbl.meta["comments"]
     elif "COMMENT" in tbl.meta:
         try:
             comments_dict = yaml.full_load("\n".join(tbl.meta["COMMENT"]))
-        except:
+        except yaml.error.YAMLError:
             logging.warning("Couldn't convert <table>.meta['COMMENT'] to dict")
             comments_dict = tbl.meta["COMMENT"]
     else:

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -742,9 +742,8 @@ def extract_base_from_unit(unit, base_unit):
 
     """
 
-    unit = unit ** 1
     extracted_units = u.Unit("")
-    for base, power in zip(unit._bases, unit._powers):
+    for base, power in zip(unit.bases, unit.powers):
         if base == base_unit:
             extracted_units *= base ** power
 

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -186,8 +186,8 @@ def deriv_polynomial2d(poly):
     ----------
     poly : astropy.modeling.models.Polynomial2D
 
-    Output
-    ------
+    Returns
+    -------
     gradient : tuple of Polynomial2d
     """
     import re

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -231,45 +231,6 @@ def add_keyword(filename, keyword, value, comment="", ext=0):
     f.close()
 
 
-def add_SED_to_scopesim(file_in, file_out=None, wave_units="um"):
-    """
-    Adds the SED given in ``file_in`` to the ScopeSim data directory
-
-    Parameters
-    ----------
-    file_in : str
-        path to the SED file. Can be either FITS or ASCII format with 2 columns
-        Column 1 is the wavelength, column 2 is the flux
-    file_out : str, optional
-        Default is None. The file path to save the ASCII file. If ``None``, the SED
-        is saved to the ScopeSim data directory i.e. to ``rc.__data_dir__``
-    wave_units : str, astropy.Units
-        Units for the wavelength column, either as a string or as astropy units
-        Default is [um]
-
-    """
-
-    path = Path(file_in)
-
-    if file_out is None:
-        if "SED_" not in path.name:
-            file_out = rc.__data_dir__ + f"SED_{path.name}.dat"
-        else:
-            file_out = rc.__data_dir__ + f"{path.name}.dat"
-
-    if path.suffix.lower() == ".fits":
-        data = fits.getdata(file_in)
-        lam, val = data[data.columns[0].name], data[data.columns[1].name]
-    else:
-        lam, val = ioascii.read(file_in)[:2]
-
-    lam = (lam * u.Unit(wave_units)).to(u.um)
-    mask = (lam > 0.3*u.um) * (lam < 5.0*u.um)
-
-    np.savetxt(file_out, np.array((lam[mask], val[mask]), dtype=np.float32).T,
-               header="wavelength    value \n [um]         [flux]")
-
-
 def airmass_to_zenith_dist(airmass):
     """
     returns zenith distance in degrees

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -714,10 +714,8 @@ def extract_type_from_unit(unit, unit_type):
         Any base units corresponding to ``unit_type``
 
     """
-
-    unit = unit ** 1
     extracted_units = u.Unit("")
-    for base, power in zip(unit._bases, unit._powers):
+    for base, power in zip(unit.bases, unit.powers):
         if unit_type == (base ** abs(power)).physical_type:
             extracted_units *= base ** power
 


### PR DESCRIPTION
This removes all warnings in PyCharm in `ter_curves.py`.

To improve upon later:
* The asserts for the base classes in `apply_to()` are a bit ugly, see #241.
* The code still accesses the `_get_ter_property()` protected member of the `SpectralSurface` class. I decided to just suppress that for the moment.
* We should do something about `make_imagehdu_from_table()` and `bg_cell_width`, see #243