### PR TITLE
Some plotting and representation improvements

### DIFF
--- a/scopesim/detector/detector_array.py
+++ b/scopesim/detector/detector_array.py
@@ -101,6 +101,21 @@ class DetectorArray:
 
         return self.latest_exposure
 
+    def __repr__(self):
+        msg = (f"{self.__class__.__name__}"
+               f"({self.detector_list!r}, **{self.meta!r})")
+        return msg
+
+    def __str__(self):
+        return f"{self.__class__.__name__} with {self.detector_list!s}"
+
+    def _repr_pretty_(self, p, cycle):
+        """For ipython"""
+        if cycle:
+            p.text(f"{self.__class__.__name__}(...)")
+        else:
+            p.text(str(self))
+
 
 def make_primary_hdu(meta):
     """Create the primary header from meta data"""

--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -4,6 +4,8 @@ import numpy as np
 from astropy import units as u
 from astropy.table import Table
 
+from matplotlib import pyplot as plt
+
 from ..base_classes import FOVSetupBase
 from .effects import Effect
 from .apertures import ApertureMask
@@ -251,22 +253,21 @@ class DetectorList(Effect):
 
         return hdrs
 
-    def plot(self):
-        import matplotlib.pyplot as plt
-        plt.gcf().clf()
+    def plot(self, axes=None):
+        if axes is None:
+            _, axes = plt.subplots()
 
         for hdr in self.detector_headers():
             x_mm, y_mm = calc_footprint(hdr, "D")
-            x_cen, y_cen = np.average(x_mm), np.average(y_mm)
-            x_mm = list(x_mm) + [x_mm[0]]
-            y_mm = list(y_mm) + [y_mm[0]]
-            plt.gca().plot(x_mm, y_mm)
-            plt.gca().text(x_cen, y_cen, hdr["ID"])
+            axes.plot(np.append(x_mm, x_mm[0]), np.append(y_mm, y_mm[0]))
+            axes.text(*np.mean((x_mm, y_mm), axis=1), hdr["ID"],
+                      ha="center", va="center")
 
-        plt.gca().set_aspect("equal")
-        plt.ylabel("Size [mm]")
+        axes.set_aspect("equal")
+        axes.set_xlabel("Size [mm]")
+        axes.set_ylabel("Size [mm]")
 
-        return plt.gcf()
+        return axes
 
 
 class DetectorWindow(DetectorList):

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -239,7 +239,12 @@ Data
 """
 
         if params["report_plot_include"] and hasattr(self, "plot"):
+            from matplotlib.figure import Figure
             fig = self.plot()
+            # HACK: plot methods should always return the same, while this is
+            #       not sorted out, deal with both fig and ax
+            if not isinstance(fig, Figure):
+                fig = fig.figure
 
             if fig is not None:
                 path = params["report_image_path"]

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -113,15 +113,12 @@ class Effect(DataContainer):
 
     @property
     def meta_string(self):
-        meta_str = ""
-        max_key_len = max(len(key) for key in self.meta.keys())
-        padlen = max_key_len + 4
-        for key in self.meta:
-            if key not in {"comments", "changes", "description", "history",
-                           "report_table_caption", "report_plot_caption",
-                           "table"}:
-                meta_str += f"{key:>{padlen}} : {self.meta[key]}\n"
-
+        padlen = 4 + len(max(self.meta, key=len))
+        exclude = {"comments", "changes", "description", "history",
+                   "report_table_caption", "report_plot_caption", "table"}
+        meta_str = "\n".join(f"{key:>{padlen}} : {value}"
+                             for key, value in self.meta.items()
+                             if key not in exclude)
         return meta_str
 
     def report(self, filename=None, output="rst", rst_title_chars="*+",
@@ -199,7 +196,7 @@ class Effect(DataContainer):
 
         """
         changes = self.meta.get("changes", [])
