### PR TITLE
Figure factory

### DIFF
--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -4,12 +4,11 @@ import numpy as np
 from astropy import units as u
 from astropy.table import Table
 
-from matplotlib import pyplot as plt
-
 from ..base_classes import FOVSetupBase
 from .effects import Effect
 from .apertures import ApertureMask
 from .. import utils
+from ..utils import close_loop, figure_factory
 from ..optics.image_plane_utils import header_from_list_of_xy, calc_footprint
 
 __all__ = ["DetectorList", "DetectorWindow"]
@@ -255,11 +254,11 @@ class DetectorList(Effect):
 
     def plot(self, axes=None):
         if axes is None:
-            _, axes = plt.subplots()
+            _, axes = figure_factory()
 
         for hdr in self.detector_headers():
             x_mm, y_mm = calc_footprint(hdr, "D")
-            axes.plot(np.append(x_mm, x_mm[0]), np.append(y_mm, y_mm[0]))
+            axes.plot(list(close_loop(x_mm)), list(close_loop(y_mm)))
             axes.text(*np.mean((x_mm, y_mm), axis=1), hdr["ID"],
                       ha="center", va="center")
 

--- a/scopesim/effects/electronic.py
+++ b/scopesim/effects/electronic.py
@@ -22,14 +22,13 @@ Functions:
 import logging
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 from astropy.io import fits
 
 from .. import rc
 from . import Effect
 from ..base_classes import DetectorBase, ImagePlaneBase
-from ..utils import from_currsys
+from ..utils import from_currsys, figure_factory
 from .. import utils
 
 
@@ -311,13 +310,15 @@ class PoorMansHxRGReadoutNoise(Effect):
 
         return det
 
-    def plot(self, det, new_figure=False, **kwargs):
+    def plot(self, det, **kwargs):
         dtcr = self.apply_to(det)
-        plt.imshow(dtcr.data, origin="lower")
+        fig, ax = figure_factory()
+        ax.imshow(dtcr.data, origin="lower")
 
     def plot_hist(self, det, **kwargs):
         dtcr = self.apply_to(det)
-        plt.hist(dtcr.data.flatten())
+        fig, ax = figure_factory()
+        ax.hist(dtcr.data.flatten())
 
 
 class BasicReadoutNoise(Effect):
@@ -347,11 +348,13 @@ class BasicReadoutNoise(Effect):
 
     def plot(self, det):
         dtcr = self.apply_to(det)
-        plt.imshow(dtcr.data)
+        fig, ax = figure_factory()
+        ax.imshow(dtcr.data)
 
     def plot_hist(self, det, **kwargs):
         dtcr = self.apply_to(det)
-        plt.hist(dtcr.data.flatten())
+        fig, ax = figure_factory()
+        ax.hist(dtcr.data.flatten())
 
 
 class ShotNoise(Effect):
@@ -392,11 +395,13 @@ class ShotNoise(Effect):
 
     def plot(self, det):
         dtcr = self.apply_to(det)
-        plt.imshow(dtcr.data)
+        fig, ax = figure_factory()
+        ax.imshow(dtcr.data)
 
     def plot_hist(self, det, **kwargs):
         dtcr = self.apply_to(det)
-        plt.hist(dtcr.data.flatten())
+        fig, ax = figure_factory()
+        ax.hist(dtcr.data.flatten())
 
 
 class DarkCurrent(Effect):
@@ -436,9 +441,10 @@ class DarkCurrent(Effect):
         dtcr = self.apply_to(det)
         dark_level = dtcr.data[0, 0] / total_time  # just read one pixel
         levels = dark_level * times
-        plt.plot(times, levels, **kwargs)
-        plt.xlabel("time")
-        plt.ylabel("dark level")
+        fig, ax = figure_factory()
+        ax.plot(times, levels, **kwargs)
+        ax.set_xlabel("time")
+        ax.set_ylabel("dark level")
 
 
 class LinearityCurve(Effect):
@@ -496,17 +502,17 @@ class LinearityCurve(Effect):
         return obj
 
     def plot(self, **kwargs):
-        plt.gcf().clf()
+        fig, ax = figure_factory()
 
         ndit = from_currsys(self.meta["ndit"])
         incident = self.table["incident"] * ndit
         measured = self.table["measured"] * ndit
 
