### PR TITLE
Add iterable_axes to figure_factory

### DIFF
--- a/scopesim/effects/surface_list.py
+++ b/scopesim/effects/surface_list.py
@@ -156,7 +156,7 @@ class SurfaceList(TERCurve):
 
         """
         if axes is None:
-            fig, axes = figure_factory(len(which), 1)
+            fig, axes = figure_factory(len(which), 1, iterable_axes=True)
         else:
             fig = axes.figure
             self._axes_guard(which, axes)

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -186,8 +186,7 @@ class TERCurve(Effect):
 
         """
         if axes is None:
-            fig, axes = figure_factory(len(which), 1)
-            # figsize=(10, 5)
+            fig, axes = figure_factory(len(which), 1, iterable_axes=True)
         else:
             fig = axes.figure
             _guard_plot_axes(which, axes)
@@ -627,8 +626,7 @@ class FilterWheelBase(Effect):
 
         """
         if axes is None:
-            fig, axes = figure_factory(len(which), 1)
-            # figsize=(10, 5)
+            fig, axes = figure_factory(len(which), 1, iterable_axes=True)
         else:
             fig = axes.figure
             _guard_plot_axes(which, axes)

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -1032,7 +1032,10 @@ def close_loop(iterable: Iterable) -> Generator:
 
 def figure_factory(nrows=1, ncols=1, **kwargs):
     """Default way to init fig and ax, to easily modify later."""
+    iterable_axes = kwargs.pop("iterable_axes", False)
     fig, ax = plt.subplots(nrows, ncols, **kwargs)
+    if iterable_axes and not isinstance(ax, Iterable):
+        ax = (ax,)
     return fig, ax
 
 


### PR DESCRIPTION
`utils.figure_factory` now supports a keyword argument `iterable_axes`, which ensures that the returned axes are iterable (duh). This is useful for some plot methods that need either a single axes or multiple ones, depending on some condition, but then iterate over those axes. That iteration attempt would cause an error when only a single axes is used. Now, `figure_factory(1, 1, iterable_axes=True)` will return a 1-tuple with the single axes object (and also return the figure, as before).