### PR TITLE
Resolve recursive bang-strings

### DIFF
--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -65,5 +65,5 @@ from .tests.mocks.load_basic_instrument import load_example_optical_train
 
 try:
     __version__ = metadata.version(__package__)
-except:
-    version = 0.8
+except metadata.PackageNotFoundError:
+    __version__ = "undetermined"

--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -82,4 +82,7 @@ from .tests.mocks.load_basic_instrument import load_example_optical_train
 #                          VERSION INFORMATION                                #
 ###############################################################################
 
-__version__ = metadata.version(__package__)
+try:
+    __version__ = metadata.version(__package__)
+except:
+    version = 0.8

--- a/scopesim/effects/effects_utils.py
+++ b/scopesim/effects/effects_utils.py
@@ -41,7 +41,7 @@ def combine_surface_effects(surface_effects):
     surflist_list = [eff for eff in surface_effects
                      if isinstance(eff, efs.SurfaceList)]
     surf_list = [eff for eff in surface_effects
-                 if isinstance(eff, (efs.TERCurve, efs.FilterWheel))
+                 if isinstance(eff, (efs.TERCurve, efs.FilterWheelBase))
                  and not isinstance(eff, efs.SurfaceList)]
 
     if not surflist_list:

--- a/scopesim/effects/surface_list.py
+++ b/scopesim/effects/surface_list.py
@@ -3,7 +3,7 @@
 import numpy as np
 from astropy import units as u
 
-from .ter_curves import TERCurve
+from .ter_curves import TERCurve, FilterWheelBase
 from ..optics import radiometry_utils as rad_utils
 from ..optics.surface import PoorMansSurface
 from ..utils import quantify, from_currsys, figure_factory
@@ -119,7 +119,7 @@ class SurfaceList(TERCurve):
     def add_surface(self, surface, name=None, position=-1, add_to_table=True):
         if name is None:
             name = surface.meta.get("name", "<unknown surface>")
-        if isinstance(surface, TERCurve):
+        if isinstance(surface, (TERCurve, FilterWheelBase)):
             ter_meta = surface.meta
             surface = surface.surface
             surface.meta.update(ter_meta)

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -1,5 +1,4 @@
 """Transmission, emissivity, reflection curves."""
-import logging
 from collections.abc import Collection
 
 import numpy as np

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -1,5 +1,5 @@
 """Transmission, emissivity, reflection curves."""
-from collections.abc import Collection
+from collections.abc import Collection, Iterable
 
 import numpy as np
 import skycalc_ipy
@@ -220,7 +220,8 @@ class TERCurve(Effect):
         abbrs = {"t": "transmission", "e": "emission",
                  "r": "reflection", "x": "throughput"}
 
-        if not isinstance(axes, list):
+
+        if not isinstance(axes, Iterable):
             axes = [axes]
         for ter, ax in zip(which, axes):
             y_name = abbrs.get(ter, "throughput")

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -237,10 +237,20 @@ class OpticsManager:
     @property
     def surfaces_table(self):
         """Get combined surface table from effects with z_order = 100...199."""
-        if self._surfaces_table is None:
-            surface_like_effects = self.get_z_order_effects(100)
-            self._surfaces_table = combine_surface_effects(surface_like_effects)
-        return self._surfaces_table
+        from copy import deepcopy
+        sle_list = self.get_z_order_effects(100)
+        sle_list_copy = []
+        for eff in sle_list:
+            if isinstance(eff, efs.SurfaceList):
+                eff_copy = deepcopy(eff)
+                eff_copy.table = from_currsys(eff.table)
+            else:
+                # Avoid infinite recursion in Wheel effects (filter, adc)
+                eff_copy = eff
+            sle_list_copy += [eff_copy]
+
+        comb_table = combine_surface_effects(sle_list_copy)
+        return comb_table
 
     @property
     def all_effects(self):

--- a/scopesim/tests/test_utils_functions.py
+++ b/scopesim/tests/test_utils_functions.py
@@ -186,14 +186,11 @@ class TestFromCurrSys:
         assert utils.from_currsys({"seed": "!SIM.random.seed"})["seed"] is None
 
     def test_converts_layered_bang_strings(self):
