### PR TITLE
Better inheritance and more

### DIFF
--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -422,11 +422,13 @@ class SlitWheel(Effect):
             current_slit: "C"
 
     """
-    def __init__(self, **kwargs):
-        required_keys = ["slit_names", "filename_format", "current_slit"]
-        check_keys(kwargs, required_keys, action="error")
 
+    required_keys = {"slit_names", "filename_format", "current_slit"}
+    _current_str = "current_slit"
+
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        check_keys(kwargs, self.required_keys, action="error")
 
         params = {"z_order": [80, 280, 580],
                   "path": "",
@@ -436,7 +438,7 @@ class SlitWheel(Effect):
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        path = Path(self.meta["path"], from_currsys(self.meta["filename_format"]))
+        path = self._get_path()
         self.slits = {}
         for name in from_currsys(self.meta["slit_names"]):
             kwargs["name"] = name
@@ -482,12 +484,6 @@ class SlitWheel(Effect):
         if not currslit:
             return False
         return self.slits[currslit]
-
-    @property
-    def display_name(self):
-        return f"{self.meta['name']} : " \
-               f"[{from_currsys(self.meta['current_slit'])}]"
-
 
     def __getattr__(self, item):
         return getattr(self.current_slit, item)

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -109,7 +109,10 @@ class Effect(DataContainer):
 
     @property
     def display_name(self):
-        return self.meta.get("name", self.meta.get("filename", "<empty>"))
+        name = self.meta.get("name", self.meta.get("filename", "<untitled>"))
+        if not hasattr(self, "_current_str"):
+            return name
+        return f"{name} : [{from_currsys(self.meta[self._current_str])}]"
 
     @property
     def meta_string(self):
@@ -321,3 +324,9 @@ Meta-data
             raise ValueError(f"__getitem__ calls must start with '#': {item}")
 
         return value
+
+    def _get_path(self):
+        if any(key not in self.meta for key in ("path", "filename_format")):
+            return None
+        return Path(self.meta["path"],
+                    from_currsys(self.meta["filename_format"]))

--- a/scopesim/effects/spectral_efficiency.py
+++ b/scopesim/effects/spectral_efficiency.py
@@ -122,7 +122,7 @@ class SpectralEfficiency(Effect):
 
         ax.set_xlabel("Wavelength [um]")
         ax.set_ylabel("Grating efficiency")
-        ax.set_title(f"Grating efficiencies from {self.filename}")
+        ax.set_title(f"Grating efficiencies {self.display_name}")
         ax.legend()
 
         return fig

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -428,13 +428,14 @@ class SpectralTraceListWheel(Effect):
               filter_names: "!INST.grism_names"
 
     """
-    def __init__(self, **kwargs):
-        required_keys = ["trace_list_names",
-                         "filename_format",
-                         "current_trace_list"]
-        check_keys(kwargs, required_keys, action="error")
 
