### PR TITLE
Add basic sky coordinates (WCS) to ScopeSim output

### DIFF
--- a/scopesim/detector/detector.py
+++ b/scopesim/detector/detector.py
@@ -28,7 +28,7 @@ class Detector(DetectorBase):
                                                        wcs_suffix="D")
 
     def reset(self):
-        self._hdu.data = np.zeros(self._hdu.data.shape)
+        self._hdu.data = np.zeros_like(self._hdu.data)
 
     @property
     def hdu(self):

--- a/scopesim/detector/detector_array.py
+++ b/scopesim/detector/detector_array.py
@@ -1,15 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Contains DetectorArray and aux functions."""
+
 import logging
 
 from astropy.io import fits
 
 from .detector import Detector
 
-from ..effects.effects_utils import get_all_effects
-from .. import effects as efs
 from .. import utils
 
 
 class DetectorArray:
+    """Manages the individual Detectors, mostly used for readout."""
+
+    # TODO: Should this class be called DetectorManager analogous to the
+    #       FOVManager and OpticsManager classes?
+    # TODO: Either way this could inherit from some collections.abc
+
     def __init__(self, detector_list=None, **kwargs):
         self.meta = {}
         self.meta.update(kwargs)
@@ -19,9 +26,22 @@ class DetectorArray:
         self.detectors = []
         self.latest_exposure = None
 
-    def readout(self, image_planes, array_effects=None, dtcr_effects=None, **kwargs):
+    def readout(self, image_planes, array_effects=None, dtcr_effects=None,
+                **kwargs) -> fits.HDUList:
         """
-        Read out the detector array into a FITS file.
+        Read out the detector array into a FITS HDU List.
+
+        1. Select the relevant image plane to extract images from.
+        2. Apply detector array effects (apply to the entire image plane)
+        3. Make a series of Detectors for each row in a DetectorList object.
+        4. Iterate through all Detectors, extract image from image_plane.
+        5. Apply all effects (to all Detectors).
+        6. Add necessary header keywords (not implemented).
+        7. Generate a HDUList with the ImageHDUs and any extras:
+          - add ``PrimaryHDU`` with meta data regarding observation in header
+          - add ``ImageHDU`` objects
+          - add ``ASCIITableHDU`` with Effects meta data in final table
+            extension (not implemented)
 
         Parameters
         ----------
@@ -36,52 +56,43 @@ class DetectorArray:
 
         Returns
         -------