-        old = rc.__currsys__["!SIM.sub_pixel.flag"]
-        rc.__currsys__["!SIM.sub_pixel.flag"] = "!SIM.sub_pixel.fraction"
-
-        result = utils.from_currsys("!SIM.sub_pixel.flag")
-        assert not isinstance(result, str)
-        assert result == 1
-
-        rc.__currsys__["!SIM.sub_pixel.flag"] = old
+        patched = {"!SIM.sub_pixel.flag": "!SIM.sub_pixel.fraction"}
+        with patch.dict("scopesim.rc.__currsys__", patched):
+            result = utils.from_currsys("!SIM.sub_pixel.flag")
+            assert not isinstance(result, str)
+            assert result == 1
 
     def test_converts_astropy_table(self):
         tbl = Table(data=[["!SIM.random.seed"]*2, ["!SIM.random.seed"]*2],
@@ -201,14 +198,11 @@ class TestFromCurrSys:
         assert utils.from_currsys(tbl["seeds2"][1]) is None
 
     def test_converts_string_numericals_to_floats(self):
-        old = rc.__currsys__["!SIM.sub_pixel.fraction"]
-        rc.__currsys__["!SIM.sub_pixel.fraction"] = "1e0"
-
-        result = utils.from_currsys("!SIM.sub_pixel.fraction")
-        assert isinstance(result, float)
-        assert result == 1
-
-        rc.__currsys__["!SIM.sub_pixel.flag"] = old
+        patched = {"!SIM.sub_pixel.fraction": "1e0"}
+        with patch.dict("scopesim.rc.__currsys__", patched):
+            result = utils.from_currsys("!SIM.sub_pixel.fraction")
+            assert isinstance(result, float)
+            assert result == 1
 
 
 # load_example_optical_train modifies __currsys__!

--- a/scopesim/tests/test_utils_functions.py
+++ b/scopesim/tests/test_utils_functions.py
@@ -185,6 +185,16 @@ class TestFromCurrSys:
     def test_converts_dict(self):
         assert utils.from_currsys({"seed": "!SIM.random.seed"})["seed"] is None
 
+    def test_converts_layered_bang_strings(self):
+        old = rc.__currsys__["!SIM.sub_pixel.flag"]
+        rc.__currsys__["!SIM.sub_pixel.flag"] = "!SIM.sub_pixel.fraction"
+
+        result = utils.from_currsys("!SIM.sub_pixel.flag")
+        assert not isinstance(result, str)
+        assert result == 1
+
+        rc.__currsys__["!SIM.sub_pixel.flag"] = old
+
     def test_converts_astropy_table(self):
         tbl = Table(data=[["!SIM.random.seed"]*2, ["!SIM.random.seed"]*2],
                     names=["seeds", "seeds2"])

--- a/scopesim/tests/test_utils_functions.py
+++ b/scopesim/tests/test_utils_functions.py
@@ -200,6 +200,15 @@ class TestFromCurrSys:
                     names=["seeds", "seeds2"])
         assert utils.from_currsys(tbl["seeds2"][1]) is None
 
+    def test_converts_string_numericals_to_floats(self):
+        old = rc.__currsys__["!SIM.sub_pixel.fraction"]
+        rc.__currsys__["!SIM.sub_pixel.fraction"] = "1e0"
+
+        result = utils.from_currsys("!SIM.sub_pixel.fraction")
+        assert isinstance(result, float)
+        assert result == 1
+
+        rc.__currsys__["!SIM.sub_pixel.flag"] = old
 
 
 # load_example_optical_train modifies __currsys__!

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -863,11 +863,18 @@ def from_currsys(item):
     if isinstance(item, str) and len(item) and item.startswith("!"):
         if item in rc.__currsys__:
             item = rc.__currsys__[item]
+            if isinstance(item, str) and item.startswith("!"):
+                item = from_currsys(item)
         else:
             raise ValueError(f"{item} was not found in rc.__currsys__")
 
-    if isinstance(item, str) and item.lower() == "none":
-        item = None
+    if isinstance(item, str):
+        if item.lower() == "none":
+            item = None
+        try:
+            item = float(item)
+        except:
+            pass
 
     return item
 

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -873,7 +873,7 @@ def from_currsys(item):
             item = None
         try:
             item = float(item)
-        except TypeError:
+        except (TypeError, ValueError):
             pass
 
     return item

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -873,7 +873,7 @@ def from_currsys(item):
             item = None
         try:
             item = float(item)
-        except:
+        except TypeError:
             pass
 
     return item

--- a/scopesim/version.py
+++ b/scopesim/version.py
@@ -1,2 +1,5 @@
 from importlib import metadata
-version = metadata.version(__package__)
+try:
+    version = metadata.version(__package__)
+except:
+    version = 0.8


### PR DESCRIPTION
Commit `13ac4db`
- Simple recursive call that (should) catch multi-level band-strings 
  (i.e. `temperature = !TEL.temperature = !ATMO.temperature = 7`)
- I also added a check to catch stringified floats, and turn them into floats. This is needed because when a single entry in a table column is a bang-string, and the other entries are floats, then astropy will read them all in as strings. And when the bang-string is resolved, it is reinserted as a string, rather than a float. This check solves that (I think)

Commit `7d8e3e6`
- Additions to several classes, primarily the `FilterWheelBase` class which enable it also be treated as a `TERCurve` in the context of the plotting routines and summary table helper functions in `OpticsManager`. These changes are (solely) cosmetic and shouldn't affect any of the real scopesim machinary.
