### PR TITLE
Reduce memory consuption by doing in place calculations

### DIFF
--- a/scopesim/effects/psf_utils.py
+++ b/scopesim/effects/psf_utils.py
@@ -307,8 +307,13 @@ def get_bkg_level(obj, bg_w):
             mask = np.zeros_like(obj, dtype=bool)
             if bg_w > 0:
                 mask[:, bg_w:-bg_w, bg_w:-bg_w] = True
-            bkg_level = np.ma.median(np.ma.masked_array(obj, mask=mask),
-                                     axis=(2, 1)).data
+
+            # Using overwrite_input=True reduces memory consumption.
+            # Nevertheless, the computation of the median here can be
+            # responsible for more than 40% of the memory consumption.
+            bkg_masked_array = np.ma.masked_array(obj, mask=mask)
+            bkg_level_temp = np.ma.median(bkg_masked_array, axis=(2, 1), overwrite_input=True)
+            bkg_level = bkg_level_temp.data
 
     else:
         raise ValueError("Unsupported dimension:", obj.ndim)

--- a/scopesim/effects/psfs.py
+++ b/scopesim/effects/psfs.py
@@ -82,7 +82,12 @@ class PSF(Effect):
                 #    kernel /= np.sum(kernel)
                 #    kernel[kernel < 0.] = 0.
 
-                image = obj.hdu.data.astype(float)
+                # This line copied the entire image, while below obj.hdu.data
+                # is updated anyway. So better do all modifications in place.
+                #image = obj.hdu.data.astype(float)
+                if obj.hdu.data.dtype != float:
+                    obj.hdu.data = obj.hdu.data.astype(float)
+                image = obj.hdu.data
 
                 # subtract background level before convolving, re-add afterwards
                 bkg_level = pu.get_bkg_level(image, self.meta["bkg_width"])
@@ -104,7 +109,10 @@ class PSF(Effect):
                             image[iplane,] - bkg_level[iplane,],
                             kernel[iplane,], mode=mode)
 
-                obj.hdu.data = new_image + bkg_level
+                # This line also copied all the data, better to do the
+                # modifications in place.
+                #obj.hdu.data = new_image + bkg_level
+                obj.hdu.data -= bkg_level
 
                 # ..todo: careful with which dimensions mean what
                 d_x = new_image.shape[-1] - image.shape[-1]


### PR DESCRIPTION
This PR reduces the memory consumption of a simple MICADO + SCAO + SPEC_15000x20 + detector_window simulation form 8.3 GB to 5.9 GB.

Might need some cleanup at some point.