-        plt.loglog(incident, measured, **kwargs)
-        plt.xlabel("Incident [ph s$^-1$]")
-        plt.ylabel("Measured [e- s$^-1$]")
+        ax.loglog(incident, measured, **kwargs)
+        ax.set_xlabel("Incident [ph s$^-1$]")
+        ax.set_ylabel("Measured [e- s$^-1$]")
 
-        return plt.gcf()
+        return fig
 
 
 class ReferencePixelBorder(Effect):
@@ -536,8 +542,9 @@ class ReferencePixelBorder(Effect):
 
     def plot(self, implane, **kwargs):
         implane = self.apply_to(implane)
-        plt.imshow(implane.data, origin="bottom", **kwargs)
-        plt.show()
+        fig, ax = figure_factory()
+        ax.imshow(implane.data, origin="bottom", **kwargs)
+        # fig.show()
 
 
 class BinnedImage(Effect):

--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -217,7 +217,6 @@ class MetisLMSSpectralTrace(SpectralTrace):
         x_max = aperture["right"]
         y_min = aperture["bottom"]
         y_max = aperture["top"]
-        trace_id = self.meta["trace_id"]
 
         layout = ioascii.read(find_file("!DET.layout.file_name"))
         det_lims = {}
@@ -237,7 +236,7 @@ class MetisLMSSpectralTrace(SpectralTrace):
                 "y_min": y_min, "y_max": y_max,
                 "xi_min": xi_min, "xi_max": xi_max,
                 "wave_min": wave_min, "wave_max": wave_max,
-                "trace_id": trace_id}
+                "trace_id": self.trace_id}
 
     def get_waverange(self, det_mm_lims):
         """Determine wavelength range that spectral trace covers on image plane"""

--- a/scopesim/effects/obs_strategies.py
+++ b/scopesim/effects/obs_strategies.py
@@ -3,7 +3,6 @@
 - ChopNodCombiner: simulate chop-nod cycle
 """
 import numpy as np
-from matplotlib import pyplot as plt
 
 from scopesim.base_classes import DetectorBase
 from scopesim.effects import Effect

--- a/scopesim/effects/psf_utils.py
+++ b/scopesim/effects/psf_utils.py
@@ -5,11 +5,11 @@ from scipy.ndimage import zoom
 from astropy import units as u
 from astropy.convolution import Gaussian2DKernel
 from astropy.io import fits
-import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 
 from .. import rc, utils
 from ..optics import image_plane_utils as imp_utils
+from ..utils import figure_factory
 
 
 def round_kernel_edges(kernel):
@@ -74,9 +74,10 @@ def nmrms_from_strehl_and_wavelength(strehl, wavelength, strehl_hdu,
         nm = np.interp(strehl, strehls[::-1], nms[::-1])
 
     if plot:
-        plt.plot(nms, strehls)
-        plt.plot(nm, strehl, "ro")
-        plt.show()
+        fig, ax = figure_factory()
+        ax.plot(nms, strehls)
+        ax.plot(nm, strehl, "ro")
+        fig.show()
 
     return nm
 

--- a/scopesim/effects/shifts.py
+++ b/scopesim/effects/shifts.py
@@ -3,7 +3,8 @@ from astropy import units as u
 from astropy.table import Table
 
 from .effects import Effect
-from ..utils import airmass2zendist, from_currsys, check_keys, quantify
+from ..utils import airmass2zendist, from_currsys, check_keys, quantify, \
+    figure_factory
 from ..base_classes import FieldOfViewBase
 
 
@@ -38,19 +39,18 @@ class Shift3D(Effect):
         return tbl
 
     def plot(self):
-        import matplotlib.pyplot as plt
-        plt.gcf().clf()
+        fig, ax = figure_factory()
 
         tbl = self.get_table()
-        plt.scatter(x=tbl["dx"], y=tbl["dy"], c=tbl["wavelength"])
-        plt.colorbar()
-        plt.xlabel(f"dx [{quantify(tbl['dx'], u.arcsec).unit}]")
-        plt.ylabel(f"dy [{quantify(tbl['dy'], u.arcsec).unit}]")
-        plt.axvline(0, ls=":")
-        plt.axhline(0, ls=":")
-        # plt.gca().set_aspect("equal")
+        pnts = ax.scatter(x=tbl["dx"], y=tbl["dy"], c=tbl["wavelength"])
+        fig.colorbar(pnts)
+        ax.set_xlabel(f"dx [{quantify(tbl['dx'], u.arcsec).unit}]")
+        ax.set_ylabel(f"dy [{quantify(tbl['dy'], u.arcsec).unit}]")
+        ax.axvline(0, ls=":")
+        ax.axhline(0, ls=":")
+        # ax.set_aspect("equal")
 
-        return plt.gcf()
+        return fig
 
 
 class AtmosphericDispersion(Shift3D):

--- a/scopesim/effects/spectral_efficiency.py
+++ b/scopesim/effects/spectral_efficiency.py
@@ -100,11 +100,11 @@ class SpectralEfficiency(Effect):
         """
         Interface between FieldOfView and SpectralEfficiency
         """
-        trace_id = obj.meta['trace_id']
+        trace_id = obj.trace_id
         try:
             effic = self.efficiencies[trace_id]
         except KeyError:
-            logging.warning("No grating efficiency for trace %s" % trace_id)
+            logging.warning("No grating efficiency for trace %s", trace_id)
             return obj
 
         wcs = WCS(obj.hdu.header).spectral

--- a/scopesim/effects/spectral_efficiency.py
+++ b/scopesim/effects/spectral_efficiency.py
@@ -3,7 +3,6 @@ Spectral grating efficiencies
 """
 import logging
 import numpy as np
