### PR TITLE
Some refactoring of z_order fuctionality

### DIFF
--- a/scopesim/effects/effects_utils.py
+++ b/scopesim/effects/effects_utils.py
@@ -1,5 +1,6 @@
 """TBA."""
 
+import logging
 import inspect
 from copy import deepcopy, copy
 from collections.abc import Iterable
@@ -131,6 +132,7 @@ def z_order_in_range(z_eff, z_range: range) -> bool:
 
     """
     if not isinstance(z_eff, Iterable):
+        logging.warning("z_order %d should be a single-item list", z_eff)
         z_eff = [z_eff]
 
     return any(zi in z_range for zi in z_eff)

--- a/scopesim/effects/effects_utils.py
+++ b/scopesim/effects/effects_utils.py
@@ -2,6 +2,8 @@
 
 import inspect
 from copy import deepcopy, copy
+from collections.abc import Iterable
+
 from astropy.table import Table
 
 from .. import effects as efs
@@ -107,3 +109,28 @@ def scopesim_effect_classes(base_effect=efs.Effect):
     sorted_effects = {key: efs_dict[key] for key in sorted(efs_dict)}
 
     return sorted_effects
+
+
+def z_order_in_range(z_eff, z_range: range) -> bool:
+    """
+    Return True if any of the z_orders in `z_eff` is in the given range.
+
+    The `z_range` parameter can be constructed as ``range(z_min, z_max)``.
+
+    Parameters
+    ----------
+    z_eff : int or list of ints
+        z_order(s) of the effect.
+    z_range : range
+        range object of allowed z_order values.
+
+    Returns
+    -------
+    bool
+        True if at least one z_order is in range, False otherwise.
+
+    """
+    if not isinstance(z_eff, Iterable):
+        z_eff = [z_eff]
+
+    return any(zi in z_range for zi in z_eff)

--- a/scopesim/effects/effects_utils.py
+++ b/scopesim/effects/effects_utils.py
@@ -132,7 +132,7 @@ def z_order_in_range(z_eff, z_range: range) -> bool:
 
     """
     if not isinstance(z_eff, Iterable):
-        logging.warning("z_order %d should be a single-item list", z_eff)
+        logging.warning("z_order %d should be a single-item iterable", z_eff)
         z_eff = [z_eff]
 
     return any(zi in z_range for zi in z_eff)

--- a/scopesim/optics/optical_element.py
+++ b/scopesim/optics/optical_element.py
@@ -132,12 +132,13 @@ class OpticalElement:
                     f"{z_max=} < {z_level=}.")
         else:
             z_max = z_min + 100  # range doesn't include final element -> 100
+        z_range = range(z_min, z_max)
 
         for eff in self.effects:
             if not eff.include or "z_order" not in eff.meta:
                 continue
 
-            if z_order_in_range(eff.meta["z_order"], range(z_min, z_max)):
+            if z_order_in_range(eff.meta["z_order"], z_range):
                 yield eff
 
     @property

--- a/scopesim/optics/optical_element.py
+++ b/scopesim/optics/optical_element.py
@@ -131,7 +131,7 @@ class OpticalElement:
                     "z_max must be greater (or equal to) z_level, but "
                     f"{z_max=} < {z_level=}.")
         else:
-            z_max = z_min + 99
+            z_max = z_min + 100  # range doesn't include final element -> 100
 
         for eff in self.effects:
             if not eff.include or "z_order" not in eff.meta:

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -166,15 +166,14 @@ class OpticsManager:
         effects : list of Effect objects
 
         """
-        effects = []
-        for opt_el in self.optical_elements:
-            # Extend evaluates generator
-            effects.extend(opt_el.get_z_order_effects(z_level))
+        def _gather_effects():
+            for opt_el in self.optical_elements:
+                yield from opt_el.get_z_order_effects(z_level)
 
-        def sortkey(eff):
+        def _sortkey(eff):
             return next(z % 100 for z in eff.meta["z_order"] if z >= z_level)
 
-        return sorted(effects, key=sortkey)
+        return sorted(_gather_effects(), key=_sortkey)
 
     @property
     def is_spectroscope(self):

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -153,7 +153,7 @@ class OpticsManager:
 
         Parameters
         ----------
-        z_level : int, tuple
+        z_level : int
             [0, 100, 200, 300, 400, 500]
 
         Returns
@@ -163,7 +163,8 @@ class OpticsManager:
         """
         effects = []
         for opt_el in self.optical_elements:
-            effects += opt_el.get_z_order_effects(z_level)
+            # Extend evaluates generator
+            effects.extend(opt_el.get_z_order_effects(z_level))
 
         return effects
 

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -172,9 +172,9 @@ class OpticsManager:
             effects.extend(opt_el.get_z_order_effects(z_level))
 
         def sortkey(eff):
-            return next(z % 100 for z in eff.meta["z_order"])
+            return next(z % 100 for z in eff.meta["z_order"] if z >= z_level)
 
-        return effects.sort(key=sortkey)
+        return sorted(effects, key=sortkey)
 
     @property
     def is_spectroscope(self):

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -139,7 +139,7 @@ class OpticsManager:
 
         return effects
 
