### PR TITLE
Add Quantization effect

### DIFF
--- a/scopesim/effects/electronic.py
+++ b/scopesim/effects/electronic.py
@@ -605,9 +605,10 @@ class Quantization(Effect):
             logging.warning("Setting quantized data to dtype %s, which is not "
                             "an integer subtype.", new_dtype)
 
-        data = np.floor(obj._hdu.data).astype(new_dtype)
-        new_imagehdu = fits.ImageHDU(data=data, header=obj._hdu.header)
-        obj._hdu = new_imagehdu
+        # This used to create a new ImageHDU with the same header but the data
+        # set to the modified data. It should be fine to simply re-assign the
+        # data attribute, but just in case it's not...
+        obj._hdu.data = np.floor(obj._hdu.data).astype(new_dtype)
 
         return obj
 

--- a/scopesim/tests/tests_effects/test_Quantization.py
+++ b/scopesim/tests/tests_effects/test_Quantization.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Contains tests for Shutter class."""
+
+import pytest
+import numpy as np
+
+from scopesim.detector import Detector
+from scopesim.effects.electronic import Quantization
+
+from scopesim.tests.mocks.py_objects.header_objects import _implane_header
+
+
+@pytest.fixture
+def mock_detector():
+    det = Detector(_implane_header())
+    return det
+
+
+@pytest.fixture(scope="function", name="det")
+def detector_with_data(mock_detector):
+    det = mock_detector
+    width = det._hdu.data.shape[1]
+    det._hdu.data[:] = 1.2
+    det._hdu.data[:, width//2] = 1.99
+    return det
+
+
+class TestInit:
+    def test_initialised_with_nothing(self):
+        quant = Quantization()
+        assert isinstance(quant, Quantization)
+
+
+class TestApplyTo:
+    def test_floors_pixels_to_integer_with_default(self, det):
+        assert det.data.sum() > det.data.size * 1.2
+        quant = Quantization()
+        det = quant.apply_to(det)
+        assert det.data.sum() == det.data.size
+        assert det.data.dtype == np.uint32
+
+    def test_floors_pixels_to_integer_with_custom(self, det):
+        assert det.data.sum() > det.data.size * 1.2
+        quant = Quantization(dtype="int16")
+        det = quant.apply_to(det)
+        assert det.data.sum() == det.data.size
+        assert det.data.dtype == np.int16
+
+    def test_logs_warning_for_float_dtype(self, det, caplog):
+        assert det.data.sum() > det.data.size * 1.2
+        quant = Quantization(dtype=float)
+        det = quant.apply_to(det)
+        assert det.data.sum() == det.data.size
+        # Test sub-dtype because exact dtype for "float" may depend on OS
+        assert np.issubdtype(det.data.dtype, np.floating)
+        assert "Setting quantized data to dtype" in caplog.text


### PR DESCRIPTION
Add a new effect `electronic.Quantization`, which does the "flooring" previously performed within `ShotNoise` and also sets the data type to `unsigned integer` (32 bit) by default. This can be changed by passing the `dtype` keyword argument to any dtype accepted by Numpy. A warning will be logged if the selected data type is not an integer, since usually the outcome of flooring should be some kind of integer.

> [!Warning]
> As this takes the flooring out of `ShotNoise`, it will probably (slightly) change (increase) any previous output unless the new `Quantization` effect is added in the corresponding IRDB YAML file.