### PR TITLE
Refactoring of FieldOfView and more warnings

### DIFF
--- a/scopesim/detector/detector_array.py
+++ b/scopesim/detector/detector_array.py
@@ -19,7 +19,7 @@ class DetectorArray:
         self.detectors = []
         self.latest_exposure = None
 
-    def readout(self, image_planes, array_effects=[], dtcr_effects=[], **kwargs):
+    def readout(self, image_planes, array_effects=None, dtcr_effects=None, **kwargs):
         """
         Read out the detector array into a FITS file
 
@@ -54,8 +54,8 @@ class DetectorArray:
         # - add ImageHDUs
         # - add ASCIITableHDU with Effects meta data in final table extension
 
-        self.array_effects = array_effects
-        self.dtcr_effects = dtcr_effects
+        self.array_effects = array_effects or []
+        self.dtcr_effects = dtcr_effects or []
         self.meta.update(kwargs)
 
         # 0. Get the image plane that corresponds to this detector array

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -652,8 +652,15 @@ class FieldOfView(FieldOfViewBase):
         else:
             _waveset = self.waverange * u.um
 
-        _waveset = np.unique(_waveset)
-        return _waveset.to(u.um)
+        # TODO: tie the round to a global precision setting (this is defined
+        #       better in another TODO somewhere...)
+        # The rounding is necessary to not end up with things like:
+        #   0.7 um
+        #   0.7000000000000001 um
+        #   0.7000000000000002 um
+        # and yes, that actually happend...
+        _waveset = np.unique(_waveset.to(u.um).round(10))
+        return _waveset
 
     @property
     def cube_fields(self):

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -169,6 +169,7 @@ class FieldOfView(FieldOfViewBase):
         return self.hdu
 
     def flatten(self):
+        """If cube, collapse along first axis."""
         if self.hdu and self.hdu.header["NAXIS"] == 3:
             image = np.sum(self.hdu.data, axis=0)
             self.hdu.data = image
@@ -595,6 +596,7 @@ class FieldOfView(FieldOfViewBase):
 
     @property
     def data(self):
+        """Return either hdu.data, image, cube, spectrum or None."""
         if self.hdu is not None:
             return self.hdu.data
         if self.image is not None:
@@ -607,13 +609,14 @@ class FieldOfView(FieldOfViewBase):
 
     @property
     def corners(self):
+        """Return sky footprint, image plane footprint."""
         sky_corners = imp_utils.calc_footprint(self.header)
         imp_corners = imp_utils.calc_footprint(self.header, "D")
         return sky_corners, imp_corners
 
     @property
     def waverange(self):
-        """Returns wavelength range in um [wave_min, wave_max]"""
+        """Return wavelength range in um [wave_min, wave_max]."""
         if self._waverange is None:
             wave_min = utils.quantify(self.meta["wave_min"], u.um).value
             wave_max = utils.quantify(self.meta["wave_max"], u.um).value
@@ -622,14 +625,14 @@ class FieldOfView(FieldOfViewBase):
 
     @property
     def wavelength(self):
-        """Returns central wavelength in um"""
+        """Return central wavelength in um."""
         if self._wavelength is None:
             self._wavelength = np.average(self.waverange)
         return utils.quantify(self._wavelength, u.um)
 
     @property
     def waveset(self):
-        """Returns a wavelength vector in um"""
+        """Return a wavelength vector in um."""
 
         field_cubes = self.cube_fields
         if len(field_cubes) > 0:
@@ -648,6 +651,7 @@ class FieldOfView(FieldOfViewBase):
 
     @property
     def cube_fields(self):
+        """Return list of non-BG_SRC ImageHDU fields with NAXIS=3."""
         return [field for field in self.fields
                 if isinstance(field, fits.ImageHDU)
                 and field.header["NAXIS"] == 3
@@ -655,6 +659,7 @@ class FieldOfView(FieldOfViewBase):
 
     @property
     def image_fields(self):
+        """Return list of non-BG_SRC ImageHDU fields with NAXIS=2."""
         return [field for field in self.fields
                 if isinstance(field, fits.ImageHDU)
                 and field.header["NAXIS"] == 2
@@ -662,12 +667,13 @@ class FieldOfView(FieldOfViewBase):
 
     @property
     def table_fields(self):
+        """Return list of Table fields."""
         return [field for field in self.fields
                 if isinstance(field, Table)]
 
-
     @property
     def background_fields(self):
+        """Return list of BG_SRC ImageHDU fields."""
         return [field for field in self.fields
                 if isinstance(field, fits.ImageHDU)
                 and field.header.get("BG_SRC", False)]

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -157,6 +157,7 @@ class FieldOfView(FieldOfViewBase):
             self.meta["sub_pixel"] = sub_pixel
 
         if hdu_type == "image":
+            # FIXME: why not just make False the default value??
             use_photlam = False if use_photlam is None else use_photlam
             self.hdu = self.make_image_hdu(use_photlam=use_photlam)
         elif hdu_type == "cube":
@@ -292,7 +293,7 @@ class FieldOfView(FieldOfViewBase):
 
         # PHOTLAM * u.um * u.m2 --> ph / s
         specs = {ref: spec(fov_waveset) for ref, spec in self.spectra.items()}
-        if use_photlam is False:
+        if not use_photlam:
             for key in specs:
                 specs[key] = (specs[key] * bin_widths * area).to(u.ph / u.s)
 
@@ -632,14 +633,14 @@ class FieldOfView(FieldOfViewBase):
         return [field for field in self.fields
                 if isinstance(field, fits.ImageHDU)
                 and field.header["NAXIS"] == 3
-                and field.header.get("BG_SRC", False) is False]
+                and not field.header.get("BG_SRC", False)]
 
     @property
     def image_fields(self):
         return [field for field in self.fields
                 if isinstance(field, fits.ImageHDU)
                 and field.header["NAXIS"] == 2
-                and field.header.get("BG_SRC", False) is False]
+                and not field.header.get("BG_SRC", False)]
 
     @property
     def table_fields(self):
@@ -651,7 +652,7 @@ class FieldOfView(FieldOfViewBase):
     def background_fields(self):
         return [field for field in self.fields
                 if isinstance(field, fits.ImageHDU)
-                and field.header.get("BG_SRC", False) is True]
+                and field.header.get("BG_SRC", False)]
 
     def __repr__(self):
         waverange = [self.meta["wave_min"].value, self.meta["wave_max"].value]

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -1,4 +1,5 @@
 """Defines FieldOfView class"""
+import logging
 from copy import deepcopy
 
 import numpy as np
@@ -111,6 +112,8 @@ class FieldOfView(FieldOfViewBase):
 
         fields_in_fov = [field for field in src.fields
                          if fu.is_field_in_fov(self.header, field)]
+        if not fields_in_fov:
+            logging.warning("No fields in FOV.")
 
         spec_refs = []
         volume = self.volume()

--- a/scopesim/optics/fov_manager.py
+++ b/scopesim/optics/fov_manager.py
@@ -258,7 +258,7 @@ class FovVolumeList(FOVSetupBase, MutableSequence):
                 continue
             if vol[f"{axis}_min"] >= value or vol[f"{axis}_max"] <= value:
                 continue
-            new_vol = vol.copy()
+            new_vol = deepcopy(vol)
             new_vol[f"{axis}_min"] = value
             vol[f"{axis}_max"] = value
             self.insert(self.index(vol) + 1, new_vol)
@@ -364,7 +364,7 @@ class FovVolumeList(FOVSetupBase, MutableSequence):
                 if not all(_volume_in_range(vol, axis, edge) for axis, edge
                            in zip(axes, edges)):
                     continue
-                new_vol = vol.copy()
+                new_vol = deepcopy(vol)
                 for axis, edge in zip(axes, edges):
                     new_vol[f"{axis}_min"] = max(edge[0], vol[f"{axis}_min"])
                     new_vol[f"{axis}_max"] = min(edge[1], vol[f"{axis}_max"])

--- a/scopesim/optics/fov_manager_utils.py
+++ b/scopesim/optics/fov_manager_utils.py
@@ -326,7 +326,9 @@ def get_spectroscopy_headers(effects, **kwargs):
     return fov_headers
 
 
-def get_spectroscopy_fovs(headers, shifts, effects=[], **kwargs):
+def get_spectroscopy_fovs(headers, shifts, effects=None, **kwargs):
+    if effects is None:
+        effects = []
 
     shift_waves = shifts["wavelengths"]     # in [um]
     shift_dx = shifts["x_shifts"]           # in [deg]

--- a/scopesim/optics/fov_manager_utils.py
+++ b/scopesim/optics/fov_manager_utils.py
@@ -1,4 +1,7 @@
+import logging
 from copy import deepcopy
+from itertools import product
+from more_itertools import pairwise
 
 import numpy as np
 from astropy import units as u
@@ -8,6 +11,8 @@ from .fov import FieldOfView
 from .. import effects as efs
 from ..effects.effects_utils import get_all_effects
 from ..utils import check_keys
+
+# TODO: Where are all these functions used??
 
 
 def get_3d_shifts(effects, **kwargs):
@@ -41,9 +46,11 @@ def get_3d_shifts(effects, **kwargs):
         shifts = [eff.fov_grid(which="shifts", **kwargs) for eff in effects]
 
         old_bin_edges = [shift[0] for shift in shifts if len(shift[0]) >= 2]
+        # TODO: could this use combine_wavesets?
         new_bin_edges = np.unique(np.sort(np.concatenate(old_bin_edges),
                                           kind="stable"))
 
+        # TODO: could this be zeros_like?
         x_shifts = np.zeros(len(new_bin_edges))
         y_shifts = np.zeros(len(new_bin_edges))
         # .. todo:: replace the 1e-7 with a variable in !SIM
@@ -99,25 +106,27 @@ def get_imaging_waveset(effects_list, **kwargs):
 
     wave_bin_edges = [filt.fov_grid(which="waveset", **kwargs)
                       for filt in filters]
-    if len(wave_bin_edges) > 0:
-        kwargs["wave_min"] = np.max([w[0].value for w in wave_bin_edges])
-        kwargs["wave_max"] = np.min([w[1].value for w in wave_bin_edges])
+    if wave_bin_edges:
+        kwargs["wave_min"] = max(wave[0].value for wave in wave_bin_edges)
+        kwargs["wave_max"] = min(wave[1].value for wave in wave_bin_edges)
+    # Bit confusing...
     wave_bin_edges = [[kwargs["wave_min"], kwargs["wave_max"]]]
 
     if kwargs["wave_min"] > kwargs["wave_max"]:
-        raise ValueError(f"Filter wavelength ranges do not overlap: {wave_bin_edges}")
+        raise ValueError("Filter wavelength ranges do not overlap: "
+                         f"{wave_bin_edges}.")
 
     # ..todo: add in Atmospheric dispersion and ADC here
     for effect_class in [efs.PSF]:
-        effects = get_all_effects(effects_list, effect_class)
-        for eff in effects:
+        for eff in get_all_effects(effects_list, effect_class):
             waveset = eff.fov_grid(which="waveset", **kwargs)
             if waveset is not None:
-                wave_bin_edges += [waveset]
+                wave_bin_edges.append(waveset)
 
-    wave_bin_edges = combine_wavesets(wave_bin_edges)
+    wave_bin_edges = combine_wavesets(*wave_bin_edges)
 
-    if len(wave_bin_edges) == 0:
+    if not wave_bin_edges:
+        # This is already set at the top, why again here?
         wave_bin_edges = [kwargs["wave_min"], kwargs["wave_max"]]
 
     return wave_bin_edges
@@ -125,7 +134,7 @@ def get_imaging_waveset(effects_list, **kwargs):
 
 def get_imaging_headers(effects, **kwargs):
     """
