### PR TITLE
Improve bug report, add top-level exception log

### DIFF
--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -8,7 +8,7 @@ import yaml
 import requests
 
 from .. import rc
-from ..utils import find_file
+from ..utils import find_file, top_level_catch
 
 __all__ = ["UserCommands"]
 
@@ -141,6 +141,7 @@ class UserCommands:
 
     """
 
+    @top_level_catch
     def __init__(self, **kwargs):
 
         self.cmds = copy.deepcopy(rc.__config__)

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -16,7 +16,7 @@ from .image_plane import ImagePlane
 from ..commands.user_commands import UserCommands
 from ..detector import DetectorArray
 from ..effects import ExtraFitsKeywords
-from ..utils import from_currsys
+from ..utils import from_currsys, top_level_catch
 from ..version import version
 from .. import rc
 
@@ -76,6 +76,7 @@ class OpticalTrain:
 
     """
 
+    @top_level_catch
     def __init__(self, cmds=None):
         self.cmds = cmds
         self._description = self.__repr__()
@@ -131,6 +132,7 @@ class OpticalTrain:
         self.detector_arrays = [DetectorArray(det_list, **kwargs)
                                 for det_list in opt_man.detector_setup_effects]
 
+    @top_level_catch
     def observe(self, orig_source, update=True, **kwargs):
         """
         Main controlling method for observing ``Source`` objects.
@@ -273,6 +275,7 @@ class OpticalTrain:
 
         return source
 
+    @top_level_catch
     def readout(self, filename=None, **kwargs):
         """
         Produce detector readouts for the observed image.

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -430,7 +430,8 @@ def _get_required_packages():
 
 
 def _get_all_irdb_pkgs(root: Path):
-    return [pkg_path for pkg_path in root.iterdir() if pkg_path.is_dir()]
+    return [pkg_path for pkg_path in root.iterdir() if pkg_path.is_dir()
+            and not pkg_path.name.startswith("__")]
 
 
 def _get_irdb_pkg_version(pkg_path: Path) -> str:

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -457,7 +457,7 @@ def _write_bug_report(stream: TextIO) -> None:
             ver = metadata.version(package_name)
             stream.write(f"{ver}\n")
         except ImportError:
-            stream.write(f"could not be loaded.\n")
+            stream.write("could not be loaded.\n")
         # except AttributeError:
         #     stream.write(f"version number not available.\n")
 
@@ -1063,6 +1063,6 @@ def top_level_catch(func):
                 logging.error("Couldn't log full exception stack.")
                 logging.error("Error message was: '%s'", err)
             log_bug_report(logging.ERROR)
-            raise err
+            raise
         return output
     return wrapper

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -425,7 +425,7 @@ def _get_required_packages():
         if "extra" in req:
             continue
 
-        name = req.split(">", maxsplit=1)[0]#.replace("-", "_")
+        name = req.split(">", maxsplit=1)[0].strip()
         yield name
 
 


### PR DESCRIPTION
## Improvements to `utils.bug_report()`

- Moved the actual functionality to `utils._write_bug_report()`, which takes a `TextIO` stream as an argument. The original `utils.bug_report()` now calls that functions with `sys.stdout`, retaining the original behavior of printing.
- Created two new helper functions `utils.bug_report_to_file(filename)` and `utils.log_bug_report()` which also call `utils._write_bug_report()`.
- The bug report itself was also improved:
  - Packages are now taken from the requirements in  ScopeSim's `pyproject.toml`, additionally the packages mentioned in #286 are always included.
  - The IRDB packages installed in `rc.__config__["!SIM.file.local_packages_path"]` are included, together with their versions.
  - OS and Python version info is unchanged.
 
## Top level exception handler

A new function `utils.top_level_catch` was added, which can be used as a decorator around any function (or method) and will log and re-raise any unhandled exception from anything happening inside that function. Additionally, it will automatically include the aforementioned bug report in the logs. The full stack trace is not included at the moment, because of another bug in ScopeSim's logging configuration preventing the use of `logging.exception()`, see #259 .

The decorator was added to the constructor methods of `UserCommands` and `OpticalTrain`, as well as `.observe()` and `.readout()`, which are usually the top-level methods most users will interact with. Feel free to apply the decorator to any other function or method where it makes sense.