### PR TITLE
Revert "Also use poetry for calling jupytext"

### DIFF
--- a/.github/workflows/notebooks_dispatch.yml
+++ b/.github/workflows/notebooks_dispatch.yml
@@ -49,4 +49,4 @@ jobs:
         env:
           TQDM_MININTERVAL: 10
           CLONE:  ${{ inputs.clone-irdb && '--clone-irdb' || '' }}
-        run: ./runnotebooks.sh $CLONE --delete
+        run: poetry run ./runnotebooks.sh $CLONE --delete

--- a/runnotebooks.sh
+++ b/runnotebooks.sh
@@ -90,10 +90,10 @@ do
   fnpy="${fnnotebook%.ipynb}.py"
 
   # Convert .ipynb file to .py.
-  poetry run jupytext --to py "${fnnotebook}"
+  jupytext --to py "${fnnotebook}"
 
-  # Run the python script and quit on first error.
-  poetry run python "${fnpy}"
+  # Run the python script.
+  python "${fnpy}"
   echo "- ${fnnotebook}" >> $STEP_SUMMARY
 
   # Delete generated files if --delete is specified.


### PR DESCRIPTION
This reverts commit b3cafcab48eea8ef8ce26957872fefd12e0699fc.

That is, it moves the `poetry run` from insdie `runnotebooks.sh` to `notebooks_dispatch.yml` that runs `runnotebooks.sh`.