-    Returns a list of Header objects for each of the FieldOfVIew objects
+    Return a generator of Header objects for each of the FieldOfVIew objects.
 
     Parameters
     ----------
@@ -135,7 +144,7 @@ def get_imaging_headers(effects, **kwargs):
 
     Returns
     -------
-    hdrs : list of Header objects
+    hdrs : generator of Header objects
 
     Notes
     -----
@@ -163,33 +172,39 @@ def get_imaging_headers(effects, **kwargs):
     aperture_effects = get_all_effects(effects, (efs.ApertureMask,
                                                  efs.SlitWheel,
                                                  efs.ApertureList))
-    if len(aperture_effects) == 0:
+    if not aperture_effects:
         detector_arrays = get_all_effects(effects, efs.DetectorList)
-        if len(detector_arrays) > 0:
-            aperture_effects += [detarr.fov_grid(which="edges",
-                                                 pixel_scale=pixel_scale)
-                                 for detarr in detector_arrays]
-        else:
-            raise ValueError("No ApertureMask or DetectorList was provided. At "
-                             "least one must be passed to make an ImagePlane: "
-                             f"{effects}")
+        if not detector_arrays:
+            raise ValueError("No ApertureMask or DetectorList was provided. "
+                             "At least one must be passed to make an "
+                             f"ImagePlane: {effects}.")
+        aperture_effects.extend(
+            detarr.fov_grid(which="edges", pixel_scale=pixel_scale)
+            for detarr in detector_arrays)
 
