### PR TITLE
Further improvements to logging

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -142,16 +142,17 @@ test = ["dateparser (==1.*)", "pre-commit", "pytest", "pytest-cov", "pytest-mock
 
 [[package]]
 name = "astar-utils"
-version = "0.2.0b0"
+version = "0.2.0b1"
 description = "Contains commonly-used utilities for AstarVienna's projects."
 optional = false
 python-versions = ">=3.9,<4.0"
 files = [
-    {file = "astar_utils-0.2.0b0-py3-none-any.whl", hash = "sha256:4a47a188edb3156ee45e0bfdc211350c9553c3c69aad1ce9872bb0b2c9ec7044"},
-    {file = "astar_utils-0.2.0b0.tar.gz", hash = "sha256:b45322ca89dff98e89828bfe0f1cd6a04fe3fafb5f49dc5a42ce1431328a8e5e"},
+    {file = "astar_utils-0.2.0b1-py3-none-any.whl", hash = "sha256:b59aaeb5920333c528aa7bef07a04a009e9a1e668e84e3cfbc09fdd8dae7fdda"},
+    {file = "astar_utils-0.2.0b1.tar.gz", hash = "sha256:f9a5fd493623c36d79f7df97f011e073fadddfe9ea94fe35d0abee82bbbf1a2b"},
 ]
 
 [package.dependencies]
+colorama = ">=0.4.6,<0.5.0"
 more-itertools = ">=10.1.0,<11.0.0"
 pyyaml = ">=6.0.1,<7.0.0"
 
@@ -2673,7 +2674,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -3712,4 +3712,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "db0d8ac00666a493c6c939f6b621d50c7a8b7c44cecd257adbc2671163b95f21"
+content-hash = "14abc3786229999350744030ad20b0113c41a61a9495e96d9e002dc5fa046037"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ tqdm = "^4.66.1"
 synphot = "^1.2.1"
 skycalc_ipy = "^0.3.0"
 anisocado = "^0.3.0"
-astar-utils = {version = "^0.2.0b0", allow-prereleases = true}
+astar-utils = {version = "^0.2.0b1", allow-prereleases = true}
 
 [tool.poetry.group.dev]
 optional = true

--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -1,10 +1,10 @@
-"Generalised telescope observation simulator."
+"""Generalised telescope observation simulator."""
 
 ###############################################################################
 #                            TURN OFF WARNINGS                                #
 ###############################################################################
-import sys
 import logging
+import logging.config
 import warnings
 import yaml
 from importlib import metadata
@@ -26,31 +26,11 @@ from . import rc
 #                         SET BASIC LOGGING LEVEL                             #
 ###############################################################################
 
-# TODO: this should be replaced with YAML-based config!! see prepipy
-
 # This should be part of ScopeSim (the app) and not scopesim_core eventually
+# TODO: need to add a function to reload the config!
 
-top_logger = logging.getLogger("astar")
-top_logger.setLevel(logging.WARNING)
-sim_logger = top_logger.getChild(__package__)
-sim_logger.setLevel(logging.DEBUG)
-top_logger.propagate = False
-formatter = logging.Formatter("%(name)s - %(levelname)s: %(message)s")
-
-log_dict = rc.__config__["!SIM.logging"]
-if log_dict["log_to_file"]:
-    file_handler = logging.FileHandler(log_dict["file_path"],
-                                       log_dict["file_open_mode"])
-    file_handler.setLevel(log_dict["file_level"])  # DEBUG
-    file_handler.setFormatter(formatter)
-    top_logger.addHandler(file_handler)
-
-if log_dict["log_to_console"]:
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setLevel(log_dict["console_level"])  # INFO
-    stdout_handler.setFormatter(formatter)
-    top_logger.addHandler(stdout_handler)
-
+logging.config.dictConfig(rc.__config__["!SIM.logging"])
+logging.captureWarnings(True)
 
 ###############################################################################
 #                         IMPORT PACKAGE MODULES                              #

--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -32,6 +32,12 @@ from . import rc
 logging.config.dictConfig(rc.__config__["!SIM.logging"])
 logging.captureWarnings(True)
 
+# This cannot be in the dict config (yet) because NestedMapping doesn't like
+#   "." in keys (yet) ...
+from astar_utils import get_logger
+# Set the "astar.scopesim" logger
+get_logger(__package__).setLevel(logging.DEBUG)
+
 ###############################################################################
 #                         IMPORT PACKAGE MODULES                              #
 ###############################################################################

--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -29,14 +29,10 @@ from . import rc
 # This should be part of ScopeSim (the app) and not scopesim_core eventually
 # TODO: need to add a function to reload the config!
 
-logging.config.dictConfig(rc.__config__["!SIM.logging"])
-logging.captureWarnings(True)
+# Import convenience functions
+from .utils import update_logging, log_to_file, set_console_log_level
+update_logging()
 
-# This cannot be in the dict config (yet) because NestedMapping doesn't like
-#   "." in keys (yet) ...
-from astar_utils import get_logger
-# Set the "astar.scopesim" logger
-get_logger(__package__).setLevel(logging.DEBUG)
 
 ###############################################################################
 #                         IMPORT PACKAGE MODULES                              #

--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -3,8 +3,7 @@
 ###############################################################################
 #                            TURN OFF WARNINGS                                #
 ###############################################################################
-import logging
-import logging.config
+
 import warnings
 import yaml
 from importlib import metadata

--- a/scopesim/defaults.yaml
+++ b/scopesim/defaults.yaml
@@ -52,12 +52,50 @@ properties :
     preamble_file: None
 
   logging :
-    log_to_file: False
-    log_to_console: True
-    file_path: ".scopesim.log"
-    file_open_mode: "w"   # w - overwrite, a - append
-    file_level:    "DEBUG"      # DEBUG INFO WARNING ERROR CRITICAL
-    console_level: "INFO"       # DEBUG INFO WARNING ERROR CRITICAL
+    # This sub-dict enables direct configuration of logging.
+    # The corresponding schema can be found at:
+    # https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
+
+    version: 1
+    disable_existing_loggers: False  # Not sure what's best here??
+
+    root:  # To allow e.g. warnings -> logging
+      level: INFO
+      handlers: [console]  # [console, file] or just [console]
+
+    loggers:
+      astar:
+        level: WARNING
+        handlers: [console, file]  # [console, file] or just [console]
+        propagate: False  # Any logging from astar stops here.
+        # Or don't add handlers here, but let it propagate to root?
+      astar.scopesim:
+        level: DEBUG
+        propagate: True  # Goes through to astar logger.
+
+    handlers:
+      console:
+        class: logging.StreamHandler
+        level: INFO
+        formatter: color
+        stream: ext://sys.stdout
+      file:
+        class : logging.handlers.RotatingFileHandler
+        level: DEBUG
+        formatter: verbose
+        filename: ".scopesim.log"
+        mode: "w"   # w - overwrite, a - append
+        encoding: "utf-8"
+        delay: True
+        maxBytes: 32768
+        backupCount: 3
+
+    formatters:
+      verbose:
+        format: '%(asctime)s - %(levelname)-8s - %(name)s - %(funcName)s - %(message)s'
+      color:
+        '()': astar_utils.loggers.ColoredFormatter
+        show_name: True
 
   tests :
     # overridden in tests/__init__.py

--- a/scopesim/defaults.yaml
+++ b/scopesim/defaults.yaml
@@ -69,9 +69,10 @@ properties :
         handlers: [console]  # [console, file] or just [console]
         propagate: False  # Any logging from astar stops here.
         # Or don't add handlers here, but let it propagate to root?
-      astar.scopesim:
-        level: DEBUG
-        propagate: True  # Goes through to astar logger.
+      # This doesn't work because NestedMapping doesn't like "." in keys...
+      # astar.scopesim:
+      #   level: DEBUG
+      #   propagate: True  # Goes through to astar logger.
 
     handlers:
       console:

--- a/scopesim/defaults.yaml
+++ b/scopesim/defaults.yaml
@@ -66,7 +66,7 @@ properties :
     loggers:
       astar:
         level: WARNING
-        handlers: [console, file]  # [console, file] or just [console]
+        handlers: [console]  # [console, file] or just [console]
         propagate: False  # Any logging from astar stops here.
         # Or don't add handlers here, but let it propagate to root?
       astar.scopesim:

--- a/scopesim/tests/conftest.py
+++ b/scopesim/tests/conftest.py
@@ -18,16 +18,16 @@ sim.rc.__currsys__["!SIM.file.error_on_missing_file"] = True
 
 @pytest.fixture(scope="package", autouse=True)
 def configure_logging():
-    top_logger = logging.getLogger("astar")
-    handlers = top_logger.handlers
+    base_logger = logging.getLogger("astar")
+    handlers = base_logger.handlers
     # Disable handlers
-    top_logger.handlers = []
+    base_logger.handlers = []
     # Make sure logging can reach pytest's caplog
-    top_logger.propagate = True
+    base_logger.propagate = True
     yield
     # Restore
-    top_logger.handlers = handlers
-    top_logger.propagate = False
+    base_logger.handlers = handlers
+    base_logger.propagate = False
 
 
 @pytest.fixture(scope="package")

--- a/scopesim/tests/test_logging.py
+++ b/scopesim/tests/test_logging.py
@@ -1,46 +1,45 @@
 # -*- coding: utf-8 -*-
 """Test to make sure the logging configuration is applied."""
 
-# import logging
-# from importlib import reload
+import logging
+from importlib import reload
 
-# import pytest
+import pytest
 
-# import scopesim as sim
-
-
-# @pytest.fixture(scope="function")
-# def reload_scopesim():
-#     """Temprarily disable the global configure_logging fixture."""
-#     base_logger = logging.getLogger("astar")
-#     handlers = base_logger.handlers
-#     prop = base_logger.propagate
-#     # Reload scopesim to apply logging configuration again
-#     reload(sim)
-#     yield
-#     # Restore
-#     base_logger.handlers = handlers
-#     base_logger.propagate = prop
+import scopesim as sim
 
 
-# @pytest.mark.usefixtures("reload_scopesim")
-# def test_loggers_are_configured():
-#     log_dict = sim.rc.__config__["!SIM.logging"]
-#     base_logger_dict = log_dict["loggers"]["astar"]
-#     sim_logger_dict = log_dict["loggers"]["astar.scopesim"]
+@pytest.fixture(scope="function")
+def reload_scopesim():
+    """Temprarily disable the global configure_logging fixture."""
+    base_logger = logging.getLogger("astar")
+    handlers = base_logger.handlers
+    prop = base_logger.propagate
+    # Reload scopesim to apply logging configuration again
+    reload(sim)
+    yield
+    # Restore
+    base_logger.handlers = handlers
+    base_logger.propagate = prop
 
-#     base_logger = logging.getLogger("astar")
-#     sim_logger = base_logger.getChild("scopesim")
 
-#     base_logger_level = logging.getLevelName(base_logger.getEffectiveLevel())
-#     assert base_logger_level == base_logger_dict["level"]
+@pytest.mark.usefixtures("reload_scopesim")
+def test_loggers_are_configured():
+    log_dict = sim.rc.__config__["!SIM.logging"]
+    base_logger_dict = log_dict["loggers"]["astar"]
 
-#     sim_logger_level = logging.getLevelName(sim_logger.getEffectiveLevel())
-#     assert sim_logger_level == sim_logger_dict["level"]
+    base_logger = logging.getLogger("astar")
+    sim_logger = base_logger.getChild("scopesim")
 
-#     assert base_logger.propagate == base_logger_dict["propagate"]
-#     assert sim_logger.propagate == sim_logger_dict["propagate"]
+    base_logger_level = logging.getLevelName(base_logger.getEffectiveLevel())
+    assert base_logger_level == base_logger_dict["level"]
 
-#     for handler, name in zip(base_logger.handlers,
-#                              base_logger_dict["handlers"]):
-#         handler.name == name
+    sim_logger_level = logging.getLevelName(sim_logger.getEffectiveLevel())
+    assert sim_logger_level == "DEBUG"
+
+    assert base_logger.propagate == base_logger_dict["propagate"]
+    assert sim_logger.propagate
+
+    for handler, name in zip(base_logger.handlers,
+                             base_logger_dict["handlers"]):
+        handler.name == name

--- a/scopesim/tests/test_logging.py
+++ b/scopesim/tests/test_logging.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Test to make sure the logging configuration is applied."""
+
+# import logging
+# from importlib import reload
+
+# import pytest
+
+# import scopesim as sim
+
+
+# @pytest.fixture(scope="function")
+# def reload_scopesim():
+#     """Temprarily disable the global configure_logging fixture."""
+#     base_logger = logging.getLogger("astar")
+#     handlers = base_logger.handlers
+#     prop = base_logger.propagate
+#     # Reload scopesim to apply logging configuration again
+#     reload(sim)
+#     yield
+#     # Restore
+#     base_logger.handlers = handlers
+#     base_logger.propagate = prop
+
+
+# @pytest.mark.usefixtures("reload_scopesim")
+# def test_loggers_are_configured():
+#     log_dict = sim.rc.__config__["!SIM.logging"]
+#     base_logger_dict = log_dict["loggers"]["astar"]
+#     sim_logger_dict = log_dict["loggers"]["astar.scopesim"]
+
+#     base_logger = logging.getLogger("astar")
+#     sim_logger = base_logger.getChild("scopesim")
+
+#     base_logger_level = logging.getLevelName(base_logger.getEffectiveLevel())
+#     assert base_logger_level == base_logger_dict["level"]
+
+#     sim_logger_level = logging.getLevelName(sim_logger.getEffectiveLevel())
+#     assert sim_logger_level == sim_logger_dict["level"]
+
+#     assert base_logger.propagate == base_logger_dict["propagate"]
+#     assert sim_logger.propagate == sim_logger_dict["propagate"]
+
+#     for handler, name in zip(base_logger.handlers,
+#                              base_logger_dict["handlers"]):
+#         handler.name == name

--- a/scopesim/tests/test_logging.py
+++ b/scopesim/tests/test_logging.py
@@ -43,3 +43,19 @@ def test_loggers_are_configured():
     for handler, name in zip(base_logger.handlers,
                              base_logger_dict["handlers"]):
         handler.name == name
+
+
+def test_log_to_file():
+    base_logger = logging.getLogger("astar")
+    sim.log_to_file(enable=True)
+    assert any(handler.name == "file" for handler in base_logger.handlers)
+    sim.log_to_file(enable=False)
+    assert not any(handler.name == "file" for handler in base_logger.handlers)
+
+
+def test_set_console_log_level():
+    base_logger = logging.getLogger("astar")
+    sim.set_console_log_level("ERROR")
+    assert base_logger.handlers[0].level == logging.ERROR
+    sim.set_console_log_level()
+    assert base_logger.handlers[0].level == logging.INFO

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -1027,3 +1027,35 @@ def top_level_catch(func):
             raise
         return output
     return wrapper
+
+
+def update_logging(capture_warnings=True):
+    """Reload logging configuration from ``rc.__config__``."""
+    logging.config.dictConfig(rc.__config__["!SIM.logging"])
+    logging.captureWarnings(capture_warnings)
+
+    # This cannot be in the dict config (yet) because NestedMapping doesn't like
+    #   "." in keys (yet) ...
+    # Set the "astar.scopesim" logger
+    get_logger(__package__).setLevel(logging.DEBUG)
+
+
+def log_to_file(enable=True):
+    """Enable or disable logging to file (convenience function)."""
+    if enable:
+        handlers = ["console", "file"]
+    else:
+        handlers = ["console"]
+
+    rc.__config__["!SIM.logging.loggers.astar.handlers"] = handlers
+    update_logging()
+
+
+def set_console_log_level(level="INFO"):
+    """Set the level for the console handler (convenience function).
+
+    This controls what is actually printed to the console by ScopeSim.
+    Accepted values are: DEBUG, INFO (default), WARNING, ERROR and CRITICAL.
+    """
+    rc.__config__["!SIM.logging.handlers.console.level"] = level
+    update_logging()

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -3,6 +3,7 @@ import math
 from pathlib import Path
 import sys
 import logging
+from logging.config import dictConfig
 from collections import OrderedDict
 from collections.abc import Iterable, Generator
 from copy import deepcopy
@@ -1031,7 +1032,7 @@ def top_level_catch(func):
 
 def update_logging(capture_warnings=True):
     """Reload logging configuration from ``rc.__config__``."""
-    logging.config.dictConfig(rc.__config__["!SIM.logging"])
+    dictConfig(rc.__config__["!SIM.logging"])
     logging.captureWarnings(capture_warnings)
 
     # This cannot be in the dict config (yet) because NestedMapping doesn't like


### PR DESCRIPTION
## Configure logging via `rc.__config__` sub-dict

Configuration of logging in ScopeSim is now done via `logging.config.dictConfig()` using the reconfigured `!SIM.logging` subsection of the `rc.__config__` configuration mapping. This enables logging configuration to be part of the overall config file `defaults.yaml` and is generally cleaner than the manual settings done previously.

## Use colored logging

The `ColoredFormatter` was recently introduced in `astar-utils.loggers`, which is now used in ScopeSim to produce color-coded logging output to the console.

## New convenience functions for logging configuration

This also introduces three new functions in the `utils` module to make it easier for the user to configure logging, without in-depth knowledge of the `dictConfig` scheme. All of these functions are available on the top level (i.e. `sim.<function>` as opposed to `sim.utils.<function>`) for further ease of use.

### `update_logging()`

This function executes the call to `logging.config.dictConfig()` and is also used automatically when importing ScopeSim. Whenever it is called, it will re-apply the current state of `rc.__config__` to the logging configuration. The single optional boolean parameter `capture_warnings` (default `True`) is used to configure `logging.captureWarnings()`, which redirects warnings to logging output. Thus calling `update_logging(capture_warnings=False)` without any changes to the logging section in `rc.__config__` will simply disable the warning capture.

### `log_to_file()`

Logging to a log file is _disabled_ by default to avoid unnecessary log spam. If a detailed log file is required, simply calling `log_to_file()` will switch it on. Calling `log_to_file(False)` will reverse this. Logging to file is done at the DEBUG level for all ScopeSim-internal loggers by default, and WARNING for all other `astar` loggers. This should be a good default behavior, since the need for a log file usually correlates with the need for more detailed logging anyway.

### `set_console_log_level(level)`

This is simply a wrapper for:
```python
rc.__config__["!SIM.logging.handlers.console.level"] = level
update_logging()
```
to quickly set the level of the logging to the console. The default is INFO.

## On the configuration of the `astar.scopesim` logger...

The `astar.scopesim` logger serves as the base for all logging calls within ScopeSim itself (and not from any of our internal dependencies, which have their own child loggers within the `astar` namespace). It doesn't need much configuration (most of the work is done by the parent logger `astar`), but does require to have its level set to DEBUG to enable an easy on/off switching of detailed logs. It is however currently not possible to use a `.` in a key name of a `NestedMapping`, such as `rc.__config__`. Thus, the line
```python
get_logger(__package__).setLevel(logging.DEBUG)
```
was added to `update_logging()`. This has the downside that this logger cannot be reconfigured via the dict, but I currently cannot think of any case where that would be an immediate problem (the actual output level is set in the handlers anyway). On the other hand, by using `__package__` as an alias for `scopesim`, this actually becomes a tiny bit more flexible and more in line with the other loggers in scopesim all using the module `__name__` (which includes the package name). But this doesn't add any real benefit either. All things considered, I think it's fine like this for now. If we ever find a reason why it's not, we might want to change `NestedMapping` to allow `.` in key names generally.