-        self.latest_exposure : fits.HDUList
+        latest_exposure : fits.HDUList
+            Output FITS HDU List.
 
         """
         # .. note:: Detector is what used to be called Chip
         #           DetectorArray is the old Detector
 
-        # 0. Select the relevant image plane to extract images from
-        # 1. make a series of Detectors for each row in a DetectorList object
-        # 2. iterate through all Detectors, extract image from image_plane
-        # 3. apply all effects (to all Detectors)
-        # 4. add necessary header keywords
-
-        # 5. Generate a HDUList with the ImageHDUs and any extras:
-        # - add PrimaryHDU with meta data regarding observation in header
-        # - add ImageHDUs
-        # - add ASCIITableHDU with Effects meta data in final table extension
-
         self.array_effects = array_effects or []
         self.dtcr_effects = dtcr_effects or []
         self.meta.update(kwargs)
 
-        # 0. Get the image plane that corresponds to this detector array
+        # 1. Get the image plane that corresponds to this detector array
         image_plane_id = self.detector_list.meta["image_plane_id"]
         image_plane = [implane for implane in image_planes if
                        implane.id == image_plane_id][0]
 
-        # 0a. Apply detector array effects (apply to the entire image plane)
+        # 2. Apply detector array effects (apply to the entire image plane)
         for effect in self.array_effects:
             image_plane = effect.apply_to(image_plane, **self.meta)
 
-        # 1. make a series of Detectors for each row in a DetectorList object
+        # 3. make a series of Detectors for each row in a DetectorList object
         self.detectors = [Detector(hdr, **self.meta)
                           for hdr in self.detector_list.detector_headers()]
 
-        # 2. iterate through all Detectors, extract image from image_plane
+        # 4. iterate through all Detectors, extract image from image_plane
+        logging.info("Extracting from %d detectors...", len(self.detectors))
         for detector in self.detectors:
             detector.extract_from(image_plane)
 
-            # 3. apply all effects (to all Detectors)
+            # 5. apply all effects (to all Detectors)
             for effect in self.dtcr_effects:
                 detector = effect.apply_to(detector)
 
-            # 4. add necessary header keywords
+            # 6. add necessary header keywords
             # .. todo: add keywords
 
-        # 5. Generate a HDUList with the ImageHDUs and any extras:
+        # 7. Generate a HDUList with the ImageHDUs and any extras:
         pri_hdu = make_primary_hdu(self.meta)
 
         # ..todo: effects_hdu unnecessary as long as make_effects_hdu does not do anything
@@ -116,23 +127,11 @@ class DetectorArray:
 
 def make_primary_hdu(meta):
     """Create the primary header from meta data."""
-    new_meta = utils.stringify_dict(meta)
     prihdu = fits.PrimaryHDU()
-    prihdu.header.update(new_meta)
-
+    prihdu.header.update(utils.stringify_dict(meta))
     return prihdu
 
 
 def make_effects_hdu(effects):
     # .. todo:: decide what goes into the effects table of meta data
     return fits.TableHDU()
-
-
-# def get_detector_list(effects):
-#     detector_lists = get_all_effects(effects, efs.DetectorList)
-#
-#     if len(detector_lists) != 1:
-#         logging.warning("None or more than one DetectorList found. Using the"
-#                       " first instance.{}".format(detector_lists))
-#
-#     return detector_lists[0]

--- a/scopesim/detector/detector_array.py
+++ b/scopesim/detector/detector_array.py
@@ -73,9 +73,9 @@ class DetectorArray:
         self.meta.update(kwargs)
 
         # 1. Get the image plane that corresponds to this detector array
-        image_plane_id = self._detector_list.meta["image_plane_id"]
-        image_plane = [implane for implane in image_planes if
-                       implane.id == image_plane_id][0]
+        # TODO: This silently only returns the first match, is that intended??
+        image_plane = next(implane for implane in image_planes if
+                           implane.id == self._detector_list.image_plane_id)
 
         # 2. Apply detector array effects (apply to the entire image plane)
         for effect in self.array_effects:

--- a/scopesim/detector/detector_array.py
+++ b/scopesim/detector/detector_array.py
@@ -20,10 +20,15 @@ class DetectorArray:
     def __init__(self, detector_list=None, **kwargs):
         self.meta = {}
         self.meta.update(kwargs)
-        self.detector_list = detector_list
+
+        # The effect from which the instance is constructed
+        self._detector_list = detector_list
+
         self.array_effects = []
         self.dtcr_effects = []
         self.detectors = []
+
+        # The (initially empty) HDUList produced by the readout
         self.latest_exposure = None
 
     def readout(self, image_planes, array_effects=None, dtcr_effects=None,
@@ -68,7 +73,7 @@ class DetectorArray:
         self.meta.update(kwargs)
 
         # 1. Get the image plane that corresponds to this detector array
-        image_plane_id = self.detector_list.meta["image_plane_id"]
+        image_plane_id = self._detector_list.meta["image_plane_id"]
         image_plane = [implane for implane in image_planes if
                        implane.id == image_plane_id][0]
 
@@ -78,7 +83,7 @@ class DetectorArray:
 
         # 3. make a series of Detectors for each row in a DetectorList object
         self.detectors = [Detector(hdr, **self.meta)
-                          for hdr in self.detector_list.detector_headers()]
+                          for hdr in self._detector_list.detector_headers()]
 
         # 4. iterate through all Detectors, extract image from image_plane
         logging.info("Extracting from %d detectors...", len(self.detectors))
@@ -111,11 +116,11 @@ class DetectorArray:
 
     def __repr__(self):
         msg = (f"{self.__class__.__name__}"
-               f"({self.detector_list!r}, **{self.meta!r})")
+               f"({self._detector_list!r}, **{self.meta!r})")
         return msg
 
     def __str__(self):
-        return f"{self.__class__.__name__} with {self.detector_list!s}"
+        return f"{self.__class__.__name__} with {self._detector_list!s}"
 
     def _repr_pretty_(self, p, cycle):
         """For ipython."""

--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -206,7 +206,7 @@ class DetectorList(Effect):
 
         pixel_size = pixel_size.to(u.mm).value
         hdr = header_from_list_of_xy(x_det, y_det, pixel_size, "D")
-        hdr["IMGPLANE"] = self.meta["image_plane_id"]
+        hdr["IMGPLANE"] = self.image_plane_id
 
         return hdr
 
@@ -280,6 +280,11 @@ class DetectorList(Effect):
         axes.set_ylabel("Size [mm]")
 
         return axes
+
+    @property
+    def image_plane_id(self) -> int:
+        """Get ID of the corresponding image plane."""
+        return self.meta["image_plane_id"]
 
 
 class DetectorWindow(DetectorList):

--- a/scopesim/effects/psf_utils.py
+++ b/scopesim/effects/psf_utils.py
@@ -97,9 +97,10 @@ def make_strehl_map_from_table(tbl, pixel_scale=1*u.arcsec):
                                          np.arange(-25, 26))).T,
                     method="nearest")
 
-    new_wcs, _ = imp_utils.create_wcs_from_points(np.array([[-25, -25],
-                                                            [25, 25]]),
-                                                  pixel_scale=1, arcsec=True)
+    new_wcs, _ = imp_utils.create_wcs_from_points(
+        np.array([[-25, -25],
+                  [25, 25]]) * u.arcsec,
+        pixel_scale=1*u.arcsec/u.pixel)
 
     map_hdu = fits.ImageHDU(header=new_wcs.to_header(), data=smap)
 

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -29,7 +29,7 @@ class FieldOfView(FieldOfViewBase):
     The initial header should contain an on-sky WCS description:
     - CDELT-, CUNIT-, NAXIS- : for pixel scale and size (assumed CUNIT in deg)
     - CRVAL-, CRPIX- : for positioning the final image
-    - CTYPE- : is assumed to be "RA---TAN", "DEC---TAN"
+    - CTYPE- : is assumed to be "RA---TAN", "DEC--TAN"
 
     and an image-plane WCS description
     - CDELT-D, CUNIT-D, NAXISn : for pixel scale and size (assumed CUNIT in mm)
@@ -41,30 +41,33 @@ class FieldOfView(FieldOfViewBase):
     """
 
     def __init__(self, header, waverange, detector_header=None, **kwargs):