+    # FIXME: all of this is a bit inconsistent; fov_grid(which="edges" is
+    #        called afterwards, but when looking in detector_arrays, the same
+    #        is called immediately; does that even work? is this all tested??
     # get aperture headers from fov_grid()
     # - for-loop catches mutliple headers from ApertureList.fov_grid()
-    hdrs = []
-    for ap_eff in aperture_effects:
-        # ..todo:: add this functionality to ApertureList effect
-        hdr = ap_eff.fov_grid(which="edges", pixel_scale=pixel_scale)
-        hdrs += hdr if isinstance(hdr, (list, tuple)) else [hdr]
+    def _get_hdrs(ap_effs):
+        for ap_eff in ap_effs:
+            # ..todo:: add this functionality to ApertureList effect
+            hdr = ap_eff.fov_grid(which="edges", pixel_scale=pixel_scale)
+            if isinstance(hdr, (list, tuple)):
+                yield from hdr
+            else:
+                yield hdr
+    headers = _get_hdrs(aperture_effects)
 
     # check size of aperture in pixels - split if necessary
-    sky_hdrs = []
-    for hdr in hdrs:
-        if hdr["NAXIS1"] * hdr["NAXIS2"] > kwargs["max_segment_size"]:
-            sky_hdrs += imp_utils.split_header(hdr, kwargs["chunk_size"])
-        else:
-            sky_hdrs += [hdr]
-
+    def _get_sky_hdrs(hdrs):
+        for hdr in hdrs:
+            if hdr["NAXIS1"] * hdr["NAXIS2"] > kwargs["max_segment_size"]:
+                yield from imp_utils.split_header(hdr, kwargs["chunk_size"])
+            else:
+                yield hdr
+    sky_hdrs = _get_sky_hdrs(headers)
     # ..todo:: Deal with the case that two or more ApertureMasks overlap
 
     # map the on-sky apertures directly to the image plane using plate_scale
