### PR TITLE
Replace printing with logging

### DIFF
--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -291,8 +291,9 @@ def check_for_updates(package_name):
         back_matter = f"api.php?package_name={package_name}"
         try:
             response = httpx.get(url=front_matter+back_matter).json()
-        except:
-            print(f"Offline. Cannot check for updates for {package_name}")
+        except httpx.HTTPError:
+            logger.warning("Offline. Cannot check for updates for %s.",
+                           package_name)
     return response
 
 

--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -63,7 +63,6 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
         #     spt.meta["ymax"] = self.slicelist["top"][sli]
 
         # if self._file is not None:
-        #     print(self._file)
         #     self.make_spectral_traces()
 
     def apply_to(self, obj, **kwargs):

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -143,7 +143,7 @@ class SpectralTrace:
                 self.dispersion_axis = "x"
             else:
                 self.dispersion_axis = "y"
-            logger.warning(
+            logger.info(
                 "Dispersion axis determined to be %s", self.dispersion_axis)
 
     def map_spectra_to_focal_plane(self, fov):

--- a/scopesim/optics/fov_utils.py
+++ b/scopesim/optics/fov_utils.py
@@ -376,7 +376,6 @@ def extract_area_from_imagehdu(imagehdu, fov_volume):
         # f0, f1 : the scaling factors for the blue and red edge cube slices
         #
         # w0, w1 = hdu_waves[i0p], hdu_waves[i1p]
-        # print(f"\nw0: {w0}, f0: {f0}, {fov_waves}, f1: {f1}, w1: {w1}")
 
         new_hdr.update({"NAXIS": 3,
                         "NAXIS3": data.shape[0],

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -1,5 +1,6 @@
+# -*- coding: utf-8 -*-
+
 import copy
-import sys
 
 from datetime import datetime
 
@@ -18,8 +19,11 @@ from .image_plane import ImagePlane
 from ..commands.user_commands import UserCommands
 from ..detector import DetectorArray
 from ..effects import ExtraFitsKeywords
-from ..utils import from_currsys, top_level_catch
+from ..utils import from_currsys, top_level_catch, get_logger
 from .. import rc, __version__
+
+
+logger = get_logger(__name__)
 
 
 class OpticalTrain:
@@ -185,7 +189,6 @@ class OpticalTrain:
         # [3D - Atmospheric shifts, PSF, NCPAs, Grating shift/distortion]
         fovs = self.fov_manager.fovs
         for fov in tqdm(fovs, desc=" FOVs", position=0):
-            # print("FOV", fov_i+1, "of", n_fovs, flush=True)
             # .. todo: possible bug with bg flux not using plate_scale
             #          see fov_utils.combine_imagehdu_fields
             fov.extract_from(source)
@@ -333,9 +336,10 @@ class OpticalTrain:
             else:
                 try:
                     hdul = self.write_header(hdul)
-                except Exception as error:
-                    print("\nWarning: header update failed, data will be saved with incomplete header.")
-                    print(f"Reason: {sys.exc_info()[0]} {error}\n")
+                except Exception:
+                    logger.exception("Header update failed, data will be "
+                                     "saved with incomplete header. See stack "
+                                     "trace for details.")
 
             if filename is not None and isinstance(filename, str):
                 fname = filename

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -289,10 +289,11 @@ class Source(SourceBase):
         try:
             bunit = u.Unit(bunit)
         except ValueError:
-            print(f"Astropy cannot parse BUNIT [{bunit}].\n"
-                  "You can bypass this check by passing an astropy Unit to "
-                  "the flux parameter:\n"
-                  ">>> Source(image_hdu=..., flux=u.Unit(bunit), ...)")
+            logger.error(
+                "Astropy cannot parse BUNIT [%s].\n"
+                "You can bypass this check by passing an astropy Unit to the "
+                "flux parameter:\n"
+                ">>> Source(image_hdu=..., flux=u.Unit(bunit), ...)", bunit)
 
         value = 0 if bunit in [u.mag, u.ABmag] else 1
         self._from_imagehdu_and_flux(image_hdu, value * bunit)
@@ -341,10 +342,10 @@ class Source(SourceBase):
             u.Unit(bunit)
         except KeyError:
             bunit = "erg / (s cm2 arcsec2)"
-            logger.warning("Keyword \"BUNIT\" not found, setting to %s by default",
-                           bunit)
-        except ValueError as errcode:
-            print("\"BUNIT\" keyword is malformed:", errcode)
+            logger.warning(
+                "Keyword \"BUNIT\" not found, setting to %s by default", bunit)
+        except ValueError as error:
+            logger.error("\"BUNIT\" keyword is malformed: %s", error)
             raise
 
         # Compute the wavelength vector. This will be attached to the cube_hdu


### PR DESCRIPTION
This removes most of the remaining `print()` calls and replaces them with an appropriate level logging call.

Also downgrading a log in `effects/spectral_trace_list_utils.py` from WARNING to INFO, because it's not warning about anything and was most likely just at that level because that used to be the default. I was quite certain I had already done that, but couldn't find the change locally. Anyway.