### PR TITLE
Don't fear the __repr__

### DIFF
--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -263,7 +263,7 @@ class UserCommands:
         return self.cmds.__contains__(item)
 
     def __repr__(self):
-        return self.cmds.__repr__()
+        return f"{self.__class__.__name__}(**{self.kwargs!r})"
 
 
 def check_for_updates(package_name):

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -1,12 +1,9 @@
 from pathlib import Path
 
-from astropy.table import Table
-
 from ..effects.data_container import DataContainer
 from .. import base_classes as bc
 from ..utils import from_currsys, write_report
 from ..reports.rst_utils import table_to_rst
-from .. import rc
 
 
 class Effect(DataContainer):

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -115,11 +115,12 @@ class Effect(DataContainer):
     def meta_string(self):
         meta_str = ""
         max_key_len = max(len(key) for key in self.meta.keys())
+        padlen = max_key_len + 4
         for key in self.meta:
             if key not in {"comments", "changes", "description", "history",
                            "report_table_caption", "report_plot_caption",
                            "table"}:
-                meta_str += f"    {key.rjust(max_key_len)} : {self.meta[key]}\n"
+                meta_str += f"{key:>{padlen}} : {self.meta[key]}\n"
 
         return meta_str
 

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -292,8 +292,7 @@ Meta-data
         """
         Prints basic information on the effect, notably the description
         """
-        name = self.meta.get("name", self.meta.get("filename", "<empty>"))
-        text = f"{type(self).__name__}: \"{name}\""
+        text = str(self)
 
         desc = self.meta.get("description")
         if desc is not None:
@@ -302,10 +301,10 @@ Meta-data
         print(text)
 
     def __repr__(self):
-        return f"{type(self).__name__}: \"{self.display_name}\""
+        return f"{self.__class__.__name__}(**{self.meta!r})"
 
     def __str__(self):
-        return self.__repr__()
+        return f"{self.__class__.__name__}: \"{self.display_name}\""
 
     def __getitem__(self, item):
         if isinstance(item, str) and item.startswith("#"):

--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -369,8 +369,12 @@ class MetisLMSSpectralTrace(SpectralTrace):
         """
         return fp_x * self.meta["plate_scale"]
 
-
     def __repr__(self):
+        msg = (f"{self.__class__.__name__}({self._file!r}, "
+               f"{self.meta['slice']!r}, {self.meta!r})")
+        return msg
+
+    def __str__(self):
         msg = (f"<MetisLMSSpectralTrace> \"{self.meta['description']}\" : "
                f"{from_currsys(self.meta['wavelen'])} um : "
                f"Order {self.meta['order']} : Angle {self.meta['angle']}")

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -337,7 +337,8 @@ class SpectralTraceList(Effect):
         return plt.gcf()
 
     def __repr__(self):
-        return "\n".join([spt.__repr__() for spt in self.spectral_traces])
+        # "\n".join([spt.__repr__() for spt in self.spectral_traces])
+        return f"{self.__class__.__name__}(**{self.meta!r})"
 
     def __str__(self):
         msg = (f"SpectralTraceList: \"{self.meta.get('name')}\" : "

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -545,6 +545,9 @@ class SpectralTrace:
                                      fill_value="extrapolate")
 
     def __repr__(self):
+        return f"{self.__class__.__name__}({self.table!r}, **{self.meta!r})"
+
+    def __str__(self):
         msg = (f"<SpectralTrace> \"{self.meta['trace_id']}\" : "
                f"[{self.wave_min:.4f}, {self.wave_max:.4f}]um : "
                f"Ext {self.meta['extension_id']} : "

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -645,6 +645,12 @@ class FieldOfView(FieldOfViewBase):
                 and field.header.get("BG_SRC", False) is True]
 
     def __repr__(self):
+        waverange = [self.meta["wave_min"].value, self.meta["wave_max"].value]
+        msg = (f"{self.__class__.__name__}({self.header!r}, {waverange!r}, "
+               f"{self.detector_header!r}, **{self.meta!r})")
+        return msg
+
+    def __str__(self):
         msg = (f"FOV id: {self.meta['id']}, with dimensions "
                f"({self.header['NAXIS1']}, {self.header['NAXIS2']})\n"
                f"Sky centre: ({self.header['CRVAL1']}, "

--- a/scopesim/optics/fov_manager.py
+++ b/scopesim/optics/fov_manager.py
@@ -44,6 +44,9 @@
 
 from copy import deepcopy
 import numpy as np
+from typing import TextIO
+from io import StringIO
+
 from astropy import units as u
 
 from . import image_plane_utils as ipu
@@ -375,6 +378,30 @@ class FovVolumeList(FOVSetupBase):
     def __delitem__(self, key):
         del self.volumes[key]
 
+    def write_string(self, stream: TextIO) -> None:
+        """Write formatted string representation to I/O stream"""
+        n_vol = len(self.volumes)
+        stream.write(f"FovVolumeList with {n_vol} volumes:")
+        max_digits = len(str(n_vol))
+
+        for i_vol, vol in enumerate(self.volumes):
+            pre = "\n└─" if i_vol == n_vol - 1 else "\n├─"
+            stream.write(f"{pre}[{i_vol:>{max_digits}}]:")
+
+            pre = "\n  " if i_vol == n_vol - 1 else "\n│ "
+            n_key = len(vol)
+            for i_key, (key, val) in enumerate(vol.items()):
+                subpre = "└─" if i_key == n_key - 1 else "├─"
+                stream.write(f"{pre}{subpre}{key}: {val}")
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.volumes[0]})"
+
+    def __str__(self) -> str:
+        with StringIO() as str_stream:
+            self.write_string(str_stream)
+            output = str_stream.getvalue()
+        return output
 
     def __iadd__(self, other):
         if isinstance(other, list):

--- a/scopesim/optics/fov_manager.py
+++ b/scopesim/optics/fov_manager.py
@@ -363,19 +363,18 @@ class FovVolumeList(FOVSetupBase):
     def __len__(self):
         return len(self.volumes)
 
-    def __getitem__(self, item):
-        return self.volumes[item]
+    def __iter__(self):
+        return iter(self.volumes)
+
+    def __getitem__(self, key):
+        return self.volumes[key]
 
     def __setitem__(self, key, value):
         self.volumes[item] = value
 
-    def __repr__(self):
-        text = f"FovVolumeList with [{len(self.volumes)}] volumes:\n"
-        for i, vol in enumerate(self.volumes):
-            mini_text = ", ".join([f"{key}: {val}" for key, val in vol.items()])
-            text += f"  [{i}] {mini_text} \n"
+    def __delitem__(self, key):
+        del self.volumes[key]
 
-        return text
 
     def __iadd__(self, other):
         if isinstance(other, list):

--- a/scopesim/optics/fov_manager.py
+++ b/scopesim/optics/fov_manager.py
@@ -189,7 +189,9 @@ class FovVolumeList(FOVSetupBase):
 
     """
 