@@ -208,13 +223,12 @@ def get_imaging_headers(effects, **kwargs):
 
         dethdr = imp_utils.header_from_list_of_xy(x_det, y_det, pixel_size, "D")
         skyhdr.update(dethdr)
-
-    return sky_hdrs
+        yield skyhdr
 
 
 def get_imaging_fovs(headers, waveset, shifts, **kwargs):
     """
-    Returns a list of ``FieldOfView`` objects
+    Return a generator of ``FieldOfView`` objects.
 
     Parameters
     ----------
@@ -224,54 +238,50 @@ def get_imaging_fovs(headers, waveset, shifts, **kwargs):
     waveset : list of floats
         [um] N+1 wavelengths for N spectral layers
 
-    shifts : list of tuples
+    shifts : list of tuples (or actually arrays?)
         [deg] x,y shifts w.r.t to the optical axis plane. N shifts for N
         spectral layers
 
     Returns
     -------
-    fovs : list of FieldOfView objects
+    fovs : generator of ``FieldOfView`` objects
 
     """
-
-    shift_waves = shifts["wavelengths"]     # in [um]
+    # Ensure array for later indexing
+    shift_waves = np.array(shifts["wavelengths"])     # in [um]
     shift_dx = shifts["x_shifts"]           # in [deg]
     shift_dy = shifts["y_shifts"]
 
     # combine the wavelength bins from 1D spectral effects and 3D shift effects