-from matplotlib import pyplot as plt
 
 from astropy.io import fits
 from astropy import units as u
@@ -13,7 +12,7 @@ from astropy.table import Table
 from .effects import Effect
 from .ter_curves import TERCurve
 from .ter_curves_utils import apply_throughput_to_cube
-from ..utils import find_file
+from ..utils import find_file, figure_factory
 from ..base_classes import FieldOfViewBase, FOVSetupBase
 
 class SpectralEfficiency(Effect):
@@ -116,12 +115,14 @@ class SpectralEfficiency(Effect):
 
     def plot(self):
         """Plot the grating efficiencies"""
+        fig, ax = figure_factory()
         for name, effic in self.efficiencies.items():
             wave = effic.throughput.waveset
-            plt.plot(wave.to(u.um), effic.throughput(wave), label=name)
+            ax.plot(wave.to(u.um), effic.throughput(wave), label=name)
 
-        plt.xlabel("Wavelength [um]")
-        plt.ylabel("Grating efficiency")
-        plt.title(f"Grating efficiencies from {self.filename}")
-        plt.legend()
-        plt.show()
+        ax.set_xlabel("Wavelength [um]")
+        ax.set_ylabel("Grating efficiency")
+        ax.set_title(f"Grating efficiencies from {self.filename}")
+        ax.legend()
+
+        return fig

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -196,7 +196,7 @@ class SpectralTraceList(Effect):
                 logging.info("Making cube")
                 obj.cube = obj.make_cube_hdu()
 
-            spt = self.spectral_traces[obj.meta["trace_id"]]
+            spt = self.spectral_traces[obj.trace_id]
             obj.hdu = spt.map_spectra_to_focal_plane(obj)
 
         return obj

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -10,7 +10,6 @@ import logging
 from itertools import cycle
 
 import numpy as np
-from matplotlib import pyplot as plt
 
 from astropy.io import fits
 from astropy.table import Table
@@ -18,7 +17,7 @@ from astropy.table import Table
 from .effects import Effect
 from .ter_curves import FilterCurve
 from .spectral_trace_list_utils import SpectralTrace, make_image_interpolations
-from ..utils import from_currsys, check_keys
+from ..utils import from_currsys, check_keys, figure_factory
 from ..optics.image_plane_utils import header_from_list_of_xy
 from ..base_classes import FieldOfViewBase, FOVSetupBase
 
@@ -346,7 +345,7 @@ class SpectralTraceList(Effect):
             wave_max = from_currsys("!SIM.spectral.wave_max")
 
         if axes is None:
-            fig, axes = plt.subplots(figsize=(12, 12))
+            fig, axes = figure_factory()
         else:
             fig = axes.figure
 

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -76,6 +76,11 @@ class SpectralTrace:
         self._xilamimg = None
         self.dlam_per_pix = None
 
+    @property
+    def trace_id(self):
+        """Return the name of the trace"""
+        return self.meta["trace_id"]
+
     def fov_grid(self):
         """
         Provide information on the source space volume required by the effect
@@ -141,7 +146,7 @@ class SpectralTrace:
         The method returns a section of the fov image along with info on
         where this image lies in the focal plane.
         """
