### PR TITLE
Allow runnotebooks.sh to run without arguments

### DIFF
--- a/runnotebooks.sh
+++ b/runnotebooks.sh
@@ -6,9 +6,61 @@ set -Eeuo pipefail
 # Set stdout as default so the script can be ran on the commandline.
 STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 
+usage() {
+  cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-v] [--clone-irdb] [--delete]
+
+Test whether all the notebooks run.
+
+Available options:
+
+-h, --help      Print this help and exit
+-v, --verbose   Print script debug info
+--clone-irdb    Clone the IRDB instead of downloading it
+--delete        Delete generated files
+EOF
+  exit
+}
+
+parse_params() {
+  # default values of variables set from params
+  DELETE=0
+  CLONEIRDB=0
+
+  while :; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    --no-color) NO_COLOR=1 ;;
+    --clone-irdb) CLONEIRDB=1 ;;
+    --delete) DELETE=1 ;;
+    -?*) die "Unknown option: $1" ;;
+    *) break ;;
+    esac
+    shift
+  done
+
+  args=("$@")
+
+  return 0
+}
+
+msg() {
+  echo >&2 -e "${1-}"
+}
+
+die() {
+  local msg=$1
+  local code=${2-1} # default exit status 1
+  msg "$msg"
+  exit "$code"
+}
+
+parse_params "$@"
+
 echo "# Running Notebooks Tests" >> $STEP_SUMMARY
 
-if [[ "x${1}" == "x--clone-irdb" ]] ; then
+if [[ "${CLONEIRDB}" == 1 ]] ; then
   # Cloning IRDB
   if [[ ! -e inst_pkgs ]] ; then
     echo "_Cloning IRDB_" >> $STEP_SUMMARY
@@ -48,7 +100,7 @@ do
   # By default do not delete any files.
   # The delete functionality is intended to make it easy for developers to test
   # all the notebooks on their own machine.
-  if [ "x$1" = "x--delete" ]
+  if [ "${DELETE}" = 1 ]
   then
     echo "Removing ${fnpy}"
     rm "${fnpy}"


### PR DESCRIPTION
This should make the ScopeSim_Data nightly run work.

This follows https://betterdev.blog/minimal-safe-bash-script-template/

Closes #328 