-    if len(shifts["wavelengths"]) > 0:
-        mask = (shift_waves > np.min(waveset)) * (shift_waves < np.max(waveset))
-        waveset = combine_wavesets([waveset, shift_waves[mask]])
+    if shift_waves.size:
+        mask = (shift_waves > min(waveset)) * (shift_waves < max(waveset))
+        waveset = combine_wavesets(waveset, shift_waves[mask])
 
-    counter = 0
-    fovs = []
+    # Actually evaluating the generators here is only necessary for the log msg
+    waveset = list(waveset)
+    headers = list(headers)
+    logging.info("Preparing %d FieldOfViews", (len(waveset) - 1) * len(headers))
 
-    print(f"Preparing {(len(waveset)-1)*len(headers)} FieldOfViews", flush=True)
+    combos = product(pairwise(waveset), headers)
+    for fov_id, ((wave_min, wave_max), hdr) in enumerate(combos):
+        # add any pre-instrument shifts to the FOV sky coords
+        wave_mid = 0.5 * (wave_min + wave_max)
+        x_shift = np.interp(wave_mid, shift_waves, shift_dx)
+        y_shift = np.interp(wave_mid, shift_waves, shift_dy)
 
-    for ii in range(len(waveset) - 1):
-        for hdr in headers:
-            # add any pre-instrument shifts to the FOV sky coords
-            wave_mid = 0.5 * (waveset[ii] + waveset[ii+1])
-            x_shift = np.interp(wave_mid, shift_waves, shift_dx)
-            y_shift = np.interp(wave_mid, shift_waves, shift_dy)
+        fov_hdr = deepcopy(hdr)
+        fov_hdr["CRVAL1"] += x_shift      # headers are in [deg]
+        fov_hdr["CRVAL2"] += y_shift
 
-            fov_hdr = deepcopy(hdr)
-            fov_hdr["CRVAL1"] += x_shift      # headers are in [deg]
-            fov_hdr["CRVAL2"] += y_shift
+        # define the wavelength range for the FOV
+        waverange = [wave_min, wave_max]
 
-            # define the wavelength range for the FOV
-            waverange = [waveset[ii], waveset[ii + 1]]
-
-            # Make the FOV
-            fov = FieldOfView(fov_hdr, waverange, id=counter, **kwargs)
-            fovs += [fov]
-            counter += 1
-
-    return fovs
+        # Make the FOV
+        yield FieldOfView(fov_hdr, waverange, id=fov_id, **kwargs)
 
 
 def get_spectroscopy_headers(effects, **kwargs):
-
+    """Return generator of Header objects."""
     required_keys = ["pixel_scale", "plate_scale",
                      "wave_min", "wave_max"]
     check_keys(kwargs, required_keys, action="error")
@@ -285,15 +295,15 @@ def get_spectroscopy_headers(effects, **kwargs):
                                                  efs.SlitWheel,
                                                  efs.ApertureMask))
 
-    if len(surface_list_effects) > 0:
+    if surface_list_effects:
         waves = surface_list_effects[0].fov_grid(which="waveset")
         if len(waves) == 2:
             kwargs["wave_min"] = np.max([waves[0].value, kwargs["wave_min"]])
             kwargs["wave_max"] = np.min([waves[1].value, kwargs["wave_max"]])
 
-    if len(detector_list_effects) > 0:
+    if detector_list_effects:
         implane_hdr = detector_list_effects[0].image_plane_header
-    elif len(spec_trace_effects) > 0:
+    elif spec_trace_effects:
         implane_hdr = spec_trace_effects[0].image_plane_header
     else:
         raise ValueError("Missing a way to determine the image plane size")
@@ -304,6 +314,7 @@ def get_spectroscopy_headers(effects, **kwargs):
                          f"{spec_trace_effects}")
     spec_trace = spec_trace_effects[0]
 
+    # TODO: The following is WET with the code in get_imaging_headers
     sky_hdrs = []
     for ap_eff in aperture_effects:
         # if ApertureList, a list of ApertureMask headers is returned
@@ -320,13 +331,15 @@ def get_spectroscopy_headers(effects, **kwargs):
                                        plate_scale=kwargs["plate_scale"]
                                        )
                    for sky_hdr in sky_hdrs]
