### PR TITLE
Further harmonize `filename` kwarg

### DIFF
--- a/scopesim/effects/data_container.py
+++ b/scopesim/effects/data_container.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from astropy.table import Table
 from astropy.io import ascii as ioascii
 from astropy.io import fits
@@ -61,6 +63,9 @@ class DataContainer:
     def __init__(self, filename=None, table=None, array_dict=None, **kwargs):
 
         if filename is None and "file_name" in kwargs:
+            warn("The 'file_name' kwarg is deprecated and will raise an error "
+                 "in the future, please use 'filename' instead!",
+                 DeprecationWarning, stacklevel=2)
             filename = kwargs["file_name"]
 
         filename = utils.find_file(filename)

--- a/scopesim/effects/electronic.py
+++ b/scopesim/effects/electronic.py
@@ -461,7 +461,7 @@ class LinearityCurve(Effect):
         - name: detector_linearity
           class: LinearityCurve
           kwargs:
-            file_name: FPA_linearity.dat
+            filename: FPA_linearity.dat
 
         - name: detector_linearity
           class: LinearityCurve

--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -308,7 +308,7 @@ class MetisLMSSpectralTrace(SpectralTrace):
         y_min = aperture["bottom"]
         y_max = aperture["top"]
 
-        layout = ioascii.read(find_file("!DET.layout.file_name"))
+        layout = ioascii.read(find_file("!DET.layout.filename"))
         det_lims = {}
         xhw = layout["pixel_size"] * layout["x_size"] / 2
         yhw = layout["pixel_size"] * layout["y_size"] / 2

--- a/scopesim/tests/mocks/MICADO_SCAO_WIDE/MICADO_IMG_SCAO_WIDE.yaml
+++ b/scopesim/tests/mocks/MICADO_SCAO_WIDE/MICADO_IMG_SCAO_WIDE.yaml
@@ -25,13 +25,13 @@ effects :
     effect_type : 1D_multiplication
     function_name : import_ter_curve
     kwargs : 
-        file_name : ter_atmo.fits
+        filename : ter_atmo.fits
 
 -   name : atmospheric_emission_map
     effect_type : 2D_multiplication
     function_name : import_multiplication_map
     kwargs : 
-        file_name : atmo_background_emission_map.fits
+        filename : atmo_background_emission_map.fits
         extension : 2
 
 ---
@@ -54,14 +54,14 @@ effects :
     effect_type : 3D_convolution
     function_name : import_psf_cube
     kwargs : 
-        file_name : PSF_MICADO_SCAO-FV_NIR.fits
+        filename : PSF_MICADO_SCAO-FV_NIR.fits
         field_varying : False
     
 -   name : telescope_surface_list
     effect_type : 1D_list
     function_name : import_ter_curve_list
     kwargs : 
-        file_name : elt_mirror_list.tbl
+        filename : elt_mirror_list.tbl
         
 -   name : telescope_vibration
     effect_type : 2D_convolution
@@ -81,7 +81,7 @@ effects :
     effect_type : 2D_distortion
     function_name : import_distortion_map
     kwargs : 
-        file_name : elt_distortion_map.fits
+        filename : elt_distortion_map.fits
         
 ---
 
@@ -100,13 +100,13 @@ effects :
     effect_type : 1D_list
     function_name : import_ter_curve_list
     kwargs : 
-        file_name : relay_mirror_list.tbl
+        filename : relay_mirror_list.tbl
         
 -   name : relay_distortion
     effect_type : 2D_distortion
     function_name : import_distortion_map
     kwargs : 
-        file_name : relay_distortion_map.fits
+        filename : relay_distortion_map.fits
 
         
 ---
@@ -128,25 +128,25 @@ effects :
     effect_type : 1D_list
     function_name : import_ter_curve_list
     kwargs : 
-        file_name : micado_mirror_list.tbl
+        filename : micado_mirror_list.tbl
       
 -   name : micado_distortion
     effect_type : 2D_distortion
     function_name : import_distortion_map
     kwargs : 
-        file_name : micado_distortion_map.fits
+        filename : micado_distortion_map.fits
         
 -   name : filter
     effect_type : 1D_multiplication
     function_name : import_ter_curve
     kwargs :