+    required_keys = {"trace_list_names", "filename_format",
+                     "current_trace_list"}
+    _current_str = "current_trace_list"
+
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        check_keys(kwargs, self.required_keys, action="error")
 
         params = {"z_order": [70, 270, 670],
                   "path": "",
@@ -444,7 +445,7 @@ class SpectralTraceListWheel(Effect):
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        path = Path(self.meta["path"], from_currsys(self.meta["filename_format"]))
+        path = self._get_path()
         self.trace_lists = {}
         for name in from_currsys(self.meta["trace_list_names"]):
             kwargs["name"] = name
@@ -462,8 +463,3 @@ class SpectralTraceListWheel(Effect):
         if trace_list_name is not None:
             trace_list_eff = self.trace_lists[trace_list_name]
         return trace_list_eff
-
-    @property
-    def display_name(self):
-        name = self.meta.get("name", self.meta.get("filename", "<untitled>"))
-        return f"{name} : [{from_currsys(self.meta['current_trace_list'])}]"

--- a/scopesim/effects/surface_list.py
+++ b/scopesim/effects/surface_list.py
@@ -145,7 +145,7 @@ class SurfaceList(TERCurve):
             "x" plots throughput. "t","e","r" plot trans/emission/refl.
             Can be a combination, e.g. "tr" or "tex" to plot each.
         wavelength : array_like, optional
-            DESCRIPTION. The default is None.
+            Passed to TERCurve.plot() for each surface. The default is None.
         axes : matplotlib axes, optional
             If given, plot into existing axes. The default is None.
 
@@ -168,7 +168,7 @@ class SurfaceList(TERCurve):
                 curve = TERCurve(**surface.meta)
                 curve.surface = surface
                 kwargs.update(plot_kwargs={"ls": "-", "label": key})
-                curve.plot(ter, axes=ax, **kwargs)
+                curve.plot(ter, wavelength, axes=ax, **kwargs)
 
             # Plot the system surface
             # TODO: self is a subclass of TERCurve, why create again??

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -166,20 +166,6 @@ class TERCurve(Effect):
 
         return self._background_source
 
-    @staticmethod
-    def _guard_axes(which, axes):
-        # TODO: this method now exists twice in this module, fix that....
-        if len(which) > 1:
-            if not isinstance(axes, Collection):
-                raise TypeError(("axes must be collection of axes if which "
-                                 "contains more than one element"))
-            if not len(axes) == len(which):
-                raise ValueError("len of which and axes must match")
-        else:
-            if isinstance(axes, Collection):
-                raise TypeError(("axes must be a single axes object if which "
-                                 "contains only one element"))
-
     def plot(self, which="x", wavelength=None, *, axes=None, **kwargs):
         """Plot TER curves.
 
@@ -189,7 +175,7 @@ class TERCurve(Effect):
             "x" plots throughput. "t","e","r" plot trans/emission/refl.
             Can be a combination, e.g. "tr" or "tex" to plot each.
         wavelength : array_like, optional
-            DESCRIPTION. The default is None.
+            Wavelength on x-axis, taken from currsys if None (default).
         axes : matplotlib axes, optional
             If given, plot into existing axes. The default is None.
 
@@ -204,7 +190,7 @@ class TERCurve(Effect):
             # figsize=(10, 5)
         else:
             fig = axes.figure
-            self._guard_axes(which, axes)
+            _guard_plot_axes(which, axes)
 
         self.meta.update(kwargs)
         params = from_currsys(self.meta)
@@ -647,20 +633,6 @@ class FilterWheel(Effect):
     def __getattr__(self, item):
         return getattr(self.current_filter, item)
 
-    @staticmethod
-    def _guard_axes(which, axes):
-        # TODO: this method now exists twice in this module, fix that....
-        if len(which) > 1:
-            if not isinstance(axes, Collection):
-                raise TypeError(("axes must be collection of axes if which "
-                                 "contains more than one element"))
-            if not len(axes) == len(which):
-                raise ValueError("len of which and axes must match")
-        else:
-            if isinstance(axes, Collection):
-                raise TypeError(("axes must be a single axes object if which "
-                                 "contains only one element"))
-
     def plot(self, which="x", wavelength=None, *, axes=None, **kwargs):
         """Plot TER curves.
 
@@ -685,7 +657,7 @@ class FilterWheel(Effect):
             # figsize=(10, 5)
         else:
             fig = axes.figure
-            self._guard_axes(which, axes)
+            _guard_plot_axes(which, axes)
 
 
         for ter, ax in zip(which, axes):
@@ -954,3 +926,16 @@ class ADCWheel(Effect):
         tbl = Table(names=["name", "max_transmission"],
                     data=[names, tmax])
         return tbl
+
+
+def _guard_plot_axes(which, axes):
+    if len(which) > 1:
+        if not isinstance(axes, Collection):
+            raise TypeError(("axes must be collection of axes if which "
+                             "contains more than one element"))
+        if not len(axes) == len(which):
+            raise ValueError("len of which and axes must match")
+    else:
+        if isinstance(axes, Collection):
+            raise TypeError(("axes must be a single axes object if which "
+                             "contains only one element"))

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -499,8 +499,8 @@ class TopHatFilterCurve(FilterCurve):
         tbl = Table(names=["wavelength", "transmission"],
                     data=[waveset, transmission])
         super().__init__(table=tbl,
-                                                wavelength_unit="um",
-                                                action="transmission")
+                         wavelength_unit="um",
+                         action="transmission")
         self.meta.update(kwargs)
 
 
@@ -713,7 +713,7 @@ class TopHatFilterWheel(FilterWheelBase):
 
     current_filter: str, optional
         Name of current filter at initialisation. If no name is given, the
-        first entry in ``filter_names`` is used by default.
+        first entry in `filter_names` is used by default.
 
     Examples
     --------

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -604,11 +604,6 @@ class FilterWheelBase(Effect):
             filter_eff = self.filters[filt_name]
         return filter_eff
 