-    fov_headers = [hdr for hdr_list in fov_headers for hdr in hdr_list]
-    # ..todo: check that each header is not larger than chunk_size
-
-    return fov_headers
+    for hdr_list in fov_headers:
+        for hdr in hdr_list:
+            yield hdr
+    # TODO: check that each header is not larger than chunk_size
+    # that's already done in get_imaging_headers, isn't it?
 
 
 def get_spectroscopy_fovs(headers, shifts, effects=None, **kwargs):
+    """Return a generator of ``FieldOfView`` objects."""
     if effects is None:
         effects = []
 
@@ -334,7 +347,7 @@ def get_spectroscopy_fovs(headers, shifts, effects=None, **kwargs):
     shift_dx = shifts["x_shifts"]           # in [deg]
     shift_dy = shifts["y_shifts"]
 
-    print(f"Preparing {len(headers)} FieldOfViews", flush=True)
+    logging.info("Preparing %d FieldOfViews", len(headers))
 
     apertures = get_all_effects(effects, (efs.ApertureList, efs.ApertureMask))
     masks = [ap.fov_grid(which="masks") for ap in apertures]
@@ -345,8 +358,7 @@ def get_spectroscopy_fovs(headers, shifts, effects=None, **kwargs):
         elif isinstance(mask, np.ndarray):
             mask_dict[len(mask_dict)] = mask
 
-    fovs = []
-    for ii, hdr in enumerate(headers):
+    for fov_id, hdr in enumerate(headers):
         # add any pre-instrument shifts to the FOV sky coords
         wave_mid = hdr["WAVE_MID"]
         x_shift = np.interp(wave_mid, shift_waves, shift_dx)
@@ -357,29 +369,30 @@ def get_spectroscopy_fovs(headers, shifts, effects=None, **kwargs):
         fov_hdr["CRVAL2"] += y_shift
 
         # Make the FOV
-        fov = FieldOfView(fov_hdr, waverange=[hdr["WAVE_MIN"], hdr["WAVE_MAX"]],
-                          **kwargs)
+        waverange = [hdr["WAVE_MIN"], hdr["WAVE_MAX"]]
+        fov = FieldOfView(fov_hdr, waverange=waverange, **kwargs)
         fov.meta["distortion"]["rotation"] = hdr["ROTANGD"]
         fov.meta["distortion"]["shear"] = hdr["SKEWANGD"]
         fov.meta["conserve_image"] = hdr["IMG_CONS"]
-        fov.meta["fov_id"] = ii
+        # TODO: In the other function, the id is set via the contructor.
+        #       What's the difference?
+        fov.meta["fov_id"] = fov_id
         fov.meta["aperture_id"] = hdr["APERTURE"]
 
         # .. todo: get these masks working
         # there needs to be fov_grid(which="mask") in ApertureList/Mask
         # fov.mask = mask_dict[hdr["APERTURE"]]
-        fovs += [fov]
-
-    return fovs
+        yield fov
 
 
-def combine_wavesets(waveset_list):
+# FIXME: This functions doesn't seem to be covered by any separate unit test.
+def combine_wavesets(*wavesets):
     """
-    Joins and sorts several sets of wavelengths into a single 1D array
+    Join and sorts several sets of wavelengths into a single 1D array.
 
     Parameters
     ----------
-    waveset_list : list
+    wavesets : one or more iterables
         A group of wavelength arrays or lists
 
     Returns
@@ -387,12 +400,22 @@ def combine_wavesets(waveset_list):
     wave_set : np.ndarray
         Combined set of wavelengths
 
+    Note
+    ----
+    This assumes that all wavesets are given in the same unit!
     """
-    wave_set = []
-    for wbe in waveset_list:        # wbe = waveset bin edges
-        wbe = wbe.value if isinstance(wbe, u.Quantity) else wbe
-        wave_set += list(wbe)
-    # ..todo:: set variable in !SIM.computing for rounding to the 7th decimal
-    wave_set = np.unique(np.round(np.sort(wave_set, kind="stable"), 7))
+    # TODO: set variable in !SIM.computing for rounding to the 7th decimal
+    decimals = 7
 
+    def _get_waves(waves):
+        for wave in waves:
+            if isinstance(wave, u.Quantity):
+                round_wave = wave.round(decimals).value
+            else:
+                round_wave = np.round(wave, decimals)
+            yield from round_wave
+
+    # NOTE: This function previously used np.sort(wave_set, kind="stable").
+    #       If any issues occur with the buitin sorted, go back to that!
+    wave_set = sorted(set(_get_waves(wavesets)))
     return wave_set