-        self.meta = {"id": None,
-                     "wave_min": utils.quantify(waverange[0], u.um),
-                     "wave_max": utils.quantify(waverange[1], u.um),
-                     "wave_bin_n": 1,
-                     "wave_bin_type": "linear",
+        self.meta = {
+            "id": None,
+            "wave_min": utils.quantify(waverange[0], u.um),
+            "wave_max": utils.quantify(waverange[1], u.um),
+            "wave_bin_n": 1,
+            "wave_bin_type": "linear",
 
-                     "area": 0 * u.m**2,
-                     "pixel_area": None,                    # [arcsec]
-                     "sub_pixel": "!SIM.sub_pixel.flag",
-                     "distortion": {"scale": [1, 1],
-                                    "offset": [0, 0],
-                                    "shear": [1, 1],
-                                    "rotation": 0,
-                                    "radius_of_curvature": None},
-                     "conserve_image": True,
-                     "trace_id": None,
-                     "aperture_id": None,
-                     }
+            "area": 0 * u.m**2,
+            "pixel_area": None,  # [arcsec]
+            "sub_pixel": "!SIM.sub_pixel.flag",
+            "distortion": {"scale": [1, 1],
+                           "offset": [0, 0],
+                           "shear": [1, 1],
+                           "rotation": 0,
+                           "radius_of_curvature": None},
+            "conserve_image": True,
+            "trace_id": None,
+            "aperture_id": None,
+        }
         self.meta.update(kwargs)
 
         if not any((utils.has_needed_keywords(header, s) for s in ["", "S"])):
-            raise ValueError(f"header must contain a valid sky-plane WCS: {dict(header)}")
+            raise ValueError(
+                f"Header must contain a valid sky-plane WCS: {dict(header)}")
         if not utils.has_needed_keywords(header, "D"):
-            raise ValueError(f"header must contain a valid image-plane WCS: {dict(header)}")
+            raise ValueError(
+                f"Header must contain a valid image-plane WCS: {dict(header)}")
 
         self.header = fits.Header()
         self.header["NAXIS"] = 2
@@ -93,23 +96,23 @@ class FieldOfView(FieldOfViewBase):
 
     @property
     def trace_id(self):