-    @property
-    def display_name(self):
-        return (f"{self.meta['name']} : "
-                f"[{from_currsys(self.meta['current_filter'])}]")
-
     def __getattr__(self, item):
         return getattr(self.current_filter, item)
 
@@ -870,11 +865,13 @@ class ADCWheel(Effect):
            filename_format: "TER_ADC_{}.dat"
            current_adc: "const_90"
     """
-    def __init__(self, **kwargs):
-        required_keys = ["adc_names", "filename_format", "current_adc"]
-        check_keys(kwargs, required_keys, action="error")
 
+    required_keys = {"adc_names", "filename_format", "current_adc"}
+    _current_str = "current_adc"
+
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        check_keys(kwargs, self.required_keys, action="error")
 
         params = {"z_order": [125, 225, 525],
                   "path": "",
@@ -884,7 +881,7 @@ class ADCWheel(Effect):
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        path = Path(self.meta["path"], from_currsys(self.meta["filename_format"]))
+        path = self._get_path()
         self.adcs = {}
         for name in from_currsys(self.meta["adc_names"]):
             kwargs["name"] = name
@@ -912,11 +909,6 @@ class ADCWheel(Effect):
         if not curradc:
             return False
         return self.adcs[curradc]
-
-    @property
-    def display_name(self):
-        return (f"{self.meta['name']} : "
-                f"[{from_currsys(self.meta['current_adc'])}]")
 
     def __getattr__(self, item):
         return getattr(self.current_adc, item)

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -548,45 +548,24 @@ class SpanishVOFilterCurve(FilterCurve):
         super().__init__(table=tbl, **kwargs)
 
 
-class FilterWheel(Effect):
-    """
-    This wheel holds a selection of predefined filters.
+class FilterWheelBase(Effect):
+    """Base class for Filter Wheels"""
 
-    Examples
-    --------
-    ::
-
-        name: filter_wheel
-        class: FilterWheel
-        kwargs:
-            filter_names: []
-            filename_format: "filters/{}.
-            current_filter: "Ks"
-
-    """
+    required_keys = set()
+    _current_str = "current_filter"
 
     def __init__(self, **kwargs):
-        required_keys = ["filter_names", "filename_format", "current_filter"]
-        check_keys(kwargs, required_keys, action="error")
-
         super().__init__(**kwargs)
+        check_keys(kwargs, self.required_keys, action="error")
 
         params = {"z_order": [124, 224, 524],
-                  "path": "",
                   "report_plot_include": True,
                   "report_table_include": True,
                   "report_table_rounding": 4}
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        path = Path(self.meta["path"], from_currsys(self.meta["filename_format"]))
         self.filters = {}
-        for name in from_currsys(self.meta["filter_names"]):
-            kwargs["name"] = name
-            self.filters[name] = FilterCurve(filename=str(path).format(name),
-                                             **kwargs)
-
-        self.table = self.get_table()
 
     def apply_to(self, obj, **kwargs):
         """Use apply_to of current filter"""
@@ -682,7 +661,42 @@ class FilterWheel(Effect):
         return tbl
 
 
-class TopHatFilterWheel(FilterWheel):
+class FilterWheel(FilterWheelBase):
+    """
+    This wheel holds a selection of predefined filters.
+
+    Examples
+    --------
+    ::
+
+        name: filter_wheel
+        class: FilterWheel
+        kwargs:
+            filter_names: []
+            filename_format: "filters/{}.
+            current_filter: "Ks"
+
+    """
+
+    required_keys = {"filter_names", "filename_format", "current_filter"}
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        params = {"path": ""}
+        self.meta.update(params)
+        self.meta.update(kwargs)
+
+        path = self._get_path()
+        for name in from_currsys(self.meta["filter_names"]):
+            kwargs["name"] = name
+            self.filters[name] = FilterCurve(filename=str(path).format(name),
+                                             **kwargs)
+
+        self.table = self.get_table()
+
+
+class TopHatFilterWheel(FilterWheelBase):
     """
     A selection of top-hat filter curves as defined in the input lists
 