--- a/scopesim/optics/fov_utils.py
+++ b/scopesim/optics/fov_utils.py
@@ -329,7 +329,11 @@ def extract_area_from_imagehdu(imagehdu, fov_volume):
 
         # OC [2021-12-14] if fov range is not covered by the source return nothing
         if not np.any(mask):
-            print(f"FOV {fov_waves[0]} um - {fov_waves[1]} um: not covered by Source")
+            logging.warning("FOV %s um - %s um: not covered by Source",
+                            fov_waves[0], fov_waves[1])
+            # FIXME: returning None here breaks the principle that a function
+            #        should always return the same type. Maybe this should
+            #        instead raise an exception that's caught higher up...
             return None
 
         i0p, i1p = np.where(mask)[0][0], np.where(mask)[0][-1]
@@ -359,6 +363,9 @@ def extract_area_from_imagehdu(imagehdu, fov_volume):
     else:
         data = imagehdu.data[y0p:y1p, x0p:x1p]
         new_hdr["SPEC_REF"] = hdr.get("SPEC_REF")
+
+    if not data.size:
+        logging.warning("Empty image HDU.")
 
     new_imagehdu = fits.ImageHDU(data=data)
     new_imagehdu.header.update(new_hdr)

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -756,13 +756,14 @@ def val2pix(header, a, b, wcs_suffix=""):
     if isinstance(header, fits.ImageHDU):
         header = header.header
 
-    if "PC1_1"+s in header:
-        pc11 = header["PC1_1"+s]
-        pc12 = header["PC1_2"+s]
-        pc21 = header["PC2_1"+s]
-        pc22 = header["PC2_2"+s]
+    pckeys = [key + s for key in ["PC1_1", "PC1_2", "PC2_1", "PC2_2"]]
+    if all(key in header for key in pckeys):
+        pc11, pc12, pc21, pc22 = (header[key] for key in pckeys)
     else:
         pc11, pc12, pc21, pc22 = 1, 0, 0, 1
+
+    if (pc11 * pc22 + pc12 * pc21) != 1.0:
+        logging.error("PC matrix det != 1.0")
 
     da = float(header["CDELT1"+s])
     db = float(header["CDELT2"+s])

--- a/scopesim/tests/tests_optics/test_FieldOfView.py
+++ b/scopesim/tests/tests_optics/test_FieldOfView.py
@@ -140,8 +140,9 @@ class TestExtractFrom:
             assert isinstance(the_fov.fields[2], Table)
 
 
-@pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
+# @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
 class TestMakeCube:
+    @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
     def test_makes_cube_from_table(self):
         src_table = so._table_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
         fov = _fov_190_210_um()
@@ -163,6 +164,7 @@ class TestMakeCube:
             plt.imshow(cube.data[0, :, :], origin="lower")
             plt.show()
 
+    @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
     def test_makes_cube_from_imagehdu(self):
         src_image = so._image_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
         fov = _fov_190_210_um()
@@ -181,6 +183,7 @@ class TestMakeCube:
             plt.imshow(cube.data[0, :, :], origin="lower")
             plt.show()
 
+    @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
     def test_makes_cube_from_other_cube_imagehdu(self):
         import scopesim as sim
         sim.rc.__currsys__["!SIM.spectral.spectral_bin_width"] = 0.01
@@ -201,6 +204,7 @@ class TestMakeCube:
             plt.imshow(cube.data[0, :, :], origin="lower")
             plt.show()
 
+    @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
     def test_makes_cube_from_two_similar_cube_imagehdus(self):
         src_cube = so._cube_source() + so._cube_source(dx=1)            # 2 cubes 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
         fov = _fov_197_202_um()
@@ -220,6 +224,7 @@ class TestMakeCube:
             plt.imshow(cube.data[0, :, :], origin="lower")
             plt.show()
 
+    @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
     def test_makes_cube_from_all_types_of_source_object(self):
         src_all = so._table_source() + \
                   so._image_source(dx=-4, dy=-4) + \