-        changes_str = "- " + "\n- ".join([str(entry) for entry in changes])
+        changes_str = "- " + "\n- ".join(str(entry) for entry in changes)
         cls_doc = self.__doc__ if self.__doc__ is not None else "<no docstring>"
         cls_descr = cls_doc.lstrip().splitlines()[0]
 
@@ -262,6 +259,9 @@ Data
                 #                            params["report_rst_path"])
                 # rel_file_path = os.path.join(rel_path, fname)
 
+                # TODO: fname is set in a loop above, so using it here in the
+                #       fstring will only access the last value from the loop,
+                #       is that intended?
                 rst_str += f"""
 .. figure:: {fname}
     :name: {"fig:" + params.get("name", "<unknown Effect>")}
@@ -292,16 +292,11 @@ Meta-data
         return rst_str
 
     def info(self):
-        """
-        Prints basic information on the effect, notably the description
-        """
-        text = str(self)
-
-        desc = self.meta.get("description")
-        if desc is not None:
-            text += f"\nDescription: {desc}"
-
-        print(text)
+        """Print basic information on the effect, notably the description."""
+        if (desc := self.meta.get("description")) is not None:
+            print(f"{self}\nDescription: {desc}")
+        else:
+            print(self)
 
     def __repr__(self):
         return f"{self.__class__.__name__}(**{self.meta!r})"

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -314,12 +314,32 @@ class SpectralTraceList(Effect):
 
         return outhdul
 
-
     def rectify_cube(self, hdulist):
         """Rectify traces and combine into a cube"""
         raise(NotImplementedError)
 
     def plot(self, wave_min=None, wave_max=None, axes=None, **kwargs):
+        """Plot every spectral trace in the spectral trace list.
+
+        Parameters
+        ----------
+        wave_min : float, optional
+            Minimum wavelength, if any. If None, value from_currsys is used.
+        wave_max : float, optional
+            Maximum wavelength, if any. If None, value from_currsys is used.
+        axes : matplotlib axes, optional
+            The axes object to use for the plot. If None (default), a new
+            figure with one axes will be created.
+        **kwargs : dict
+            Any other parameters passed along to the plot method of the
+            individual spectral traces.
+
+        Returns
+        -------
+        fig : matplotlib figure
+            DESCRIPTION.
+
+        """
         if wave_min is None:
             wave_min = from_currsys("!SIM.spectral.wave_min")
         if wave_max is None:

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -181,7 +181,7 @@ class SpectralTraceList(Effect):
                     ex_vol["meta"].update(vol)
                     ex_vol["meta"].pop("wave_min")
                     ex_vol["meta"].pop("wave_max")
-                new_vols_list += extracted_vols
+                new_vols_list.extend(extracted_vols)
 
             obj.volumes = new_vols_list
 
@@ -197,8 +197,7 @@ class SpectralTraceList(Effect):
                 logging.info("Making cube")
                 obj.cube = obj.make_cube_hdu()
 
-            trace_id = obj.meta["trace_id"]
-            spt = self.spectral_traces[trace_id]
+            spt = self.spectral_traces[obj.meta["trace_id"]]
             obj.hdu = spt.map_spectra_to_focal_plane(obj)
 
         return obj
@@ -210,11 +209,11 @@ class SpectralTraceList(Effect):
         xfoot, yfoot = [], []
         for spt in self.spectral_traces.values():
             xtrace, ytrace = spt.footprint()
-            xfoot += xtrace
-            yfoot += ytrace
+            xfoot.extend(xtrace)
+            yfoot.extend(ytrace)
 
-        xfoot = [np.min(xfoot), np.max(xfoot), np.max(xfoot), np.min(xfoot)]
-        yfoot = [np.min(yfoot), np.min(yfoot), np.max(yfoot), np.max(yfoot)]
+        xfoot = [min(xfoot), max(xfoot), max(xfoot), min(xfoot)]
+        yfoot = [min(yfoot), min(yfoot), max(yfoot), max(yfoot)]
 
         return xfoot, yfoot
 
@@ -301,7 +300,7 @@ class SpectralTraceList(Effect):
         #pdu.header['FILTER'] = from_currsys("!OBS.filter_name_fw1")
         outhdul = fits.HDUList([pdu])
 
-        for i, trace_id in enumerate(self.spectral_traces):
+        for i, trace_id in enumerate(self.spectral_traces, start=1):
             hdu = self[trace_id].rectify(hdulist,
                                          interps=interps,
                                          bin_width=bin_width,
@@ -309,7 +308,7 @@ class SpectralTraceList(Effect):
                                          wave_min=wave_min, wave_max=wave_max)
             if hdu is not None:   # ..todo: rectify does not do that yet
                 outhdul.append(hdu)
-                outhdul[0].header[f"EXTNAME{i+1}"] = trace_id
+                outhdul[0].header[f"EXTNAME{i}"] = trace_id
 
         outhdul[0].header.update(inhdul[0].header)
 

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -7,8 +7,10 @@ The Effect is called `SpectralTraceList`, it applies a list of
 
 from pathlib import Path
 import logging
+from itertools import cycle
 
 import numpy as np
+from matplotlib import pyplot as plt
 
 from astropy.io import fits
 from astropy.table import Table
@@ -318,23 +320,22 @@ class SpectralTraceList(Effect):
         """Rectify traces and combine into a cube"""
         raise(NotImplementedError)
 
-    def plot(self, wave_min=None, wave_max=None, **kwargs):
+    def plot(self, wave_min=None, wave_max=None, axes=None, **kwargs):
         if wave_min is None:
             wave_min = from_currsys("!SIM.spectral.wave_min")
         if wave_max is None:
             wave_max = from_currsys("!SIM.spectral.wave_max")
 
-        from matplotlib import pyplot as plt
-        from matplotlib._pylab_helpers import Gcf
-        if len(Gcf.figs) == 0:
-            plt.figure(figsize=(12, 12))
+        if axes is None:
+            fig, axes = plt.subplots(figsize=(12, 12))
+        else:
+            fig = axes.figure
 
         if self.spectral_traces is not None:
-            clrs = "rgbcymk" * (1 + len(self.spectral_traces) // 7)
-            for spt, c in zip(self.spectral_traces.values(), clrs):
-                spt.plot(wave_min, wave_max, c=c)
+            for spt, c in zip(self.spectral_traces.values(), cycle("rgbcymk")):
+                spt.plot(wave_min, wave_max, c=c, axes=axes, **kwargs)
 
-        return plt.gcf()
+        return fig
 
     def __repr__(self):
         # "\n".join([spt.__repr__() for spt in self.spectral_traces])

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -482,9 +482,48 @@ class SpectralTrace:
                 [y_edge.min(), y_edge.min(), y_edge.max(), y_edge.max()])
 
     def plot(self, wave_min=None, wave_max=None, xi_min=None, xi_max=None, *,
-             c="r", axes=None, plot_footprint=True, plot_text=True,
+             c="r", axes=None, plot_footprint=True, plot_wave=True,
              plot_ctrlpnts=True, plot_outline=False, plot_trace_id=False):
-        """Plot control points of the SpectralTrace"""
+        """Plot control points (and/or footprint) of the SpectralTrace.
+
+        Parameters
+        ----------
+        wave_min : float, optional
+            Minimum wavelength, if any.
+        wave_max : float, optional
+            Maximum wavelength, if any.
+        xi_min : float, optional
+            Minimum slit, if any.
+        xi_max : float, optional
+            Maximum slit, if any.
+        c : str, optional
+            Colour, any valid matplotlib colour string. The default is "r".
+        axes : matplotlib axes, optional
+            The axes object to use for the plot. If None (default), a new
+            figure with one axes will be created.
+
+        Returns
+        -------
+        axes : matplotlib axes
+            The axes object containing the plot.
+
+        Other Parameters
+        ----------------
+        plot_footprint : bool, optional
+            Plot a rectangle encompassing all control points, which may be
+            larger than the area actually covered by the trace, if the trace is
+            not exactly perpendicular to the detector. The default is True.
+        plot_wave : bool, optional
+            Annotate the wavelength points. The default is True.
+        plot_ctrlpnts : bool, optional
+            Plot the individual control points as makers. The default is True.
+        plot_outline : bool, optional
+            Plot the smallest tetragon encompassing all control points.
+            The default is False.
+        plot_trace_id : bool, optional
+            Write the trace ID in the middle of the trace.
+            The default is False.
+        """
         if axes is None:
             _, axes = plt.subplots()
 
@@ -548,7 +587,7 @@ class SpectralTrace:
             xx.sort()
             dx = xx[-1] - xx[-2]
 
-            if plot_text:
+            if plot_wave:
                 axes.text(x[w==wave].max() + 0.5 * dx,
                           y[w==wave].mean(),
                           str(wave), va="center", ha="left")

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -556,7 +556,7 @@ class SpectralTrace:
             xi_max = xis.max()
 
         mask = ((waves >= wave_min) & (waves <= wave_max)
-                & (xis >= xi_min)& (xis <= xi_max))
+                & (xis >= xi_min) & (xis <= xi_max))
         if sum(mask) <= 2:
             return axes
 

--- a/scopesim/optics/optical_element.py
+++ b/scopesim/optics/optical_element.py
@@ -215,6 +215,13 @@ class OpticalElement:
     def __str__(self):
         return f"{self.__class__.__name__}: \"{self.display_name}\""
 
+    def _repr_pretty_(self, p, cycle):
+        """For ipython"""
+        if cycle:
+            p.text(f"{self.__class__.__name__}(...)")
+        else:
+            p.text(str(self))
+
     @property
     def properties_str(self):
         prop_str = ""

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -497,6 +497,36 @@ class OpticalTrain:
     def __str__(self):
         return self._description
 
+    def _repr_pretty_(self, p, cycle):
+        """For ipython"""
+        if cycle:
+            p.text(f"{self.__class__.__name__}(...)")
+        else:
+            p.text(f"{self.__class__.__name__} ")
+            p.text(f"for {self.cmds['!OBS.instrument']} ")
+            p.text(f"@ {self.cmds['!TEL.telescope']}:")
+            p.breakable()
+            p.text("UserCommands:")
+            p.breakable()
+            p.pretty(self.cmds)
+            p.breakable()
+            p.text("OpticalElements:")
+            with p.indent(2):
+                for item in self:
+                    p.breakable()
+                    p.pretty(item)
+            p.breakable()
+            p.text("DetectorArrays:")
+            with p.indent(2):
+                for item in self.detector_arrays:
+                    p.breakable()
+                    p.pretty(item)
+            p.breakable()
+            p.text("Effects:")
+            p.breakable()
+            with p.indent(2):
+                p.pretty(self.effects)
+
     def __getitem__(self, item):
         return self.optics_manager[item]
 


### PR DESCRIPTION
1. Some improvements to plotting methods of `SpectralTrace`, `SpectralTraceList` and `DetectorList`. They now use `matplotlib`'s "OOP mode" (i.e. `fig, ax` instead of all `plt.whatever`), as a first step to migrate all plotting related functions to that. This allows e.g. to easily plot the spectral traces into the detector layout plot by passing the `axes` object (this use-case was the main motivation for this modification). More configurability for the plot methods was added along the way, but the default behavior should remain the same as before.
2. A `_repr_pretty_` method was added to some classes, which is accessed by IPython to support a nicer human-readable representation of an object. This is currently very experimental, as there are multiple (not really compatible) ways to implement this. This will require more though, experimentation, and finally standardization. And probably a separate issue...