-        file_name : micado_Ks_filter.dat
+        filename : micado_Ks_filter.dat
         
 -   name : micado_ncpas
     effect_type : 3D_convolution
     function_name : import_ter_curve
     kwargs :
-        file_name : micado_Ks_filter.dat
+        filename : micado_Ks_filter.dat
         
 -   name : micado_adc
     effect_type : 3D_shift
@@ -172,13 +172,13 @@ effects :
     effect_type : 1D_multiplication
     function_name : import_ter_curve
     kwargs :
-        file_name : h4rg_QE.dat
+        filename : h4rg_QE.dat
     
 -   name : noise_frames
     effect_type : 0D_addition
     function_name : import_ter_curve
     kwargs :
-        file_name : h4rg_QE.dat
+        filename : h4rg_QE.dat
     
 -   name : micado_wide_chip_geometry.tbl
     effect_type : 2D_mask_list

--- a/scopesim/tests/mocks/py_objects/yaml_objects.py
+++ b/scopesim/tests/mocks/py_objects/yaml_objects.py
@@ -58,7 +58,7 @@ effects :
 -   name : micado_surface_list
     class : SurfaceList
     kwargs :
-        file_name : LIST_mirrors_MICADO_Wide.tbl
+        filename : LIST_mirrors_MICADO_Wide.tbl
 
 -   name : micado_adc
     class : AtmosphericDispersion

--- a/scopesim/tests/mocks/yamls/MICADO_full.yaml
+++ b/scopesim/tests/mocks/yamls/MICADO_full.yaml
@@ -221,7 +221,7 @@ effects :
     description : Quantum efficiency curves for each detector
     class : QuantumEfficiencyCurve
     kwargs :
-        file_name : QE_detector_H2RG.dat
+        filename : QE_detector_H2RG.dat
 
 -   name: dark_current
     description : MICADO dark current
@@ -244,4 +244,4 @@ effects :
     description : Readout noise frames
     class : ReadoutNoise
     kwargs :
-        file_name : FPA_noise.fits
+        filename : FPA_noise.fits

--- a/scopesim/tests/mocks/yamls/test_cfo.yaml
+++ b/scopesim/tests/mocks/yamls/test_cfo.yaml
@@ -11,4 +11,4 @@ effects :
 -   name : relay_surface_list
     class : SurfaceList
     kwargs :
-        file_name : relay_mirror_list.tbl
+        filename : relay_mirror_list.tbl

--- a/scopesim/tests/mocks/yamls/test_fpa.yaml
+++ b/scopesim/tests/mocks/yamls/test_fpa.yaml
@@ -12,9 +12,9 @@ effects :
 -   name : detector_qe_curve
     class : TERCurve
     kwargs :
-        file_name : h4rg_QE.dat
+        filename : h4rg_QE.dat
 
 -   name : micado_detector_geometry
     class : DetectorList
     kwargs:
-        file_name: micado_detector_geometry.tbl
+        filename: micado_detector_geometry.tbl

--- a/scopesim/tests/mocks/yamls/test_inst.yaml
+++ b/scopesim/tests/mocks/yamls/test_inst.yaml
@@ -12,7 +12,7 @@ effects :
 -   name : micado_surface_list
     class : SurfaceList
     kwargs :
-        file_name : micado_mirror_list.tbl
+        filename : micado_mirror_list.tbl
 
 -   name : micado_adc
     class : AtmosphericDispersion

--- a/scopesim/tests/mocks/yamls/test_scope.yaml
+++ b/scopesim/tests/mocks/yamls/test_scope.yaml
@@ -15,10 +15,10 @@ effects :
 -   name : telescope_psf
     class : FieldVaryingPsfFromFile
     kwargs :
-        file_name : PSF_MICADO_SCAO-FV_NIR.fits
+        filename : PSF_MICADO_SCAO-FV_NIR.fits
         field_varying : False
 
 -   name : telescope_surface_list
     class : SurfaceList
     kwargs :
-        file_name : elt_mirror_list.tbl
+        filename : elt_mirror_list.tbl


### PR DESCRIPTION
Following AstarVienna/irdb#147, this further harmonizes `file_name` to `filename` and throw a warning if the old one is still used, as suggested by @hugobuddel in that same PR.