@@ -271,7 +276,7 @@ class TestMakeCube:
         assert "CTYPE3" in cube.header
 
 
-@pytest.mark.xfail(reason="revisit fov.waveset e.g. use make_cube waveset")
+# @pytest.mark.xfail(reason="revisit fov.waveset e.g. use make_cube waveset")
 class TestMakeImage:
     def test_makes_image_from_table(self):
         src_table = so._table_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
@@ -317,6 +322,7 @@ class TestMakeImage:
             plt.imshow(img.data, origin="lower")
             plt.show()
 
+    @pytest.mark.xfail(reason="revisit fov.waveset e.g. use make_cube waveset")
     def test_makes_image_from_cube(self):
         src_cube = so._cube_source()  # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
         fov = _fov_197_202_um()
@@ -334,6 +340,7 @@ class TestMakeImage:
 
         assert out_sum == approx(in_sum)
 
+    @pytest.mark.xfail(reason="revisit fov.waveset e.g. use make_cube waveset")
     def test_makes_image_from_all_types_of_source_object(self):
         src_all = so._table_source() + \
                   so._image_source(dx=-4, dy=-4) + \
@@ -370,7 +377,7 @@ class TestMakeImage:
             plt.show()
 
 
-@pytest.mark.xfail(reason="revisit fov.waveset e.g. use make_cube waveset")
+# @pytest.mark.xfail(reason="revisit fov.waveset e.g. use make_cube waveset")
 class TestMakeSpectrum:
     def test_make_spectrum_from_table(self):
         src_table = so._table_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm


### PR DESCRIPTION
## Refactoring

### `FieldOfView`

- The three `.make_...` methods were very long, but clearly sectioned. I used that to create several smaller auxiliary functions to split things up a bit. Maybe, with some further refactoring in the future, we might be able to merge some of those. Or subclass `FieldOfView` 🙃 
- In several cases, `np.unique` was used to get a list of unique elements (reference indices for spectra mostly). This is a textbook usecase of a `set`, so I used that instead.
- Some tests marked as `xfail` actually (currently) XPASS, so I included them back in. Those were quite useful in making sure the refactoring here didn't break stuff. I think it would be worth looking into why the others still xfail (as they did before this PR).
- `FovVolumeList` now inherits from `collections.abc.MutableSequence`, because that's what it really is, making some nice mixin-methods available.

### Generators

I turned some "list-appending-in-loop" functions (mostly in `optics.fov_manager_utils` (*sidenote: I'm not sure where the functions in that module are actually used - I hope it's not something abandoned?* 😂 )) into generators, meaning they will not return the instantiated `list`, but a generator, that can either be turned into a `list` immediately, or just iterated over when access to the whole list (or repeated access) is not needed. This will change the API of some functions, so I updated some tests accordingly.

### De-nesting

Various parts of the codebase have almost a whole function inside an `if`-clause, which is skipped if the condition is not met. Most of these cases can be simplified by an "early return" approach, i.e. checking for the negative of that condition, and aborting if it's not met, otherwise proceeding as normal (I think it's called a "guard clause" sometimes). There are more of these that I will eventually tackle when working on those classes anyway...

In some other cases, things could be de-nested by other approaches, such as combining a double loop into a single iteration.

## Warnings

Motivated by the issues a user was experiencing, I included a few checks for observing a source and warnings if those fail:

- Check if the "PC-matrix" in the header has a determinant of 1.0.
- Check if the array from the source is non-empty (in `extract_area_from_imagehdu`).
- Check if any fields of the source are inside the FOV.

## Misc

### No more mutable default arguments

Mutable default arguments (i.e. `def foo(bar=[]):`) can cause unintended consequences (see e.g. [this article](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments)) and should be avoided. If I haven't missed any, this should get rid of all of them in this repo (there were only a handful of cases anyway). In all cases, `None` is now used as the default, and check for that.

### Boolean conditions

There were a few cases of `if foo is True:` or `if foo is False:`, which I replaced with `if foo:` or `if not foo:`, respectively.

### log instead of print

Self-explaining...

### Renaming

Not really worth mentioning, but for completeness: I renamed some variables for clarity (and to shutup pylint).

### Docstring

Along the way, I made some fixes to various docstrings, both in content and to comply with Numpy's style manual.