### PR TITLE
Include ScopeSim_Data in notebook tests

### DIFF
--- a/.github/workflows/notebooks_dispatch.yml
+++ b/.github/workflows/notebooks_dispatch.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install --with test --with dev --all-extras
+          pip install git+https://github.com/AstarVienna/ScopeSim_Data.git
 
       - name: Run notebooks
         env:


### PR DESCRIPTION
Skycalc is down, and automated tests other than ScopeSim_Data should not access third party services, see #323