-    def __init__(self, initial_volume={}):
+    def __init__(self, initial_volume=None):
+        if initial_volume is None:
+            initial_volume = {}
 
         self.volumes = [{"wave_min": 0.3,
                          "wave_max": 30,

--- a/scopesim/optics/optical_element.py
+++ b/scopesim/optics/optical_element.py
@@ -204,10 +204,11 @@ class OpticalElement:
     def properties_str(self):
         prop_str = ""
         max_key_len = max(len(key) for key in self.properties.keys())
+        padlen = max_key_len + 4
         for key in self.properties:
             if key not in {"comments", "changes", "description", "history",
                            "report"}:
-                prop_str += f"    {key.rjust(max_key_len)} : {self.properties[key]}\n"
+                prop_str += f"{key:>{padlen}} : {self.properties[key]}\n"
 
         return prop_str
 

--- a/scopesim/optics/optical_element.py
+++ b/scopesim/optics/optical_element.py
@@ -1,5 +1,7 @@
 import logging
 from inspect import isclass
+from typing import TextIO
+from io import StringIO
 
 from astropy.table import Table
 
@@ -189,16 +191,29 @@ class OpticalElement:
 
         return obj
 
+    def write_string(self, stream: TextIO, list_effects: bool = True) -> None:
+        """Write formatted string representation to I/O stream"""
+        stream.write(f"{self!s} contains {len(self.effects)} Effects\n")
+        if list_effects:
+            for i_eff, eff in enumerate(self.effects):
+                stream.write(f"[{i_eff}] {eff!r}\n")
+
+    def pretty_str(self) -> str:
+        """Return formatted string representation as str"""
+        with StringIO() as str_stream:
+            self.write_string(str_stream)
+            output = str_stream.getvalue()
+        return output
+
+    @property
+    def display_name(self):
+        return self.meta.get("name", self.meta.get("filename", "<empty>"))
+
     def __repr__(self):
-        msg = (f"\nOpticalElement : \"{self.meta['name']}\" contains "
-               f"{len(self.effects)} Effects: \n")
-        eff_str = "\n".join([f"[{i}] {eff.__repr__()}" for i, eff
-                             in enumerate(self.effects)])
-        return msg + eff_str
+        return f"<{self.__class__.__name__}>"
 
     def __str__(self):
-        name = self.meta.get("name", self.meta.get("filename", "<empty>"))
-        return f"{type(self).__name__}: \"{name}\""
+        return f"{self.__class__.__name__}: \"{self.display_name}\""
 
     @property
     def properties_str(self):

--- a/scopesim/optics/optical_element.py
+++ b/scopesim/optics/optical_element.py
@@ -174,7 +174,7 @@ class OpticalElement:
         elif isinstance(item, int):
             obj = self.effects[item]
         elif isinstance(item, str):
-            if item[0] == "#" and "." in item:
+            if item.startswith("#") and "." in item:
                 eff, meta = item.replace("#", "").split(".")
                 obj = self[eff][f"#{meta}"]
             else:

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -492,6 +492,9 @@ class OpticalTrain:
     def effects(self):
         return self.optics_manager.list_effects()
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.cmds!r})"
+
     def __str__(self):
         return self._description
 

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -83,9 +83,8 @@ class OpticalTrain:
 
     """
     def __init__(self, cmds=None):
-
-        self._description = self.__repr__()
         self.cmds = cmds
+        self._description = self.__repr__()
         self.optics_manager = None
         self.fov_manager = None
         self.image_planes = []

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -30,7 +30,7 @@ class OpticsManager:
 
     """
 
