### PR TITLE
Add Shutter effect

### DIFF
--- a/scopesim/effects/__init__.py
+++ b/scopesim/effects/__init__.py
@@ -14,6 +14,7 @@ from . import ter_curves_utils
 
 from .detector_list import *
 from .electronic import *
+from .shutter import *
 from .obs_strategies import *
 from .fits_headers import *
 

--- a/scopesim/effects/shutter.py
+++ b/scopesim/effects/shutter.py
@@ -1,10 +1,24 @@
 # -*- coding: utf-8 -*-
 """Contains the Shutter effect."""
 
+import logging
+
 from . import Effect
+from ..base_classes import ImagePlaneBase
 
 
 class Shutter(Effect):
     """Simulate a closed shutter, useful for dark exposures."""
 
-    pass
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.meta["z_order"] = [799]
+
+    def apply_to(self, obj, **kwargs):
+        """Set all pixels of image plane to zero."""
+        if not isinstance(obj, ImagePlaneBase):
+            return obj
+
+        logging.warning("Shutter is closed, setting all pixels to zero.")
+        obj.data[:] = 0.0
+        return obj

--- a/scopesim/effects/shutter.py
+++ b/scopesim/effects/shutter.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Contains the Shutter effect."""
+
+from . import Effect
+
+
+class Shutter(Effect):
+    """Simulate a closed shutter, useful for dark exposures."""
+
+    pass

--- a/scopesim/tests/tests_effects/test_Shutter.py
+++ b/scopesim/tests/tests_effects/test_Shutter.py
@@ -1,2 +1,37 @@
 # -*- coding: utf-8 -*-
 """Contains tests for Shutter class."""
+
+import pytest
+import numpy as np
+
+from scopesim.effects.shutter import Shutter
+from scopesim.optics.image_plane import ImagePlane
+
+from scopesim.tests.mocks.py_objects.imagehdu_objects import _image_hdu_square
+
+
+@pytest.fixture(scope="function", name="implane")
+def mock_implane():
+    implane = ImagePlane(_image_hdu_square().header)
+    implane.hdu.data = np.ones(implane.hdu.data.shape)
+    return implane
+
+
+class TestInit:
+    def test_initialised_with_nothing(self):
+        shtr = Shutter()
+        assert isinstance(shtr, Shutter)
+
+
+class TestApplyTo:
+    def test_sets_pixels_to_zero(self, implane):
+        assert implane.data.sum() == implane.data.size
+        shtr = Shutter()
+        implane = shtr.apply_to(implane)
+        assert implane.data.sum() == 0.0
+
+    def test_shape_is_preserved(self, implane):
+        orig_shape = implane.data.shape
+        shtr = Shutter()
+        implane = shtr.apply_to(implane)
+        assert implane.data.shape == orig_shape

--- a/scopesim/tests/tests_effects/test_Shutter.py
+++ b/scopesim/tests/tests_effects/test_Shutter.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Contains tests for Shutter class."""


### PR DESCRIPTION
Adds a `Shutter` effect in `effects.shutter.py`, which simply sets all pixels to zero before any detector effects are applied.