-    def get_z_order_effects(self, z_level):
+    def get_z_order_effects(self, z_level: int):
         """
         Return a list of all effects with a z_order keywords within `z_level`.
 
@@ -150,11 +150,16 @@ class OpticsManager:
         - Apply Source altering effects - z_order = 200..299
         - Apply FOV specific (3D) effects - z_order = 300..399
         - Apply FOV-independent (2D) effects - z_order = 400..499
+        - Apply XXX effects - z_order = 500..599
+        - Apply XXX effects - z_order = 600..699
+        - Apply lambda-independent 2D image plane effects - z_order = 700..799
+        - Apply detector effects - z_order = 800..899
+        - Apply detector array effects - z_order = 900..999
 
         Parameters
         ----------
-        z_level : int
-            [0, 100, 200, 300, 400, 500]
+        z_level : {0, 100, 200, 300, 400, 500, 600, 700, 800, 900}
+            100-range of z_orders.
 
         Returns
         -------

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -183,11 +183,10 @@ class OpticsManager:
     @property
     def image_plane_headers(self):
         detector_lists = self.detector_setup_effects
-        headers = [det_list.image_plane_header for det_list in detector_lists]
-
         if not detector_lists:
             raise ValueError(f"No DetectorList objects found. {detector_lists}")
 
+        headers = [det_list.image_plane_header for det_list in detector_lists]
         return headers
 
     @property

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -178,55 +178,62 @@ class OpticsManager:
 
     @property
     def is_spectroscope(self):
+        """Return True if any of the effects is a spectroscope."""
         return is_spectroscope(self.all_effects)
 
     @property
     def image_plane_headers(self):
+        """Get headers from detector setup effects."""
         detector_lists = self.detector_setup_effects
         if not detector_lists:
-            raise ValueError(f"No DetectorList objects found. {detector_lists}")
+            raise ValueError("No DetectorList objects found.")
 
-        headers = [det_list.image_plane_header for det_list in detector_lists]
-        return headers
+        return [det_list.image_plane_header for det_list in detector_lists]
 
     @property
     def detector_array_effects(self):
+        """Get effects with z_order = 900...999."""
         return self.get_z_order_effects(900)
 
     @property
     def detector_effects(self):
+        """Get effects with z_order = 800...899."""
         return self.get_z_order_effects(800)
 
     @property
     def image_plane_effects(self):
-        effects = self.get_z_order_effects(700)
-        return effects
+        """Get effects with z_order = 700...799."""
+        return self.get_z_order_effects(700)
 
     @property
     def fov_effects(self):
-        effects = self.get_z_order_effects(600)
-        return effects
+        """Get effects with z_order = 600...699."""
+        return self.get_z_order_effects(600)
 
     @property
     def source_effects(self):
+        """Get effects with z_order = 500...599."""
         return self.get_z_order_effects(500)   # Transmission
 
     @property
     def detector_setup_effects(self):
-        # !!! Only DetectorLists go in here !!!
+        """Get effects with z_order = 400...499 (DetectorLists only!)."""
         return self.get_z_order_effects(400)
 
     @property
     def image_plane_setup_effects(self):
+        """Get effects with z_order = 300...399."""
         return self.get_z_order_effects(300)
 
     @property
     def fov_setup_effects(self):
+        """Get effects with z_order = 200...299."""
         # Working out where to set wave_min, wave_max
         return self.get_z_order_effects(200)
 
     @property
     def surfaces_table(self):
+        """Get combined surface table from effects with z_order = 100...199."""
         if self._surfaces_table is None:
             surface_like_effects = self.get_z_order_effects(100)
             self._surfaces_table = combine_surface_effects(surface_like_effects)
@@ -234,6 +241,7 @@ class OpticsManager:
 
     @property
     def all_effects(self):
+        """Get all effects in all optical elements."""
         return [eff for opt_eff in self.optical_elements for eff in opt_eff]
 
     @property

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -173,7 +173,8 @@ class OpticsManager:
         def _sortkey(eff):
             return next(z % 100 for z in eff.meta["z_order"] if z >= z_level)
 
-        return sorted(_gather_effects(), key=_sortkey)
+        # return sorted(_gather_effects(), key=_sortkey)
+        return list(_gather_effects())
 
     @property
     def is_spectroscope(self):

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -171,7 +171,10 @@ class OpticsManager:
             # Extend evaluates generator
             effects.extend(opt_el.get_z_order_effects(z_level))
 
-        return effects
+        def sortkey(eff):
+            return next(z % 100 for z in eff.meta["z_order"])
+
+        return effects.sort(key=sortkey)
 
     @property
     def is_spectroscope(self):

--- a/scopesim/tests/tests_optics/test_OpticalElement.py
+++ b/scopesim/tests/tests_optics/test_OpticalElement.py
@@ -52,11 +52,13 @@ class TestOpticalElementInit:
 
 @pytest.mark.usefixtures("patch_mock_path")
 class TestOpticalElementGetZOrderEffects:
-    @pytest.mark.parametrize("z_orders, n", [(0, 2), (100, 1), ([200, 299], 1)])
-    def test_returns_the_effects_with_z_values(self, z_orders, n,
+    @pytest.mark.parametrize("z_lvl, zmax, n", [(0, None, 2),
+                                                (100, None, 1),
+                                                (200, 299, 1)])
+    def test_returns_the_effects_with_z_values(self, z_lvl, zmax, n,
                                                detector_yaml_dict):
         opt_el = opt_elem.OpticalElement(detector_yaml_dict)
-        assert len(opt_el.get_z_order_effects(z_orders)) == n
+        assert len(list(opt_el.get_z_order_effects(z_lvl, zmax))) == n
 
 
 @pytest.mark.usefixtures("patch_mock_path")


### PR DESCRIPTION
After a more general discussion on the topic with @astronomyk and @hugobuddel, the effects should _not_ be ordered according to the final two digits of their z-orders, but rather the order should follow that of definition in the respective IRDB yaml files (which is the current behavior). Ultimately, the z_order might be removed completely, so it's not worth investing much if any time in any functionality related to it.

However, that discussion came after the commits found in this PR (except the final one), and everything else can still be considered and improvement, even if it's only for the docstrings, so I'm still in favor of merging. The only test that now fails is the codecov, but creating new tests for something that will likely be removed soon anyway, seems unnecessary, so I'd just ignore that.