-        """Return the name of the trace"""
+        """Return the name of the trace."""
         return self.meta["trace_id"]
 
     @property
     def pixel_area(self):
         if self.meta["pixel_area"] is None:
-            self.meta["pixel_area"] = self._pixarea(self.header).value  # [arcsec]
+            # [arcsec] (really?)
+            self.meta["pixel_area"] = self._pixarea(self.header).value
         return self.meta["pixel_area"]
 
     def extract_from(self, src):
-        """ ..assumption: Bandpass has been applied
+        """..assumption: Bandpass has been applied.
 
         .. note:: Spectra are cut and copied from the original Source object.
             They are in original units. ph/s/pix comes in the make_**** methods
 
         """
-
         if not isinstance(src, SourceBase):
             raise ValueError(f"source must be a Source object: {type(src)}")
 
@@ -128,7 +131,8 @@ class FieldOfView(FieldOfViewBase):
 
             elif isinstance(fld, fits.ImageHDU):
                 if fld.header["NAXIS"] in (2, 3):
-                    fields_in_fov[ifld] = fu.extract_area_from_imagehdu(fld, volume)
+                    fields_in_fov[ifld] = fu.extract_area_from_imagehdu(fld,
+                                                                        volume)
                 if fld.header["NAXIS"] == 2 or fld.header.get("BG_SRC"):
                     ref = fld.header.get("SPEC_REF")
                     if ref is not None:
@@ -181,7 +185,8 @@ class FieldOfView(FieldOfViewBase):
 
     def _calc_area_factor(self, field):
         bg_solid_angle = u.Unit(field.header["SOLIDANG"]).to(u.arcsec**-2)
-        area_factor = self.pixel_area * bg_solid_angle  # arcsec**2 * arcsec**-2
+        # arcsec**2 * arcsec**-2
+        area_factor = self.pixel_area * bg_solid_angle
         return area_factor
 
     def _make_spectrum_cubefields(self, fov_waveset):
@@ -260,7 +265,7 @@ class FieldOfView(FieldOfViewBase):
             self._make_spectrum_imagefields(fov_waveset),
             self._make_spectrum_tablefields(fov_waveset),
             self._make_spectrum_backfields(fov_waveset),
-            ), start=np.zeros_like(fov_waveset.value))
+        ), start=np.zeros_like(fov_waveset.value))
 
         spectrum = SourceSpectrum(Empirical1D, points=fov_waveset,
                                   lookup_table=canvas_flux)
@@ -275,11 +280,13 @@ class FieldOfView(FieldOfViewBase):
         * yield cube image  to be added to canvas image
         """
         for field in self.cube_fields:
-            # cube_fields come in with units of photlam/arcsec2, need to convert to ph/s
+            # cube_fields come in with units of photlam/arcsec2,
+            # need to convert to ph/s
             # We need to the voxel volume (spectral and solid angle) for that.
             # ..todo: implement branch for use_photlam is True
             spectral_bin_width = (field.header["CDELT3"] *
-                                  u.Unit(field.header["CUNIT3"])).to(u.Angstrom)
+                                  u.Unit(field.header["CUNIT3"])
+                                  ).to(u.Angstrom)
             # First collapse to image, then convert units
             image = np.sum(field.data, axis=0) * PHOTLAM/u.arcsec**2
             image = (image * self._pixarea(field.header) * area *
@@ -387,7 +394,8 @@ class FieldOfView(FieldOfViewBase):
                 # Mask out any stars that were pushed out of the fov by rounding
                 mask = ((x < canvas_image_hdu.data.shape[1]) *
                         (y < canvas_image_hdu.data.shape[0]))
-                canvas_image_hdu.data[y[mask], x[mask]] += flux[mask] * weight[mask]
+                canvas_image_hdu.data[y[mask], x[mask]
+                                      ] += flux[mask] * weight[mask]
 
         canvas_image_hdu.data = sum(self._make_image_backfields(fluxes),
                                     start=canvas_image_hdu.data)
@@ -443,7 +451,9 @@ class FieldOfView(FieldOfViewBase):
                 canvas_image_hdu,
                 spline_order=spline_order)
             spec = specs[field.header["SPEC_REF"]]
