### PR TITLE
Ensure logging messages don't reach the root logger

### DIFF
--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -33,7 +33,7 @@ from . import rc
 top_logger = logging.getLogger("astar")
 top_logger.setLevel(logging.WARNING)
 sim_logger = top_logger.getChild(__package__)
-sim_logger.setLevel(logging.DEBUG)
+sim_logger.setLevel(logging.INFO)
 formatter = logging.Formatter("%(name)s - %(levelname)s: %(message)s")
 
 log_dict = rc.__config__["!SIM.logging"]

--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -33,7 +33,8 @@ from . import rc
 top_logger = logging.getLogger("astar")
 top_logger.setLevel(logging.WARNING)
 sim_logger = top_logger.getChild(__package__)
-sim_logger.setLevel(logging.INFO)
+sim_logger.setLevel(logging.DEBUG)
+top_logger.propagate = False
 formatter = logging.Formatter("%(name)s - %(levelname)s: %(message)s")
 
 log_dict = rc.__config__["!SIM.logging"]

--- a/scopesim/tests/conftest.py
+++ b/scopesim/tests/conftest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Global fixtures for pytest."""
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,20 @@ from scopesim.system_dict import UniqueList
 MOCK_DIR = Path(__file__).parent / "mocks"
 
 sim.rc.__currsys__["!SIM.file.error_on_missing_file"] = True
+
+
+@pytest.fixture(scope="package", autouse=True)
+def configure_logging():
+    top_logger = logging.getLogger("astar")
+    handlers = top_logger.handlers
+    # Disable handlers
+    top_logger.handlers = []
+    # Make sure logging can reach pytest's caplog
+    top_logger.propagate = True
+    yield
+    # Restore
+    top_logger.handlers = handlers
+    top_logger.propagate = False
 
 
 @pytest.fixture(scope="package")


### PR DESCRIPTION
DEBUG should only be used when, well, debugging, and is thus not useful to have on by default.