-        logging.info("Mapping %s", fov.meta["trace_id"])
+        logging.info("Mapping %s", fov.trace_id)
         # Initialise the image based on the footprint of the spectral
         # trace and the focal plane WCS
         wave_min = fov.meta["wave_min"].value       # [um]
@@ -175,7 +180,7 @@ class SpectralTrace:
         ## Check if spectral trace footprint is outside FoV
         if xmax < 0 or xmin > naxis1d or ymax < 0 or ymin > naxis2d:
             logging.info("Spectral trace %s: footprint is outside FoV",
-                         fov.meta["trace_id"])
+                         fov.trace_id)
             return None
 
         # Only work on parts within the FoV
@@ -592,11 +597,6 @@ class SpectralTrace:
 
         axes.set_aspect("equal")
         return axes
-
-    @property
-    def trace_id(self):
-        """Return the name of the trace"""
-        return self.meta["trace_id"]
 
     def _set_dispersion(self, wave_min, wave_max, pixsize=None):
         """Computation of dispersion dlam_per_pix along xi=0

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -15,7 +15,6 @@ import numpy as np
 
 from scipy.interpolate import RectBivariateSpline
 from scipy.interpolate import interp1d
-from matplotlib import pyplot as plt
 
 from astropy.table import Table, vstack
 from astropy.modeling import fitting
@@ -24,7 +23,8 @@ from astropy import units as u
 from astropy.wcs import WCS
 from astropy.modeling.models import Polynomial2D
 
-from ..utils import power_vector, quantify, from_currsys
+from ..utils import power_vector, quantify, from_currsys, close_loop, \
+    figure_factory
 
 
 class SpectralTrace:
@@ -525,17 +525,15 @@ class SpectralTrace:
             The default is False.
         """
         if axes is None:
-            _, axes = plt.subplots()
+            _, axes = figure_factory()
 
         # Footprint (rectangle enclosing the trace)
         xlim, ylim  = self.footprint(wave_min=wave_min, wave_max=wave_max)
         if xlim is None:
             return axes
 
-        xlim.append(xlim[0])
-        ylim.append(ylim[0])
         if plot_footprint:
-            axes.plot(xlim, ylim)
+            axes.plot(list(close_loop(xlim)), list(close_loop(ylim)))
 
         # for convenience...
         xname = self.meta["x_colname"]

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -84,6 +84,11 @@ class FieldOfView(FieldOfViewBase):
         self._volume = None
 
     @property
+    def trace_id(self):
+        """Return the name of the trace"""
+        return self.meta["trace_id"]
+
+    @property
     def pixel_area(self):
         if self.meta["pixel_area"] is None:
             hdr = self.header

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -8,9 +8,9 @@ import logging
 from collections import OrderedDict
 from collections.abc import Iterable, Generator
 from itertools import chain
-from docutils.core import publish_string
 from copy import deepcopy
 
+from docutils.core import publish_string
 import requests
 import yaml
 import numpy as np
@@ -181,7 +181,7 @@ def deriv_polynomial2d(poly):
     degree = poly.degree
     dpoly_dx = Polynomial2D(degree=degree - 1)
     dpoly_dy = Polynomial2D(degree=degree - 1)
-    regexp = re.compile(r'c(\d+)_(\d+)')
+    regexp = re.compile(r"c(\d+)_(\d+)")
     for pname in poly.param_names:
         # analyse the name
         match = regexp.match(pname)
@@ -264,8 +264,7 @@ def seq(start, stop, step=1):
     except ZeroDivisionError:
         if step == 0 and delta == 0:
             return start
-        else:
-            raise ValueError("invalid '(stop - start) / step'")
+        raise ValueError("invalid '(stop - start) / step'")
 
     if npts < 0:
         raise ValueError("wrong sign in 'step' argument")