-            field_cube = canvas_image_hdu.data[None, :, :] * spec[:, None, None]  # 2D * 1D -> 3D
+
+            # 2D * 1D -> 3D
+            field_cube = canvas_image_hdu.data[None, :, :] * spec[:, None, None]
             yield field_cube.value
 
     def _make_cube_tablefields(self, specs):
@@ -531,7 +541,6 @@ class FieldOfView(FieldOfViewBase):
         """
         spline_order = utils.from_currsys("!SIM.computing.spline_order")
 
-
         # 1. Make waveset and canvas cube (area, bin_width are applied at end)
         # TODO: Why is this not self.waveset? What's different?
         wave_unit = u.Unit(utils.from_currsys("!SIM.spectral.wave_unit"))
@@ -549,10 +558,11 @@ class FieldOfView(FieldOfViewBase):
         #     wmin, wmax = wave_min.to(u.um).value, wave_max.to(u.um).value
         #     fov_waveset = np.logspace(wmin, wmax, wave_bin_n)
 
-        specs = {ref: spec(fov_waveset)                     # PHOTLAM = ph/s/cm2/AA
+        specs = {ref: spec(fov_waveset)                 # PHOTLAM = ph/s/cm2/AA
                  for ref, spec in self.spectra.items()}
 
-        # make canvas cube based on waveset of largest cube and NAXIS1,2 from fov.header
+        # make canvas cube based on waveset of largest cube and NAXIS1,2
+        # from fov.header
         canvas_cube_hdu = fits.ImageHDU(
             data=np.zeros((len(fov_waveset),
                            self.header["NAXIS2"],
@@ -583,7 +593,7 @@ class FieldOfView(FieldOfViewBase):
         # SpectralTrace wants ph/s/um/arcsec2 --> get rid of m2, leave um
         area = utils.from_currsys(self.meta["area"])  # u.m2
         canvas_cube_hdu.data *= area.to(u.cm ** 2).value
-        canvas_cube_hdu.data *= 1e4        # ph/s/AA/arcsec2 --> ph/s/um/arcsec2
+        canvas_cube_hdu.data *= 1e4       # ph/s/AA/arcsec2 --> ph/s/um/arcsec2
 
         # TODO: what's with this code??
         # bin_widths = np.diff(fov_waveset).to(u.AA).value
@@ -714,7 +724,6 @@ class FieldOfView(FieldOfViewBase):
         self.header["CRVAL2"] *= convf
         self.header["CUNIT1"] = "deg"
         self.header["CUNIT2"] = "deg"
-            
 
     def __repr__(self):
         waverange = [self.meta["wave_min"].value, self.meta["wave_max"].value]

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -144,15 +144,15 @@ def _make_bounding_header_for_tables(*tables, pixel_scale=1*u.arcsec):
         extents.append(extent)
     pnts = np.vstack(extents)
 
+    # TODO: check if this could just use create_wcs_from_points
     hdr = header_from_list_of_xy(pnts[:, 0], pnts[:, 1], pixel_scale.value,
-                                 wcs_suffix, arcsec=True)
+                                 wcs_suffix, arcsec=wcs_suffix != "D")
     return hdr
 
 
 def create_wcs_from_points(points: np.ndarray,
                            pixel_scale: float,
-                           wcs_suffix: str = "",
-                           arcsec: bool = False) -> Tuple[WCS, np.ndarray]:
+                           wcs_suffix: str = "") -> Tuple[WCS, np.ndarray]:
     """
     Create `astropy.wcs.WCS` instance that fits all points inside.
 