-    def __init__(self, yaml_dicts=[], **kwargs):
+    def __init__(self, yaml_dicts=None, **kwargs):
         self.optical_elements = []
         self.meta = {}
         self.meta.update(kwargs)

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -1,5 +1,8 @@
 import logging
 from inspect import isclass
+from typing import TextIO
+from io import StringIO
+from collections.abc import Sequence
 
 import numpy as np
 from astropy import units as u
@@ -344,15 +347,26 @@ Summary of Effects in Optical Elements:
         elif isinstance(obj, efs.Effect) and isinstance(value, dict):
             obj.meta.update(value)
 
-    def __repr__(self):
-        msg = (f"\nOpticsManager contains {len(self.optical_elements)} "
-               "OpticalElements \n")
-        for ii, opt_el in enumerate(self.optical_elements):
-            msg += (f"[{ii}] \"{opt_el.meta['name']}\" contains "
-                    f"{len(opt_el.effects)} effects \n")
+    def write_string(self, stream: TextIO) -> None:
+        """Write formatted string representation to I/O stream"""
+        stream.write(f"{self!s} contains {len(self.optical_elements)} "
+                     "OpticalElements\n")
+        for opt_elem in enumerate(self.optical_elements):
+            opt_elem.write_string(stream, list_effects=False)
 
-        return msg
+    def pretty_str(self) -> str:
+        """Return formatted string representation as str"""
+        with StringIO() as str_stream:
+            self.write_string(str_stream)
+            output = str_stream.getvalue()
+        return output
+
+    @property
+    def display_name(self):
+        return self.meta.get("name", self.meta.get("filename", "<empty>"))
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}>"
 
     def __str__(self):
-        name = self.meta.get("name", self.meta.get("filename", "<empty>"))
-        return f"{type(self).__name__}: \"{name}\""
+        return f"{self.__class__.__name__}: \"{self.display_name}\""

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -45,7 +45,7 @@ class OpticsManager:
     def set_derived_parameters(self):
 
         if "!INST.pixel_scale" not in rc.__currsys__:
-            raise ValueError("!INST.pixel_scale is missing from the current"
+            raise ValueError("'!INST.pixel_scale' is missing from the current"
                              "system. Please add this to the instrument (INST)"
                              "properties dict for the system.")
         pixel_scale = rc.__currsys__["!INST.pixel_scale"] * u.arcsec
@@ -82,10 +82,10 @@ class OpticsManager:
 
         """
 
-        if isinstance(yaml_dicts, dict):
+        if not isinstance(yaml_dicts, Sequence):
             yaml_dicts = [yaml_dicts]
-        self.optical_elements += [OpticalElement(dic, **kwargs)
-                                  for dic in yaml_dicts if "effects" in dic]
+        self.optical_elements.extend(OpticalElement(dic, **kwargs)
+                                     for dic in yaml_dicts if "effects" in dic)
 
     def add_effect(self, effect, ext=0):
         """
@@ -176,7 +176,7 @@ class OpticsManager:
         detector_lists = self.detector_setup_effects
         headers = [det_list.image_plane_header for det_list in detector_lists]
 
-        if len(detector_lists) == 0:
+        if not detector_lists:
             raise ValueError(f"No DetectorList objects found. {detector_lists}")
 
         return headers
@@ -314,7 +314,7 @@ Summary of Effects in Optical Elements:
             obj = self.optical_elements[item]
         elif isinstance(item, str):
             # check for hash-string for getting Effect.meta values
-            if item[0] == "#" and "." in item:
+            if item.startswith("#") and "." in item:
                 opt_el_name = item.replace("#", "").split(".")[0]
                 new_item = item.replace(f"{opt_el_name}.", "")
                 obj = self[opt_el_name][new_item]

--- a/scopesim/optics/radiometry.py
+++ b/scopesim/optics/radiometry.py
@@ -91,4 +91,4 @@ class RadiometryTable:
         return self.surfaces[item]
 
     def __repr__(self):
-        return self.table.__repr__()
+        return f"{self.__class__.__name__}({self.table!r}, **{self.meta})"

--- a/scopesim/optics/surface.py
+++ b/scopesim/optics/surface.py
@@ -282,9 +282,14 @@ class SpectralSurface:
         return val_out
 
     def __repr__(self):
+        msg = (f"{self.__class__.__name__}({self.meta['filename']}, "
+               f"**{self.meta!r})")
+        return msg
+
+    def __str__(self):
         meta = self.meta
         name = meta["name"] if "name" in meta else meta["filename"]
         cols = "".join([col[0].upper() for col in self.table.colnames])
-        msg = "<SpectralSurface> [{cols}] \"{name}\""
+        msg = "SpectralSurface [{cols}] \"{name}\""
 
         return msg

--- a/scopesim/system_dict.py
+++ b/scopesim/system_dict.py
@@ -1,17 +1,25 @@
+# -*- coding: utf-8 -*-
+
 import logging
+from typing import TextIO
+from io import StringIO
+from collections.abc import Iterable, Mapping, MutableMapping
+
+from more_itertools import ilen
 
 
-class SystemDict():
+class SystemDict(MutableMapping):
     def __init__(self, new_dict=None):
         self.dic = {}
-        if isinstance(new_dict, dict):
+        if isinstance(new_dict, Mapping):
             self.update(new_dict)
-        elif isinstance(new_dict, list):
+        elif isinstance(new_dict, Iterable):
             for entry in new_dict:
                 self.update(entry)
 
-    def update(self, new_dict):
-        if isinstance(new_dict, dict) \
+    def update(self, new_dict: MutableMapping) -> None:
+        # TODO: why do we check for dict here but not in the else?
+        if isinstance(new_dict, Mapping) \
                 and "alias" in new_dict \
                 and "properties" in new_dict:
             alias = new_dict["alias"]
@@ -35,6 +43,8 @@ class SystemDict():
 
     def __getitem__(self, item):
         if isinstance(item, str) and item.startswith("!"):
+            # TODO: these should be replaced with item.removeprefix("!")
+            #       once we can finally drop support for Python 3.8 UwU
             item_chunks = item[1:].split(".")
             entry = self.dic
             for item in item_chunks:
@@ -44,45 +54,88 @@ class SystemDict():
 
     def __setitem__(self, key, value):
         if isinstance(key, str) and key.startswith("!"):
-            key_chunks = key[1:].split(".")
+            # TODO: these should be replaced with item.removeprefix("!")
+            #       once we can finally drop support for Python 3.8 UwU
+            *key_chunks, final_key = key[1:].split(".")
             entry = self.dic
-            for key in key_chunks[:-1]:
+            for key in key_chunks:
                 if key not in entry:
                     entry[key] = {}
                 entry = entry[key]
-            entry[key_chunks[-1]] = value
+            entry[final_key] = value
         else:
             self.dic[key] = value
 
-    def __contains__(self, item):
-        if isinstance(item, str) and item.startswith("!"):
-            item_chunks = item[1:].split(".")
-            entry = self.dic
-            for item in item_chunks:
-                if not isinstance(entry, dict) or item not in entry:
-                    return False
-                entry = entry[item]
-            return True
-        return item in self.dic
+    def __delitem__(self, item):
+        raise NotImplementedError("item deletion is not yet implemented for "
+                                  f"{self.__class__.__name__}")
 
-    def __repr__(self):
-        msg = "<SystemDict> contents:"
-        for key, val in self.dic.items():
-            msg += f"\n{key}: "
-            if isinstance(val, dict):
-                for subkey in val.keys():
-                    msg += f"\n  {subkey}: {val[subkey]}"
+    # def __contains__(self, item):
+          # method is redundant when inheriting from abc
+    #     if isinstance(item, str) and item.startswith("!"):
+    #         # TODO: these should be replaced with item.removeprefix("!")
+    #         #       once we can finally drop support for Python 3.8 UwU
+    #         item_chunks = item[1:].split(".")
+    #         entry = self.dic
+    #         for item in item_chunks:
+    #             if not isinstance(entry, Mapping) or item not in entry:
+    #                 return False
+    #             entry = entry[item]
+    #         return True
+    #     return item in self.dic
+
+    def _yield_subkeys(self, key, value):
+        for subkey, subvalue in value.items():
+            if isinstance(subvalue, Mapping):
+                yield from self._yield_subkeys(f"{key}.{subkey}", subvalue)
             else:
-                msg += f"{val}\n"
-        return msg
+                yield f"!{key}.{subkey}"
+
+    def __iter__(self):
+        for key, value in self.dic.items():
+            if isinstance(value, Mapping):
+                yield from self._yield_subkeys(key, value)
+            else:
+                yield key
+
+    def __len__(self) -> int:
+        return ilen(iter(self))
+
+    def _write_subdict(self, subdict: Mapping, stream: TextIO,
+                       pad: str = "") -> None:
+        pre = pad.replace("├─", "│ ").replace("└─", "  ")
+        n_sub = len(subdict)
+        for i_sub, (key, val) in enumerate(subdict.items()):
+            subpre = "└─" if i_sub == n_sub - 1 else "├─"
+            stream.write(f"{pre}{subpre}{key}: ")
+            if isinstance(val, Mapping):
+                self._write_subdict(val, stream, pre + subpre)
+            else:
+                stream.write(f"{val}")
+
+    def write_string(self, stream: TextIO) -> None:
+        """Write formatted string representation to I/O stream"""
+        stream.write("SystemDict contents:")
+        self._write_subdict(self.dic, stream, "\n")
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.dic!r})"
+
+    def __str__(self) -> str:
+        # SystemDict({"foo":5, "bar":{"bogus": {"a":42, "b":69}, "baz":"meh"}, "moo":"yolo", "yeet": {"x":0, "y":420}})
+        # "SystemDict contents:\n├─foo: 5\n├─bar: \n│ ├─bogus: \n│ │ ├─a: 42\n│ │ └─b: 69\n│ └─baz: meh\n├─moo: yolo\n└─yeet: \n  ├─x: 0\n  └─y: 420"
+        with StringIO() as str_stream:
+            self.write_string(str_stream)
+            output = str_stream.getvalue()
+        return output
 
 
-def recursive_update(old_dict, new_dict):
+def recursive_update(old_dict: MutableMapping, new_dict: Mapping) -> MutableMapping:
     if new_dict is not None:
         for key in new_dict:
             if old_dict is not None and key in old_dict:
-                if isinstance(old_dict[key], dict):
-                    if isinstance(new_dict[key], dict):
+                if isinstance(old_dict[key], Mapping):
+                    if isinstance(new_dict[key], Mapping):
                         old_dict[key] = recursive_update(old_dict[key],
                                                          new_dict[key])
                     else:
@@ -90,7 +143,7 @@ def recursive_update(old_dict, new_dict):
                                         old_dict[key], new_dict[key])
                         old_dict[key] = new_dict[key]
                 else:
-                    if isinstance(new_dict[key], dict):
+                    if isinstance(new_dict[key], Mapping):
                         logging.warning("Overwriting non-dict: %s with dict: %s",
                                         old_dict[key], new_dict[key])
                     old_dict[key] = new_dict[key]


### PR DESCRIPTION
This will close #222, at least to the extent that all the already implemented `__repr__()` methods confirm to the behavior outlined in that issue, except a few cases where the corresponding class was too complex, i.e. it's not straightforward to represent it fully. These cases will now produce `"<classname>"`, which is at least somewhat uniform.

*Additionally*, some classes previously had "pretty print"-style methods, which might be useful for some applications (e.g. reporting, logging, ...). Those were in some cases rewritten using a I/O-stream object, so the output could be directly piped to a file, if needed. Calling `__str__()` on those classes will dump that into a string stream and return a perfectly normal string. Some classes had `__str__()` methods defined, using just a `display_name`. For those cases, another method `pretty_str` was added, to keep these two behaviors separate.

*Finally*, the `SystemDict` was modified to inherit from `collection.abc.MutableMapping`, thus effectively making it a `dict`, if that is already in the name. The exact implementation there might be optimized further in the future...