@@ -341,7 +340,8 @@ def telescope_diffraction_limit(aperture_size, wavelength, distance=None):
 
     """
 
-    diff_limit = (((wavelength * u.um) / (aperture_size * u.m)) * u.rad).to(u.arcsec).value
+    diff_limit = (((wavelength * u.um) / (aperture_size * u.m))
+                  * u.rad).to(u.arcsec).value
 
     if distance is not None:
         diff_limit *= distance / u.pc.to(u.AU)
@@ -601,9 +601,9 @@ def change_table_entry(tbl, col_name, new_val, old_val=None, position=None):
 
 
 def real_colname(name, colnames, silent=True):
-    names = [name.lower(), name.upper(), name[0].upper() + name[1:].lower()]
+    names = [name.lower(), name.upper(), name.capitalize()]
     real_name = [name for name in names if name in colnames]
-    if len(real_name) == 0:
+    if not real_name:
         real_name = None
         if not silent:
             logging.warning("None of %s were found in %s", names, colnames)
@@ -657,13 +657,13 @@ def get_meta_quantity(meta_dict, name, fallback_unit=""):
 
     """
 
-    if isinstance(meta_dict[name], str) and meta_dict[name][0] == "!":
+    if isinstance(meta_dict[name], str) and meta_dict[name].startswith("!"):
         meta_dict[name] = from_currsys(meta_dict[name])
 
     if isinstance(meta_dict[name], u.Quantity):
         unit = meta_dict[name].unit
-    elif name + "_unit" in meta_dict:
-        unit = meta_dict[name + "_unit"]
+    elif f"{name}_unit" in meta_dict:
+        unit = meta_dict[f"{name}_unit"]
     else:
         unit = u.Unit(fallback_unit)
 