@@ -164,8 +164,6 @@ def create_wcs_from_points(points: np.ndarray,
         DESCRIPTION.
     wcs_suffix : str, optional
         DESCRIPTION. The default is "".
-    arcsec : bool, optional
-        DESCRIPTION. The default is False.
 
     Returns
     -------
@@ -175,9 +173,10 @@ def create_wcs_from_points(points: np.ndarray,
         Array of NAXIS needed to fit all points.
 
     """
-    # TODO: either make pixel_scale a quantity or deal with arcsec flag...
+    # TODO: should pixel_scale be called pixel_size by conventions elsewhere?
+    # TODO: add quantity stuff to docstring
     # TODO: find out how this plays with chunks
-    if wcs_suffix != "D" and not arcsec:
+    if wcs_suffix != "D":
         points = _fix_360(points)
 
     # TODO: test whether abs(pixel_scale) breaks anything
@@ -191,16 +190,29 @@ def create_wcs_from_points(points: np.ndarray,
     #     crpix = np.array([1., 1.])
     #     crval = points.min(axis=0)
     # else:
+
+    if isinstance(naxis, u.Quantity):
+        naxis = naxis.decompose()
+        if naxis.unit != "pixel":
+            raise u.UnitConversionError("If given quantities, must resolve to "
+                                        f"pix, got '{naxis.unit}' instead.")
+        naxis = naxis.value
+
     crpix = (naxis + 1) / 2
     crval = (points.min(axis=0) + points.max(axis=0)) / 2
 
     ctype = "LINEAR" if wcs_suffix in "DX" else "RA---TAN"
-    if wcs_suffix == "D":
-        cunit = "mm"
-    elif arcsec:
-        cunit = "arcsec"
+
+    if isinstance(points, u.Quantity):
+        cunit = points.unit
     else:
-        cunit = "deg"
+        if wcs_suffix == "D":
+            cunit = "mm"
+        else:
+            cunit = "deg"
+
+    if isinstance(pixel_scale, u.Quantity):
+        pixel_scale = pixel_scale.value
 
     new_wcs = WCS(key=wcs_suffix)
     new_wcs.wcs.ctype = 2 * [ctype]
@@ -229,8 +241,12 @@ def header_from_list_of_xy(x, y, pixel_scale, wcs_suffix="", arcsec=False):
 
     """
     points = np.column_stack((x, y))
-    new_wcs, naxis = create_wcs_from_points(points, pixel_scale,
-                                            wcs_suffix, arcsec)
+
+    if arcsec:
+        points <<= u.arcsec
+        pixel_scale <<= u.arcsec / u.pixel
+
+    new_wcs, naxis = create_wcs_from_points(points, pixel_scale, wcs_suffix)
 
     hdr = fits.Header()
     hdr["NAXIS"] = 2
@@ -990,9 +1006,13 @@ def split_header(hdr, chunk_size, wcs_suffix=""):
 
 def _fix_360(arr):
     """Fix the "full circle overflow" that occurs with deg."""
-    arr = np.asarray(arr)
-    arr[arr > 270] -= 360
-    arr[arr <= -90] += 360
+    if isinstance(arr, u.Quantity):
+        arr[arr > 270*u.deg] -= 360*u.deg
+        arr[arr <= -90*u.deg] += 360*u.deg
+    else:
+        arr = np.asarray(arr)
+        arr[arr > 270] -= 360
+        arr[arr <= -90] += 360
     return arr
 
 
@@ -1000,6 +1020,6 @@ def _get_unit_from_headers(*headers, wcs_suffix: str = "") -> str:
     unit = headers[0][f"CUNIT1{wcs_suffix}"].lower()
     assert all(header[f"CUNIT{i}{wcs_suffix}"].lower() == unit
                for header, i in product(headers, range(1, 3))), \
-        [header[f"CUNIT{i}{wcs_suffix}"]
+        [(i, header[f"CUNIT{i}{wcs_suffix}"])
          for header, i in product(headers, range(1, 3))]
     return unit

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -420,16 +420,6 @@ class OpticalTrain:
                 iheader[f"SURFACE{isurface}"] = eff.meta["name"]
                 isurface += 1
 
-
-        for eff in self.optics_manager.fov_effects:
-            efftype = type(eff).__name__
-
-            if efftype == "SpectralTraceList" and eff.include:
-                if "CTYPE1" in eff.meta:
-                    for key in {"WCSAXES", "CTYPE1", "CTYPE2", "CRPIX1", "CRPIX2", "CRVAL1",
-                                "CRVAL2", "CDELT1", "CDELT2", "CUNIT1", "CUNIT2"}:
-                        iheader[key] = eff.meta[key]
-
         return hdulist
 
     def set_focus(self, **kwargs):

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -428,38 +428,19 @@ class OpticalTrain:
                 iheader["PRESSURE"] = eff.meta["pressure"], "[hPa]"
                 iheader["PWV"] = eff.meta["pwv"], "precipitable water vapour"
 
-            if efftype == "AtmosphericTERCurve" and eff.include:
-                iheader["ATMOSPHE"] = eff.meta["filename"], "atmosphere model"
-                # ..todo: expand if necessary
-
             if efftype == "SurfaceList" and eff.include:
-                iheader[f"SURFACE{isurface}"] = (eff.meta["filename"],
-                                                 eff.meta["name"])
+                iheader[f"SURFACE{isurface}"] = eff.meta["name"]
                 isurface += 1
 
-            if efftype == "QuantumEfficiencyCurve" and eff.include:
-                iheader["QE"] = Path(eff.meta["filename"]).name, eff.meta["name"]
 
         for eff in self.optics_manager.fov_effects:
             efftype = type(eff).__name__
 
-            # ..todo: needs to be handled with isinstance(eff, PSF)
-            if efftype == "FieldConstantPSF" and eff.include:
-                iheader["PSF"] = eff.meta["filename"], "point spread function"
-
             if efftype == "SpectralTraceList" and eff.include:
-                iheader["SPECTRAC"] = (from_currsys(eff.meta["filename"]),
-                                       "spectral trace definition")
                 if "CTYPE1" in eff.meta:
                     for key in {"WCSAXES", "CTYPE1", "CTYPE2", "CRPIX1", "CRPIX2", "CRVAL1",
                                 "CRVAL2", "CDELT1", "CDELT2", "CUNIT1", "CUNIT2"}:
                         iheader[key] = eff.meta[key]
-
-        for eff in self.optics_manager.detector_effects:
-            efftype = type(eff).__name__
-
-            if efftype == "LinearityCurve" and eff.include:
-                iheader["DETLIN"] = from_currsys(eff.meta["filename"])
 
         return hdulist
 

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -367,18 +367,6 @@ class OpticalTrain:
         iheader["BUNIT"] = "e", "per EXPTIME"
         iheader["PIXSCALE"] = from_currsys("!INST.pixel_scale"), "[arcsec]"
 
-        # A simple WCS
-        iheader["CTYPE1"] = "LINEAR"
-        iheader["CTYPE2"] = "LINEAR"
-        iheader["CRPIX1"] = (iheader["NAXIS1"] + 1) / 2
-        iheader["CRPIX2"] = (iheader["NAXIS2"] + 1) / 2
-        iheader["CRVAL1"] = 0.
-        iheader["CRVAL2"] = 0.
-        iheader["CDELT1"] = iheader["PIXSCALE"]
-        iheader["CDELT2"] = iheader["PIXSCALE"]
-        iheader["CUNIT1"] = "arcsec"
-        iheader["CUNIT2"] = "arcsec"
-
         for eff in self.optics_manager.detector_setup_effects:
             efftype = type(eff).__name__
 


### PR DESCRIPTION
1. Add two functions in `optics/image_plane_utils`: `det_wcs_from_sky_wcs()` and `sky_wcs_from_det_wcs()`, which convert detector (mm) WCS into on-sky (arcsec or deg) WCS and vice versa using the pixel and plate scales. Both in turn use the function `create_wcs_from_points()`, which has been slightly modified as well. There used to be a bit of a less-than-ideal state because a sky WCS could use either arcsec or deg and ScopeSim is not fully consistent with that, which may lead to bugs if one or the other is incorrectly assumed. All three functions now use astropy units, which is also not ideal for performance, but acceptable for now until we can be certain our units are consistent. If a non-quantity (i.e. float) is passed, a reasonable (documented) unit is assumed. The function `header_from_list_of_xy()`, which internally also calls `create_wcs_from_points()`, is unchanged in its parameters and still uses the `arcsec` flag. This function might be phased out mostly in favor of direct calls to `create_wcs_from_points()`.
2. Adaptions to these changes in several places, most importantly in `FOVManager.generate_fov_list()`, which now uses `det_wcs_from_sky_wcs()`. The code previously there was the main inspiration for the two new functions.
3. Include the (approximate) on-sky WCS in `Detector.hdu`, which was the main motivation to do all of this. This will be collected by `DetectorArray.readout()` and thus also included in the output from `OpticalTrain.readout()`. In the process, some minor changes to `DetectorArray` as a whole, mostly documentation, some comments, and everyone's favorite: formatting and linting 🙃 
4. Remove some obsolete lines from `OpticalTrain.write_header()`, notably the WCS and some input file names, see also #305 .
5. Some minor formatting and cleanup in a few other places.
6. Add tests for the new WCS functions to ensure a round-trip of `sky` ➡️ `detector` ➡️ `sky` works.