@@ -721,35 +735,30 @@ class TopHatFilterWheel(FilterWheel):
             current_filter: "K"
 
     """
+
+    required_keys = {"filter_names", "transmissions", "wing_transmissions",
+                     "blue_cutoffs", "red_cutoffs"}
+
     def __init__(self, **kwargs):
-        required_keys = ["filter_names", "transmissions", "wing_transmissions",
-                         "blue_cutoffs", "red_cutoffs"]
-        check_keys(kwargs, required_keys, action="error")
+        super().__init__(**kwargs)
 
-        super(FilterWheel, self).__init__(**kwargs)
-
-        params = {"z_order": [124, 224, 524],
-                  "report_plot_include": True,
-                  "report_table_include": True,
-                  "report_table_rounding": 4,
-                  "current_filter": kwargs.get("current_filter",
-                                               kwargs["filter_names"][0])
-                  }
+        current_filter = kwargs.get("current_filter",
+                                    kwargs["filter_names"][0])
+        params = {"current_filter": current_filter}
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        self.filters = {}
-        for i in range(len(self.meta["filter_names"])):
-            name = self.meta["filter_names"][i]
-            effect_kwargs = {"name": name,
-                             "transmission": self.meta["transmissions"][i],
-                             "wing_transmission": self.meta["wing_transmissions"][i],
-                             "blue_cutoff": self.meta["blue_cutoffs"][i],
-                             "red_cutoff": self.meta["red_cutoffs"][i]}
+        for i_filt, name in enumerate(self.meta["filter_names"]):
+            effect_kwargs = {
+                "name": name,
+                "transmission": self.meta["transmissions"][i_filt],
+                "wing_transmission": self.meta["wing_transmissions"][i_filt],
+                "blue_cutoff": self.meta["blue_cutoffs"][i_filt],
+                "red_cutoff": self.meta["red_cutoffs"][i_filt]}
             self.filters[name] = TopHatFilterCurve(**effect_kwargs)
 
 
-class SpanishVOFilterWheel(FilterWheel):
+class SpanishVOFilterWheel(FilterWheelBase):
     """
     A FilterWheel that loads all the filters from the Spanish VO service
 