@@ -687,7 +687,7 @@ def quantify(item, unit):
 
     """
 
-    if isinstance(item, str) and item[0] == "!":
+    if isinstance(item, str) and item.startswith("!"):
         item = from_currsys(item)
     if isinstance(item, u.Quantity):
         quant = item.to(u.Unit(unit))
@@ -755,13 +755,9 @@ def extract_base_from_unit(unit, base_unit):
     return new_unit, extracted_units
 
 
-def is_fits(filename):
-    flag = False
-    if filename is not None:
-        if filename.split(".")[-1].lower() in "fits":
-            flag = True
-
-    return flag
+def is_fits(filename) -> bool:
+    # Using 'in ".fits"' to also catch ".fit", which exists sometimes...
+    return (filename is not None and Path(filename).suffix.lower() in ".fits")
 
 
 def get_fits_type(filename):
@@ -782,7 +778,7 @@ def quantity_from_table(colname, table, default_unit=""):
         else:
             col = col.data << col.unit
     else:
-        colname_u = colname + "_unit"
+        colname_u = f"{colname}_unit"
         if colname_u in table.meta:
             col = col * u.Unit(table.meta[colname_u])
         else:
@@ -805,7 +801,7 @@ def unit_from_table(colname, table, default_unit=""):
     """
     Looks for the unit for a column based on the meta dict keyword "<col>_unit"
     """
-    colname_u = colname + "_unit"
+    colname_u = f"{colname}_unit"
     col = table[colname]
     if col.unit is not None:
         unit = col.unit
@@ -836,16 +832,16 @@ def has_needed_keywords(header, suffix=""):
     """
     Check to see if the WCS keywords are in the header
     """
-    keys = ["CDELT1", "CRVAL1", "CRPIX1"]
-    return (sum(key + suffix in header.keys() for key in keys) == 3 and
-            "NAXIS1" in header.keys())
+    keys = {"CDELT1", "CRVAL1", "CRPIX1"}
+    keys = {key + suffix for key in keys}
+    keys.add("NAXIS1")
+    return all(key in header.keys() for key in keys)
 
 
 def stringify_dict(dic, ignore_types=(str, int, float)):
     """
     Turns a dict entries into strings for addition to FITS headers
     """
-    from copy import deepcopy
     dic_new = deepcopy(dic)
     for key in dic_new:
         if not isinstance(dic_new[key], ignore_types):
@@ -928,7 +924,8 @@ def check_keys(input_dict, required_keys, action="error", all_any="all"):
     if not keys_present:
         if "error" in action:
             raise ValueError("One or more of the following keys missing from "
-                             f"input_dict: \n{required_keys} \n{input_dict.keys()}")
+                             f"input_dict: \n{required_keys} "
+                             f"\n{input_dict.keys()}")
         if "warn" in action:
             logging.warning(("One or more of the following keys missing "
                              "from input_dict: \n%s \n%s"), required_keys,
@@ -979,33 +976,44 @@ def pretty_print_dict(dic, indent=0):
     return text
 
 
-def return_latest_github_actions_jobs_status(owner_name="AstarVienna", repo_name="ScopeSim",
-                                             branch="dev_master", actions_yaml_name="tests.yml"):
+def return_latest_github_actions_jobs_status(
+        owner_name="AstarVienna",
+        repo_name="ScopeSim",
+        branch="dev_master",
+        actions_yaml_name="tests.yml",
+    ):
     """
     Gets the status of the latest test run
     """
-    response = requests.get(f"https://api.github.com/repos/{owner_name}/{repo_name}/"
-                            f"actions/workflows/{actions_yaml_name}/runs?branch={branch}&per_page=1")
+    response = requests.get(
+        f"https://api.github.com/repos/{owner_name}/{repo_name}/actions/"
+        f"workflows/{actions_yaml_name}/runs?branch={branch}&per_page=1"
+    )
     dic = response.json()
     run_id = dic["workflow_runs"][0]["id"]
 
-    response = requests.get(f"https://api.github.com/repos/{owner_name}/{repo_name}/actions/runs/{run_id}/jobs")
+    response = requests.get(
+        f"https://api.github.com/repos/{owner_name}/{repo_name}/actions/runs/"
+        f"{run_id}/jobs"
+    )
     dic = response.json()
     params_list = []
     for job in dic["jobs"]:
         params = {
-            "name": job['name'],
-            "status": job['status'],
-            "conclusion": job['conclusion'],
-            "started_at": job['started_at'],
-            "completed_at": job['completed_at'],
-            "url": job['html_url'],
+            "name": job["name"],
+            "status": job["status"],
+            "conclusion": job["conclusion"],
+            "started_at": job["started_at"],
+            "completed_at": job["completed_at"],
+            "url": job["html_url"],
             "badge_url": None
         }
 
-        key = "Python_" + job['name'].split()[-1][:-1]
-        value = "passing" if job['conclusion'] == "success" else "failing"
-        colour = "brightgreen" if job['conclusion'] == "success" else "red"
+        # TODO: this could use the new badges from IRDB, once that's in
+        #       scopesim_core...
+        key = "Python_" + job["name"].split()[-1][:-1]
+        value = "passing" if job["conclusion"] == "success" else "failing"
+        colour = "brightgreen" if job["conclusion"] == "success" else "red"
         badge_url = f"https://img.shields.io/badge/{key}-{value}-{colour}"
         params["badge_url"] = badge_url
         params_list.append(params)

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -6,12 +6,15 @@ from pathlib import Path
 import sys
 import logging
 from collections import OrderedDict
+from collections.abc import Iterable, Generator
+from itertools import chain
 from docutils.core import publish_string
 from copy import deepcopy
 
 import requests
 import yaml
 import numpy as np
+from matplotlib import pyplot as plt
 from astropy import units as u
 from astropy.io import fits
 from astropy.table import Column, Table
@@ -1008,3 +1011,25 @@ def return_latest_github_actions_jobs_status(owner_name="AstarVienna", repo_name
         params_list.append(params)
 
     return params_list
+
+
+def close_loop(iterable: Iterable) -> Generator:
+    """x, y = zip(*close_loop(zip(x, y)))"""
+    iterator = iter(iterable)
+    first = next(iterator)
+    yield first
+    yield from iterator
+    yield first
+
+
+def figure_factory(nrows=1, ncols=1, **kwargs):
+    """Default way to init fig and ax, to easily modify later."""
+    fig, ax = plt.subplots(nrows, ncols, **kwargs)
+    return fig, ax
+
+
+def figure_grid_factory(nrows=1, ncols=1, **kwargs):
+    """Gridspec variant."""
+    fig = plt.figure()
+    gs = fig.add_gridspec(nrows, ncols, **kwargs)
+    return fig, gs


### PR DESCRIPTION
Move from `plt` to `fig, ax` API for matplotlib.

Basically a continuation of #260 

This allows more control over the actual figure and axes objects used for plotting, it also outsources the creation of those to a new function in `utils`. This means if we want to change some configuration of these plots in the future, we should only need to do so in one place. Also, this eliminates the need to import matplotlib in many modules, while utils is usually imported (from) anyway.

Additionally, this gets rid of things like the `clf()` method, which is "deprecated" and "discouraged" according to the matplotlib docs.

This also adds `utils.close_loop`, which can be used to append the first element of an iterable at the end of that iterable, thus "closing the loop". This is needed in some places in the code, mostly to plot footprints and such, where the line needs to come back to the starting point.