### PR TITLE
Display note for deprecated irdb modes

### DIFF
--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -231,6 +231,8 @@ class UserCommands:
                 for mode in modes:
                     if mode in self.modes_dict:
                         defyam["properties"]["modes"].append(mode)
+                        if "deprecate" in self.modes_dict[mode]:
+                            logging.warning(self.modes_dict[mode]["deprecate"])
                     else:
                         raise ValueError(f"mode '{mode}' was not recognised")
 
@@ -243,6 +245,8 @@ class UserCommands:
                 dic = self.modes_dict[mode_name]
                 desc = dic["description"] if "description" in dic else "<None>"
                 modes[mode_name] = desc
+                if "deprecate" in dic:
+                    modes[mode_name] += " (deprecated)"
 
             msg = "\n".join([f"{key}: {value}" for key, value in modes.items()])
         else:


### PR DESCRIPTION
`UserCommands.set_modes()` displays a deprecation note if the parameter `deprecate` is set in the irdb mode definition. 
`UserCommands.list_modes()` adds "(deprecated)" to the description of such modes.