### PR TITLE
Minor cleanup in `user_commands.py`

### DIFF
--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -99,15 +99,15 @@ class UserCommands:
     and ``yamls`` must be specified, otherwise scopesim will not know
     where to look for yaml files (only relevant if reading in yaml files)::
 
-        >>> from scopesim.server.database import download_package
-        >>> from scopesim.commands import UserCommands
-        >>>
-        >>> download_package("test_package")
-        >>> cmd = UserCommands(packages=["test_package"],
-        ...                    yamls=["test_telescope.yaml",
-        ...                           {"alias": "ATMO",
-        ...                            "properties": {"pwv": 9001}}],
-        ...                    properties={"!ATMO.pwv": 8999})
+    >>> from scopesim.server.database import download_package
+    >>> from scopesim.commands import UserCommands
+    >>>
+    >>> download_package("test_package")
+    >>> cmd = UserCommands(packages=["test_package"],
+    >>>                    yamls=["test_telescope.yaml",
+    >>>                           {"alias": "ATMO",
+    >>>                            "properties": {"pwv": 9001}}],
+    >>>                    properties={"!ATMO.pwv": 8999})
 
     Notes
     -----
@@ -128,14 +128,14 @@ class UserCommands:
         However, if you would still like to avoid your IP address being stored,
         you can run ``scopesim`` 100% anonymously by setting::
 
-            >>> scopsim.rc.__config__["!SIM.reports.ip_tracking"] = True
+        >>> scopsim.rc.__config__["!SIM.reports.ip_tracking"] = True
 
         at the beginning of each session. Alternatively you can also pass the
         same bang keyword when generating a ``UserCommand`` object::
 
-            >>> from scopesim import UserCommands
-            >>> UserCommands(use_instrument="MICADO",
-            >>>              properties={"!SIM.reports.ip_tracking": False})
+        >>> from scopesim import UserCommands
+        >>> UserCommands(use_instrument="MICADO",
+        >>>              properties={"!SIM.reports.ip_tracking": False})
 
         If you use a custom ``yaml`` configuration file, you can also add this
         keyword to the ``properties`` section of the ``yaml`` file.

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -289,7 +289,7 @@ def check_for_updates(package_name):
     # tracking **exclusively** your IP address for our internal stats
     if rc.__currsys__["!SIM.reports.ip_tracking"] and \
             "TRAVIS" not in os.environ:
-        front_matter = rc.__currsys__["!SIM.file.server_base_url"]
+        front_matter = str(rc.__currsys__["!SIM.file.server_base_url"])
         back_matter = f"api.php?package_name={package_name}"
         try:
             response = httpx.get(url=front_matter+back_matter).json()

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -104,10 +104,10 @@ class UserCommands:
     >>>
     >>> download_package("test_package")
     >>> cmd = UserCommands(packages=["test_package"],
-    >>>                    yamls=["test_telescope.yaml",
-    >>>                           {"alias": "ATMO",
-    >>>                            "properties": {"pwv": 9001}}],
-    >>>                    properties={"!ATMO.pwv": 8999})
+    ...                    yamls=["test_telescope.yaml",
+    ...                           {"alias": "ATMO",
+    ...                            "properties": {"pwv": 9001}}],
+    ...                    properties={"!ATMO.pwv": 8999})
 
     Notes
     -----

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -1,5 +1,4 @@
-import os
-import copy
+from copy import deepcopy
 from pathlib import Path
 from collections.abc import Mapping
 
@@ -146,7 +145,7 @@ class UserCommands:
     @top_level_catch
     def __init__(self, **kwargs):
 
-        self.cmds = copy.deepcopy(rc.__config__)
+        self.cmds = deepcopy(rc.__config__)
         self.yaml_dicts = []
         self.kwargs = kwargs
         self.ignore_effects = []
@@ -287,8 +286,7 @@ def check_for_updates(package_name):
     response = {}
 
     # tracking **exclusively** your IP address for our internal stats
-    if rc.__currsys__["!SIM.reports.ip_tracking"] and \
-            "TRAVIS" not in os.environ:
+    if rc.__currsys__["!SIM.reports.ip_tracking"]:
         front_matter = str(rc.__currsys__["!SIM.file.server_base_url"])
         back_matter = f"api.php?package_name={package_name}"
         try:

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -1,6 +1,7 @@
 import os
 import copy
 from pathlib import Path
+from collections.abc import Mapping
 
 import yaml
 import httpx
@@ -184,7 +185,7 @@ class UserCommands:
                     else:
                         logger.warning("%s could not be found", yaml_input)
 
-                elif isinstance(yaml_input, dict):
+                elif isinstance(yaml_input, Mapping):
                     self.cmds.update(yaml_input)
                     self.yaml_dicts.append(yaml_input)
 
@@ -240,7 +241,7 @@ class UserCommands:
         self.__init__(yamls=self.default_yamls)
 
     def list_modes(self):
-        if isinstance(self.modes_dict, dict):
+        if isinstance(self.modes_dict, Mapping):
             modes = {}
             for mode_name in self.modes_dict:
                 dic = self.modes_dict[mode_name]

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -135,7 +135,7 @@ class UserCommands:
 
         >>> from scopesim import UserCommands
         >>> UserCommands(use_instrument="MICADO",
-        >>>              properties={"!SIM.reports.ip_tracking": False})
+        ...              properties={"!SIM.reports.ip_tracking": False})
 
         If you use a custom ``yaml`` configuration file, you can also add this
         keyword to the ``properties`` section of the ``yaml`` file.


### PR DESCRIPTION
[5b64b00](https://github.com/AstarVienna/ScopeSim/pull/362/commits/5b64b00ae810b5cbbe0b8d1b4d433cd32b7c54e6) is the important one here, as that's the reason things fail in other places.

The rest is docstrings and typing, while already in this file...