### PR TITLE
use tqdm.autonotebook

### DIFF
--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -7,7 +7,7 @@ The Effect is called `SpectralTraceList`, it applies a list of
 
 from itertools import cycle
 
-from tqdm import tqdm
+from tqdm.autonotebook import tqdm
 
 from astropy.io import fits
 from astropy.table import Table

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy.interpolate import interp1d
 from astropy import units as u
 
-from tqdm import tqdm
+from tqdm.autonotebook import tqdm
 
 from synphot.units import PHOTLAM
 
@@ -185,7 +185,7 @@ class OpticalTrain:
 
         # [3D - Atmospheric shifts, PSF, NCPAs, Grating shift/distortion]
         fovs = self.fov_manager.fovs
-        for fov in tqdm(fovs, desc=" FOVs", position=0):
+        for fov in tqdm(fovs, desc=" FOVs"):
             # print("FOV", fov_i+1, "of", n_fovs, flush=True)
             # .. todo: possible bug with bg flux not using plate_scale
             #          see fov_utils.combine_imagehdu_fields
@@ -194,7 +194,7 @@ class OpticalTrain:
             hdu_type = "cube" if self.fov_manager.is_spectroscope else "image"
             fov.view(hdu_type)
             for effect in tqdm(self.optics_manager.fov_effects,
-                               desc=" FOV effects", position=1, leave=False):
+                               desc=" FOV effects"):
                 fov = effect.apply_to(fov)
 
             fov.flatten()

--- a/scopesim/server/download_utils.py
+++ b/scopesim/server/download_utils.py
@@ -14,7 +14,7 @@ from shutil import get_terminal_size
 import httpx
 import bs4
 
-from tqdm import tqdm
+from tqdm.autonotebook import tqdm
 # from tqdm.contrib.logging import logging_redirect_tqdm
 # put with logging_redirect_tqdm(loggers=all_loggers): around tqdm
 


### PR DESCRIPTION
tqdm has special support for Jupyter notebooks in tqdm.notebook. It can also automatically select the right tqdm (the terminal or notebook one) with
```
from tqdm.autonotebook import tqdm
```

It looks much better:
![tqdmnotebook](https://github.com/AstarVienna/ScopeSim/assets/1306453/ddb37924-1a2f-47ec-91ec-563b065c1eba)

For completeness, the same notebook in the terminal:
![tqdmconsole](https://github.com/AstarVienna/ScopeSim/assets/1306453/e1f4b99c-ba71-4dfd-9d21-6785662e1234)

And the code:
```python
from tqdm import tqdm as tqdm_normal
from tqdm.notebook import tqdm as tqdm_notebook
from time import sleep

maxa = 2
maxb = 3
zzzz = 0.1

print()
print("normal without leave")
for aa in tqdm_normal(range(maxa), desc=" AA1", leave=False):
    for bb in tqdm_normal(range(maxb), desc=" BB1", leave=False):
        sleep(zzzz)

print()
print("normal with leave")
for aa in tqdm_normal(range(maxa), desc=" AA2", leave=True):
    for bb in tqdm_normal(range(maxb), desc=" BB2", leave=True):
        sleep(zzzz)

print()
print("notebook without leave")
for aa in tqdm_notebook(range(maxa), desc=" AA3", leave=False):
    for bb in tqdm_notebook(range(maxb), desc=" BB3", leave=False):
        sleep(zzzz)

print()
print("notebook with leave")
for aa in tqdm_notebook(range(maxa), desc=" AA4", leave=True):
    for bb in tqdm_notebook(range(maxb), desc=" BB4", leave=True):
        sleep(zzzz)
```

It was not really clear when we used `leave=False`, or why we specified a `position`. I think removing those arguments looks fine, but I'm also fine with using `leave=False` everywhere. The `position` argument seems to be mostly useful in a multi-threaded environment, which we don't have.