@@ -791,37 +800,32 @@ class SpanishVOFilterWheel(FilterWheel):
             include_str: "_filter"
 
     """
-    def __init__(self, **kwargs):
-        required_keys = ["observatory", "instrument", "current_filter"]
-        check_keys(kwargs, required_keys, action="error")
 
-        # Call Effect.init, *NOT* FilterWheel.init --> different required_keys
-        super(FilterWheel, self).__init__(**kwargs)
+    required_keys = {"observatory", "instrument", "current_filter"}
 
-        params = {"z_order": [124, 224, 524],
-                  "report_plot_include": True,
-                  "report_table_include": True,
-                  "report_table_rounding": 4,
-                  "include_str": None,         # passed to
+    def __init__(self, **kwargs):        
+        super().__init__(**kwargs)
+
+        params = {"include_str": None,         # passed to
                   "exclude_str": None,
                   }
         self.meta.update(params)
         self.meta.update(kwargs)
 
         obs, inst = self.meta["observatory"], self.meta["instrument"]
-        inc, exc = self.meta["include_str"], self.meta["exclude_str"]
-        filter_names = download_svo_filter_list(obs, inst, short_names=True,
-                                                include=inc, exclude=exc)
+        filter_names = download_svo_filter_list(
+            obs, inst, short_names=True,
+            include=self.meta["include_str"], exclude=self.meta["exclude_str"])
 
         self.meta["filter_names"] = filter_names
-        self.filters = {name: SpanishVOFilterCurve(observatory=obs,
-                                                   instrument=inst,
-                                                   filter_name=name)
-                        for name in filter_names}
-        self.filters["open"] = FilterCurve(array_dict={"wavelength": [0.3, 3.0],
-                                                       "transmission": [1., 1.]},
-                                           wavelength_unit="um",
-                                           name="unity transmission")
+        for name in filter_names:
+            self.filters[name] = SpanishVOFilterCurve(observatory=obs,
+                                                      instrument=inst,
+                                                      filter_name=name)
+
+        self.filters["open"] = FilterCurve(
+            array_dict={"wavelength": [0.3, 3.0], "transmission": [1., 1.]},
+            wavelength_unit="um", name="unity transmission")
 
         self.table = self.get_table()
 

--- a/scopesim/tests/tests_effects/test_SpectralTraceList.py
+++ b/scopesim/tests/tests_effects/test_SpectralTraceList.py
@@ -5,7 +5,8 @@ import pytest
 from astropy.io import fits
 
 
-from scopesim.effects.spectral_trace_list import SpectralTraceList
+from scopesim.effects.spectral_trace_list import SpectralTraceList, \
+    SpectralTraceListWheel
 from scopesim.effects.spectral_trace_list_utils import SpectralTrace
 from scopesim.tests.mocks.py_objects import trace_list_objects as tlo
 from scopesim.tests.mocks.py_objects import header_objects as ho
@@ -21,18 +22,22 @@ PLOTS = False
 # pylint: disable=missing-class-docstring,
 # pylint: disable=missing-function-docstring
 
+
 @pytest.fixture(name="slit_header", scope="class")
 def fixture_slit_header():
     return ho._short_micado_slit_header()
+
 
 @pytest.fixture(name="long_slit_header", scope="class")
 def fixture_long_slit_header():
     return ho._long_micado_slit_header()
 
+
 @pytest.fixture(name="full_trace_list", scope="class")
 def fixture_full_trace_list():
     """Instantiate a trace definition hdu list"""
     return tlo.make_trace_hdulist()
+
 
 class TestInit:
     def test_initialises_with_nothing(self):
@@ -70,13 +75,32 @@ def fixture_spectral_trace_list():
     """Instantiate a SpectralTraceList"""
     return SpectralTraceList(hdulist=tlo.make_trace_hdulist())
 
+
 class TestRectification:
     def test_rectify_cube_not_implemented(self, spectral_trace_list):
         hdulist = fits.HDUList()
         with pytest.raises(NotImplementedError):
             spectral_trace_list.rectify_cube(hdulist)
 
-    #def test_rectify_traces_needs_ximin_and_ximax(self, spectral_trace_list):
+    # def test_rectify_traces_needs_ximin_and_ximax(self, spectral_trace_list):
     #    hdulist = fits.HDUList([fits.PrimaryHDU()])
     #    with pytest.raises(KeyError):
     #        spectral_trace_list.rectify_traces(hdulist)
+
+
+class TestSpectralTraceListWheel:
+    def test_basic_init(self):
+        """
+        This is a super basic test just to see the thing basically works and
+        parameters are passed correctly. Please feel free to improve this!!
+        """
+        kwargs = {"current_trace_list": "bogus",
+                  "filename_format": "bogus_{}",
+                  "trace_list_names": ["foo"]}
+        stw = SpectralTraceListWheel(**kwargs)
+        assert isinstance(stw, SpectralTraceListWheel)
+        assert stw.meta["current_trace_list"] == "bogus"
+        assert stw.meta["filename_format"] == "bogus_{}"
+        assert stw.meta["trace_list_names"] == ["foo"]
+        assert isinstance(stw.trace_lists["foo"], SpectralTraceList)
+        assert stw.trace_lists["foo"].meta["filename"] == "bogus_foo"

--- a/scopesim/tests/tests_effects/test_TERCurve.py
+++ b/scopesim/tests/tests_effects/test_TERCurve.py
@@ -158,7 +158,7 @@ class TestSpanishVOFilterWheelInit:
                                              current_filter=default_filter,
                                              name="test_svo_wheel")
 
-        assert isinstance(filt_wheel, tc.FilterWheel)
+        assert isinstance(filt_wheel, tc.FilterWheelBase)
         assert default_filter in filt_wheel.filters
 
     def test_returns_filters_with_include_str(self):


### PR DESCRIPTION
This solves the "grandfather super()" issue in the `FilterWheel` subclasses by introducing a `FilterWheelBase` base class, to separate code that applies to `FilterWheel` *but not* to subclasses (which isn't a lot anyway).

Inspired by the main conflict (different required keys) that led to this issue in the first place, I made some changes to how `required_keys` is handled: I made it a class attribute, and call `check_keys` afterwards. This is in preparation for a change I started thinking about some time ago: Move the `check_keys` call up in the inheritance, either as part of `Effect` or a new class in between. Since subclass attributes take priority above parent class attributes, that should work fine and remove the `check_keys` call from the subclasses. For now, I only changed things in the classes affected here anyway, in a backwards-compatible way, to keep this PR limited.

Additionally, I had noticed earlier that several `Effect` subclasses define a *very* similar `display_name` property (overriding that property from `Effect`). The only difference was the key used to get the name from currsys, usually some `"current_xy"`. So for those classes, I introduced another class attribute `_current_str`, which holds that key (string), hardcoded. The (previously existing) property `Effect.display_name` now checks if that attribute exists and falls back to the previous behavior if that's not the case. So, all behaviors should stay the same, but with less code duplication.

Finally, in the same move, I also abstracted `._get_path()` to `Effect`, because the very same line existed in at least 4 unrelated subclasses. Again, if the subclass in question does not have the required keys, nothing happens.

Opinions and comments on all of this are of course welcome 😄 
