### PR TITLE
Add ipykernel as dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 dev = [
     "jupyter",
     "jupytext",
+    "ipykernel",
 ]
 test = [
     "pytest>=5.0.0",
@@ -50,6 +51,7 @@ test = [
     "scopesim_templates>=0.4.4",
     # Just so that readthedocs doesn't include the tests module - yes it's hacky
     "skycalc_cli",
+    "ipykernel",
 ]
 docs = [
     "sphinx>=4.3.0",
@@ -59,6 +61,7 @@ docs = [
     "nbsphinx",
     "numpydoc",
     "scopesim_templates>=0.4.4",
+    "ipykernel"
 ]
 
 [project.urls]


### PR DESCRIPTION
Not sure whether it is necessary everywhere, but it seems to be necessary for docs, so conceivably it is also necessary for test and dev.

ipykernel used to be installed automatically by ReadTheDocs but not anymore.