### PR TITLE
Delete redundant vesion.py

### DIFF
--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -1,12 +1,23 @@
 """Generalised telescope observation simulator."""
 
+from importlib import metadata
+
+###############################################################################
+#                          VERSION INFORMATION                                #
+###############################################################################
+
+try:
+    __version__ = metadata.version(__package__)
+except metadata.PackageNotFoundError:
+    __version__ = "undetermined"
+
+
 ###############################################################################
 #                            TURN OFF WARNINGS                                #
 ###############################################################################
 
 import warnings
 import yaml
-from importlib import metadata
 from astropy.utils.exceptions import AstropyWarning
 
 warnings.simplefilter('ignore', UserWarning)
@@ -58,12 +69,3 @@ from .server.database import (list_packages, download_packages, download_package
                               list_example_data, download_example_data)
 
 from .tests.mocks.load_basic_instrument import load_example_optical_train
-
-###############################################################################
-#                          VERSION INFORMATION                                #
-###############################################################################
-
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    __version__ = "undetermined"

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -19,8 +19,7 @@ from ..commands.user_commands import UserCommands
 from ..detector import DetectorArray
 from ..effects import ExtraFitsKeywords
 from ..utils import from_currsys, top_level_catch
-from ..version import version
-from .. import rc
+from .. import rc, __version__
 
 
 class OpticalTrain:
@@ -353,7 +352,7 @@ class OpticalTrain:
         # Primary hdu
         pheader = hdulist[0].header
         pheader["DATE"] = datetime.now().isoformat(timespec="seconds")
-        pheader["ORIGIN"] = "Scopesim " + version
+        pheader["ORIGIN"] = f"Scopesim {__version__}"
         pheader["INSTRUME"] = from_currsys("!OBS.instrument")
         pheader["INSTMODE"] = ", ".join(from_currsys("!OBS.modes"))
         pheader["TELESCOP"] = from_currsys("!TEL.telescope")

--- a/scopesim/version.py
+++ b/scopesim/version.py
@@ -1,5 +1,0 @@
-from importlib import metadata
-try:
-    version = metadata.version(__package__)
-except:
-    version = 0.8


### PR DESCRIPTION
After discussing with @astronomyk , we decided that the `__version__` variable in `__init__.py` is sufficient, similar to what we recently did in another package.