### PR TITLE
Removing currsys as global parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ dist
 *TEST.fits
 *temp*
 *speclecado*.fits
+*inst_pkgs/
 
 # Spyder project settings
 .spyderproject

--- a/scopesim/detector/detector.py
+++ b/scopesim/detector/detector.py
@@ -12,12 +12,13 @@ logger = get_logger(__name__)
 
 
 class Detector(DetectorBase):
-    def __init__(self, header, **kwargs):
+    def __init__(self, header, cmds=None, **kwargs):
         image = np.zeros((header["NAXIS2"], header["NAXIS1"]))
         self._hdu = fits.ImageHDU(header=header, data=image)
         self.meta = {}
         self.meta.update(header)
         self.meta.update(kwargs)
+        self.cmds = cmds
 
     def extract_from(self, image_plane, spline_order=1, reset=True):
         if reset:
@@ -38,8 +39,8 @@ class Detector(DetectorBase):
         new_meta = stringify_dict(self.meta)
         self._hdu.header.update(new_meta)
 
-        pixel_scale = from_currsys("!INST.pixel_scale")
-        plate_scale = from_currsys("!INST.plate_scale")
+        pixel_scale = from_currsys("!INST.pixel_scale", self.cmds)
+        plate_scale = from_currsys("!INST.plate_scale", self.cmds)
         if pixel_scale == 0 or plate_scale == 0:
             logger.warning("Could not create sky WCS.")
         else:

--- a/scopesim/detector/detector_array.py
+++ b/scopesim/detector/detector_array.py
@@ -17,9 +17,10 @@ class DetectorArray:
     #       FOVManager and OpticsManager classes?
     # TODO: Either way this could inherit from some collections.abc
 
-    def __init__(self, detector_list=None, **kwargs):
+    def __init__(self, detector_list=None, cmds=None, **kwargs):
         self.meta = {}
         self.meta.update(kwargs)
+        self.cmds = cmds
 
         # The effect from which the instance is constructed
         self._detector_list = detector_list
@@ -82,7 +83,7 @@ class DetectorArray:
             image_plane = effect.apply_to(image_plane, **self.meta)
 
         # 3. make a series of Detectors for each row in a DetectorList object
-        self.detectors = [Detector(hdr, **self.meta)
+        self.detectors = [Detector(hdr, cmds=self.cmds, **self.meta)
                           for hdr in self._detector_list.detector_headers()]
 
         # 4. iterate through all Detectors, extract image from image_plane

--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -82,7 +82,7 @@ class ApertureMask(Effect):
                                                  "array_dict"]]):
             if "width" in kwargs and "height" in kwargs and \
                     "filename_format" in kwargs:
-                kwargs = from_currsys(kwargs)
+                kwargs = from_currsys(kwargs, self.cmds)
                 w, h = kwargs["width"], kwargs["height"]
                 kwargs["filename"] = kwargs["filename_format"].format(w, h)
 
@@ -147,7 +147,7 @@ class ApertureMask(Effect):
         return self._header
 
     def get_header(self):
-        self.meta = from_currsys(self.meta)
+        self.meta = from_currsys(self.meta, self.cmds)
         x = quantity_from_table("x", self.table, u.arcsec).to(u.deg).value
         y = quantity_from_table("y", self.table, u.arcsec).to(u.deg).value
         pix_scale_deg = self.meta["pixel_scale"] / 3600.
@@ -169,7 +169,7 @@ class ApertureMask(Effect):
         """
         For placing over FOVs if the Aperture is rotated w.r.t. the field.
         """
-        self.meta = from_currsys(self.meta)
+        self.meta = from_currsys(self.meta, self.cmds)
 
         if self.meta["no_mask"] is False:
             x = quantity_from_table("x", self.table, u.arcsec).to(u.deg).value
@@ -218,10 +218,10 @@ class RectangularApertureMask(ApertureMask):
 
     def get_table(self, **kwargs):
         self.meta.update(kwargs)
-        x = from_currsys(self.meta["x"])
-        y = from_currsys(self.meta["y"])
-        dx = 0.5 * from_currsys(self.meta["width"])
-        dy = 0.5 * from_currsys(self.meta["height"])
+        x = from_currsys(self.meta["x"], self.cmds)
+        y = from_currsys(self.meta["y"], self.cmds)
+        dx = 0.5 * from_currsys(self.meta["width"], self.cmds)
+        dy = 0.5 * from_currsys(self.meta["height"], self.cmds)
         xs = [x - dx, x + dx, x + dx, x - dx]
         ys = [y - dy, y - dy, y + dy, y + dy]
         tbl = Table(names=["x", "y"], data=[xs, ys], meta=self.meta)
@@ -446,7 +446,7 @@ class SlitWheel(Effect):
 
         path = self._get_path()
         self.slits = {}
-        for name in from_currsys(self.meta["slit_names"]):
+        for name in from_currsys(self.meta["slit_names"], self.cmds):
             kwargs["name"] = name
             fname = str(path).format(name)
             self.slits[name] = ApertureMask(filename=fname, **kwargs)
@@ -487,7 +487,7 @@ class SlitWheel(Effect):
     @property
     def current_slit(self):
         """Return the currently used slit."""
-        currslit = from_currsys(self.meta["current_slit"])
+        currslit = from_currsys(self.meta["current_slit"], self.cmds)
         if not currslit:
             return False
         return self.slits[currslit]

--- a/scopesim/effects/data_container.py
+++ b/scopesim/effects/data_container.py
@@ -58,10 +58,15 @@ class DataContainer:
 
     """
 
-    def __init__(self, filename=None, table=None, array_dict=None, **kwargs):
+    def __init__(self, filename=None, table=None, array_dict=None, cmds=None,
+                 **kwargs):
 
+        self.cmds = cmds
         if filename is None and "file_name" in kwargs:
             filename = kwargs["file_name"]
+
+        if isinstance(filename, str) and filename.startswith("!"):
+            filename = utils.from_currsys(filename, self.cmds)
 
         filename = utils.find_file(filename)
         self.meta = {"filename": filename,

--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -141,7 +141,7 @@ class DetectorList(Effect):
             xy_mm = calc_footprint(hdr, "D")
             pixel_size = hdr["CDELT1D"]              # mm
             pixel_scale = kwargs.get("pixel_scale", self.meta["pixel_scale"])   # ["]
-            pixel_scale = from_currsys(pixel_scale)
+            pixel_scale = from_currsys(pixel_scale, self.cmds)
 
             # x["] = x[mm] * ["] / [mm]
             xy_sky = xy_mm * pixel_scale / pixel_size
@@ -162,7 +162,7 @@ class DetectorList(Effect):
         aperture_mask = None
         if which == "edges":
             self.meta.update(kwargs)
-            self.meta = from_currsys(self.meta)
+            self.meta = from_currsys(self.meta, self.cmds)
 
             hdr = self.image_plane_header
             xy_mm = calc_footprint(hdr, "D")
@@ -221,7 +221,7 @@ class DetectorList(Effect):
         else:
             raise ValueError("Could not determine which detectors are active: "
                              f"{self.meta['active_detectors']}, {self.table},")
-        tbl = from_currsys(tbl)
+        tbl = from_currsys(tbl, self.cmds)
 
         return tbl
 
@@ -229,7 +229,7 @@ class DetectorList(Effect):
         if ids is not None and all(isinstance(ii, int) for ii in ids):
             self.meta["active_detectors"] = list(ids)
 
-        tbl = from_currsys(self.active_table)
+        tbl = from_currsys(self.active_table, self.cmds)
         hdrs = []
         for row in tbl:
             pixel_size = row["pixel_size"]

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -34,12 +34,11 @@ class Effect(DataContainer):
 
     """
 
-    def __init__(self, cmds=None, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.meta["z_order"] = []
         self.meta["include"] = True
         self.meta.update(kwargs)
-        self.cmds = cmds
 
     def apply_to(self, obj, **kwargs):
         """TBA."""

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -34,11 +34,12 @@ class Effect(DataContainer):
 
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, cmds=None, **kwargs):
         super().__init__(**kwargs)
         self.meta["z_order"] = []
         self.meta["include"] = True
         self.meta.update(kwargs)
+        self.cmds = cmds
 
     def apply_to(self, obj, **kwargs):
         """TBA."""
@@ -101,7 +102,7 @@ class Effect(DataContainer):
 
     @property
     def include(self):
-        return from_currsys(self.meta["include"])
+        return from_currsys(self.meta["include"], self.cmds)
 
     @include.setter
     def include(self, item):
@@ -112,7 +113,7 @@ class Effect(DataContainer):
         name = self.meta.get("name", self.meta.get("filename", "<untitled>"))
         if not hasattr(self, "_current_str"):
             return name
-        return f"{name} : [{from_currsys(self.meta[self._current_str])}]"
+        return f"{name} : [{from_currsys(self.meta[self._current_str], self.cmds)}]"
 
     @property
     def meta_string(self):
@@ -218,7 +219,7 @@ class Effect(DataContainer):
                   "changes_str": changes_str}
         params.update(self.meta)
         params.update(kwargs)
-        params = from_currsys(params)
+        params = from_currsys(params, self.cmds)
 
         rst_str = f"""
 {str(self)}
@@ -312,9 +313,9 @@ Meta-data
                 if item.endswith("!"):
                     key = item[1:-1]
                     if len(key) > 0:
-                        value = from_currsys(self.meta[key])
+                        value = from_currsys(self.meta[key], self.cmds)
                     else:
-                        value = from_currsys(self.meta)
+                        value = from_currsys(self.meta, self.cmds)
                 else:
                     value = self.meta[item[1:]]
             else:
@@ -328,4 +329,4 @@ Meta-data
         if any(key not in self.meta for key in ("path", "filename_format")):
             return None
         return Path(self.meta["path"],
-                    from_currsys(self.meta["filename_format"]))
+                    from_currsys(self.meta["filename_format"], self.cmds))

--- a/scopesim/effects/effects_utils.py
+++ b/scopesim/effects/effects_utils.py
@@ -71,7 +71,7 @@ def get_all_effects(effects, effect_class):
     return my_effects
 
 
-def make_effect(effect_dict, **properties):
+def make_effect(effect_dict, cmds=None, **properties):
     effect_meta_dict = {key: effect_dict[key] for key in effect_dict
                         if key not in ["class", "kwargs"]}
     effect_class_name = effect_dict["class"]
@@ -84,8 +84,7 @@ def make_effect(effect_dict, **properties):
     if "kwargs" in effect_dict:
         effect_kwargs.update(effect_dict["kwargs"])  # individual effect kwargs
 
-    effect = effect_cls(**effect_kwargs)
-    # effect.meta.update(effect_meta_dict)  # is this needed? Seems redundant
+    effect = effect_cls(cmds=cmds, **effect_kwargs)
 
     return effect
 

--- a/scopesim/effects/electronic.py
+++ b/scopesim/effects/electronic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Electronic detector effects - related to detector readout.
 
@@ -97,7 +96,8 @@ class DetectorModePropertiesSetter(Effect):
 
     def apply_to(self, obj, **kwargs):
         mode_name = kwargs.get("detector_readout_mode",
-                               from_currsys("!OBS.detector_readout_mode"))
+                               from_currsys("!OBS.detector_readout_mode",
+                                            self.cmds))
         if isinstance(obj, ImagePlaneBase) and mode_name == "auto":
             mode_name = self.select_mode(obj, **kwargs)
             print("Detector mode set to", mode_name)
@@ -123,7 +123,8 @@ class DetectorModePropertiesSetter(Effect):
         """
         immax = np.max(obj.data)
         fillfrac = kwargs.get("fill_frac",
-                              from_currsys("!OBS.auto_exposure.fill_frac"))
+                              from_currsys("!OBS.auto_exposure.fill_frac",
+                                           self.cmds))
 
         goodmodes = []
         goodron = []
@@ -190,20 +191,23 @@ class AutoExposure(Effect):
     def apply_to(self, obj, **kwargs):
         if isinstance(obj, (ImagePlaneBase, DetectorBase)):
             implane_max = np.max(obj.data)
-            exptime = kwargs.get("exptime", from_currsys("!OBS.exptime"))
-            mindit = from_currsys(self.meta["mindit"])
+            exptime = kwargs.get("exptime",
+                                 from_currsys("!OBS.exptime", self.cmds))
+            mindit = from_currsys(self.meta["mindit"], self.cmds)
 
             if exptime is None:
-                exptime = from_currsys("!OBS.dit") * from_currsys("!OBS.ndit")
+                exptime = from_currsys("!OBS.dit", self.cmds) * \
+                          from_currsys("!OBS.ndit", self.cmds)
             print(f"Requested exposure time: {exptime:.3f} s")
 
             if exptime < mindit:
                 print(f"    increased to MINDIT: {mindit:.3f} s")
                 exptime = mindit
 
-            full_well = from_currsys(self.meta["full_well"])
+            full_well = from_currsys(self.meta["full_well"], self.cmds)
             fill_frac = kwargs.get("fill_frac",
-                                   from_currsys(self.meta["fill_frac"]))
+                                   from_currsys(self.meta["fill_frac"],
+                                                self.cmds))
             dit = fill_frac * full_well / implane_max
 
             # np.ceil so that dit is at most what is required for fill_frac
@@ -212,8 +216,8 @@ class AutoExposure(Effect):
 
             # dit must be at least mindit, this might lead to saturation
             # ndit changed so that exptime is not exceeded (hence np.floor)
-            if dit < from_currsys(self.meta["mindit"]):
-                dit = from_currsys(self.meta["mindit"])
+            if dit < from_currsys(self.meta["mindit"], self.cmds):
+                dit = from_currsys(self.meta["mindit"], self.cmds)
                 ndit = int(np.floor(exptime / dit))
                 print("Warning: The detector will be saturated!")
                 # ..todo: turn into proper warning
@@ -242,8 +246,8 @@ class SummedExposure(Effect):
 
     def apply_to(self, obj, **kwargs):
         if isinstance(obj, DetectorBase):
-            dit = from_currsys(self.meta["dit"])
-            ndit = from_currsys(self.meta["ndit"])
+            dit = from_currsys(self.meta["dit"], self.cmds)
+            ndit = from_currsys(self.meta["ndit"], self.cmds)
 
             obj._hdu.data *= dit * ndit
 
@@ -264,7 +268,7 @@ class Bias(Effect):
 
     def apply_to(self, obj, **kwargs):
         if isinstance(obj, DetectorBase):
-            biaslevel = from_currsys(self.meta["bias"])
+            biaslevel = from_currsys(self.meta["bias"], self.cmds)
             obj._hdu.data += biaslevel
 
         return obj
@@ -288,11 +292,12 @@ class PoorMansHxRGReadoutNoise(Effect):
 
     def apply_to(self, det, **kwargs):
         if isinstance(det, DetectorBase):
-            self.meta["random_seed"] = from_currsys(self.meta["random_seed"])
+            self.meta["random_seed"] = from_currsys(self.meta["random_seed"],
+                                                    self.cmds)
             if self.meta["random_seed"] is not None:
                 np.random.seed(self.meta["random_seed"])
 
-            from_currsys(self.meta)
+            self.meta = from_currsys(self.meta, self.cmds)
             ron_keys = ["noise_std", "n_channels", "channel_fraction",
                         "line_fraction", "pedestal_fraction", "read_fraction"]
             ron_kwargs = {key: self.meta[key] for key in ron_keys}
@@ -335,11 +340,11 @@ class BasicReadoutNoise(Effect):
 
     def apply_to(self, det, **kwargs):
         if isinstance(det, DetectorBase):
-            ndit = from_currsys(self.meta["ndit"])
-            ron = from_currsys(self.meta["noise_std"])
+            ndit = from_currsys(self.meta["ndit"], self.cmds)
+            ron = from_currsys(self.meta["noise_std"], self.cmds)
             noise_std = ron * np.sqrt(float(ndit))
 
-            random_seed = from_currsys(self.meta["random_seed"])
+            random_seed = from_currsys(self.meta["random_seed"], self.cmds)
             if random_seed is not None:
                 np.random.seed(random_seed)
             det._hdu.data += np.random.normal(loc=0, scale=noise_std,
@@ -367,7 +372,8 @@ class ShotNoise(Effect):
 
     def apply_to(self, det, **kwargs):
         if isinstance(det, DetectorBase):
-            self.meta["random_seed"] = from_currsys(self.meta["random_seed"])
+            self.meta["random_seed"] = from_currsys(self.meta["random_seed"],
+                                                    self.cmds)
             if self.meta["random_seed"] is not None:
                 np.random.seed(self.meta["random_seed"])
 
@@ -417,25 +423,25 @@ class DarkCurrent(Effect):
 
     def apply_to(self, obj, **kwargs):
         if isinstance(obj, DetectorBase):
-            if isinstance(from_currsys(self.meta["value"]), dict):
+            if isinstance(from_currsys(self.meta["value"], self.cmds), dict):
                 dtcr_id = obj.meta[real_colname("id", obj.meta)]
-                dark = from_currsys(self.meta["value"][dtcr_id])
-            elif isinstance(from_currsys(self.meta["value"]), float):
-                dark = from_currsys(self.meta["value"])
+                dark = from_currsys(self.meta["value"][dtcr_id], self.cmds)
+            elif isinstance(from_currsys(self.meta["value"], self.cmds), float):
+                dark = from_currsys(self.meta["value"], self.cmds)
             else:
                 raise ValueError("<DarkCurrent>.meta['value'] must be either "
                                  f"dict or float, but is {self.meta['value']}")
 
-            dit = from_currsys(self.meta["dit"])
-            ndit = from_currsys(self.meta["ndit"])
+            dit = from_currsys(self.meta["dit"], self.cmds)
+            ndit = from_currsys(self.meta["ndit"], self.cmds)
 
             obj._hdu.data += dark * dit * ndit
 
         return obj
 
     def plot(self, det, **kwargs):
-        dit = from_currsys(self.meta["dit"])
-        ndit = from_currsys(self.meta["ndit"])
+        dit = from_currsys(self.meta["dit"], self.cmds)
+        ndit = from_currsys(self.meta["ndit"], self.cmds)
         total_time = dit * ndit
         times = np.linspace(0, 2*total_time, 10)
         dtcr = self.apply_to(det)
@@ -491,13 +497,15 @@ class LinearityCurve(Effect):
 
     def apply_to(self, obj, **kwargs):
         if isinstance(obj, DetectorBase):
-            ndit = from_currsys(self.meta["ndit"])
+            ndit = from_currsys(self.meta["ndit"], self.cmds)
             if self.table is not None:
                 incident = self.table["incident"] * ndit
                 measured = self.table["measured"] * ndit
             else:
-                incident = np.asarray(from_currsys(self.meta["incident"])) * ndit
-                measured = np.asarray(from_currsys(self.meta["measured"])) * ndit
+                incident = np.asarray(from_currsys(self.meta["incident"],
+                                                   self.cmds)) * ndit
+                measured = np.asarray(from_currsys(self.meta["measured"],
+                                                   self.cmds)) * ndit
             obj._hdu.data = np.interp(obj._hdu.data, incident, measured)
 
         return obj
@@ -505,7 +513,7 @@ class LinearityCurve(Effect):
     def plot(self, **kwargs):
         fig, ax = figure_factory()
 
-        ndit = from_currsys(self.meta["ndit"])
+        ndit = from_currsys(self.meta["ndit"], self.cmds)
         incident = self.table["incident"] * ndit
         measured = self.table["measured"] * ndit
 
@@ -558,7 +566,7 @@ class BinnedImage(Effect):
 
     def apply_to(self, det, **kwargs):
         if isinstance(det, DetectorBase):
-            bs = from_currsys(self.meta["bin_size"])
+            bs = from_currsys(self.meta["bin_size"], self.cmds)
             image = det._hdu.data
             h, w = image.shape
             new_image = image.reshape((h//bs, bs, w//bs, bs))
@@ -576,8 +584,8 @@ class UnequalBinnedImage(Effect):
 
     def apply_to(self, det, **kwargs):
         if isinstance(det, DetectorBase):
-            bx = from_currsys(self.meta["binx"])
-            by = from_currsys(self.meta["biny"])
+            bx = from_currsys(self.meta["binx"], self.cmds)
+            by = from_currsys(self.meta["biny"], self.cmds)
             image = det._hdu.data
             h, w = image.shape
             new_image = image.reshape((h//bx, bx, w//by, by))

--- a/scopesim/effects/psfs.py
+++ b/scopesim/effects/psfs.py
@@ -321,7 +321,7 @@ class GaussianDiffractionPSF(AnalyticalPSF):
 
     def fov_grid(self, which="waveset", **kwargs):
         """See parent docstring."""
-        logger.warn("The fov_grid method is deprecated and will be removed "
+        warnings.warn("The fov_grid method is deprecated and will be removed "
                       "in a future release.", DeprecationWarning, stacklevel=2)
         wavelengths = []
         if which == "waveset" and \

--- a/scopesim/effects/psfs.py
+++ b/scopesim/effects/psfs.py
@@ -15,10 +15,12 @@ from ..base_classes import ImagePlaneBase, FieldOfViewBase, FOVSetupBase
 from ..utils import (figure_grid_factory, from_currsys, quantify, figure_factory,
                      check_keys, get_logger)
 
+import warnings
+
 # TODO: directly import currsys stuff, replace utils.
 # DONE (KL 19.01.2024)
 
-#logger = get_logger()
+logger = get_logger(__name__)
 
 
 class PoorMansFOV:

--- a/scopesim/effects/psfs.py
+++ b/scopesim/effects/psfs.py
@@ -12,25 +12,25 @@ from .effects import Effect
 from . import ter_curves_utils as tu
 from . import psf_utils as pu
 from ..base_classes import ImagePlaneBase, FieldOfViewBase, FOVSetupBase
-from .. import utils
-from ..utils import figure_grid_factory
+from ..utils import (figure_grid_factory, from_currsys, quantify, figure_factory,
+                     check_keys)
 
 # TODO: directly import currsys stuff, replace utils.
+# DONE (KL 19.01.2024)
 
 
 class PoorMansFOV:
-    def __init__(self, recursion_call=False):
-        pixel_scale = utils.from_currsys("!INST.pixel_scale")
+    def __init__(self, pixel_scale, spec_dict, recursion_call=False):
         self.header = {"CDELT1": pixel_scale / 3600.,
                        "CDELT2": pixel_scale / 3600.,
                        "NAXIS": 2,
                        "NAXIS1": 128,
                        "NAXIS2": 128,
                        }
-        self.meta = utils.from_currsys("!SIM.spectral")
-        self.wavelength = self.meta["wave_mid"] * u.um
+        self.meta = spec_dict
+        self.wavelength = spec_dict["wave_mid"] * u.um
         if not recursion_call:
-            self.hdu = PoorMansFOV(recursion_call=True)
+            self.hdu = PoorMansFOV(pixel_scale, recursion_call=True)
 
 
 class PSF(Effect):
@@ -53,7 +53,7 @@ class PSF(Effect):
                   }
         self.meta.update(params)
         self.meta.update(kwargs)
-        self.meta = utils.from_currsys(self.meta)
+        self.meta = from_currsys(self.meta, self.cmds)
         self.convolution_classes = (FieldOfViewBase, ImagePlaneBase)
 
     def apply_to(self, obj, **kwargs):
@@ -63,7 +63,7 @@ class PSF(Effect):
             waveset = self._waveset
             if len(waveset) != 0:
                 waveset_edges = 0.5 * (waveset[:-1] + waveset[1:])
-                obj.split("wave", utils.quantify(waveset_edges, u.um).value)
+                obj.split("wave", quantify(waveset_edges, u.um).value)
 
         # 2. During observe: convolution
         elif isinstance(obj, self.convolution_classes):
@@ -78,7 +78,7 @@ class PSF(Effect):
                     kernel = pu.rotational_blur(kernel, rot_blur_angle)
 
                 # normalise psf kernel      KERNEL SHOULD BE normalised within get_kernel()
-                # if utils.from_currsys(self.meta["normalise_kernel"]) is True:
+                # if from_currsys(self.meta["normalise_kernel"], self.cmds):
                 #    kernel /= np.sum(kernel)
                 #    kernel[kernel < 0.] = 0.
 
@@ -88,7 +88,7 @@ class PSF(Effect):
                 bkg_level = pu.get_bkg_level(image, self.meta["bkg_width"])
 
                 # do the convolution
-                mode = utils.from_currsys(self.meta["convolve_mode"])
+                mode = from_currsys(self.meta["convolve_mode"], self.cmds)
 
                 if image.ndim == 2 and kernel.ndim == 2:
                     new_image = convolve(image - bkg_level, kernel, mode=mode)
@@ -140,7 +140,7 @@ class PSF(Effect):
 
     def plot(self, obj=None, **kwargs):
         from matplotlib.colors import LogNorm
-        fig, axes = utils.figure_factory()
+        fig, axes = figure_factory()
 
         kernel = self.get_kernel(obj)
         axes.imshow(kernel, norm=LogNorm(), origin="lower", **kwargs)
@@ -168,12 +168,12 @@ class Vibration(AnalyticalPSF):
         self.convolution_classes = ImagePlaneBase
 
         self.required_keys = ["fwhm", "pixel_scale"]
-        utils.check_keys(self.meta, self.required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
         self.kernel = None
 
     def get_kernel(self, obj):
         if self.kernel is None:
-            utils.from_currsys(self.meta)
+            from_currsys(self.meta, self.cmds)
             fwhm_pix = self.meta["fwhm"] / self.meta["pixel_scale"]
             sigma = fwhm_pix / 2.35
             width = max(1, int(fwhm_pix * self.meta["width_n_fwhms"]))
@@ -206,20 +206,20 @@ class NonCommonPathAberration(AnalyticalPSF):
 
         self.convolution_classes = FieldOfViewBase
         self.required_keys = ["pixel_scale"]
-        utils.check_keys(self.meta, self.required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
 
     def fov_grid(self, which="waveset", **kwargs):
         """See parent docstring."""
         if which == "waveset":
             self.meta.update(kwargs)
-            self.meta = utils.from_currsys(self.meta)
+            self.meta = from_currsys(self.meta, self.cmds)
 
             min_sr = pu.wfe2strehl(self.total_wfe, self.meta["wave_min"])
             max_sr = pu.wfe2strehl(self.total_wfe, self.meta["wave_max"])
 
             srs = np.arange(min_sr, max_sr, self.meta["strehl_drift"])
             waves = 6.2831853 * self.total_wfe * (-np.log(srs))**-0.5
-            waves = utils.quantify(waves, u.um).value
+            waves = quantify(waves, u.um).value
             waves = (list(waves) + [self.meta["wave_max"]]) * u.um
         else:
             waves = [] * u.um
@@ -253,10 +253,10 @@ class NonCommonPathAberration(AnalyticalPSF):
         return self._total_wfe
 
     def plot(self):
-        fig, axes = utils.figure_factory()
+        fig, axes = figure_factory()
 
-        wave_min, wave_max = utils.from_currsys([self.meta["wave_min"],
-                                                 self.meta["wave_max"]])
+        wave_min, wave_max = from_currsys([self.meta["wave_min"],
+                                           self.meta["wave_max"]], self.cmds)
         waves = np.linspace(wave_min, wave_max, 1001) * u.um
         wfe = self.total_wfe
         strehl = pu.wfe2strehl(wfe=wfe, wave=waves)
@@ -290,7 +290,7 @@ class SeeingPSF(AnalyticalPSF):
     #     if which == "waveset" and \
     #             "waverange" in kwargs and \
     #             "pixel_scale" in kwargs:
-    #         waverange = utils.quantify(kwargs["waverange"], u.um)
+    #         waverange = quantify(kwargs["waverange"], u.um)
     #         wavelengths = waverange
     #         # ..todo: return something useful
     #
@@ -301,10 +301,10 @@ class SeeingPSF(AnalyticalPSF):
         # called by .apply_to() from the base PSF class
 
         pixel_scale = fov.header["CDELT1"] * u.deg.to(u.arcsec)
-        pixel_scale = utils.quantify(pixel_scale, u.arcsec)
+        pixel_scale = quantify(pixel_scale, u.arcsec)
 
         # add in the conversion to fwhm from seeing and wavelength here
-        fwhm = utils.from_currsys(self.meta["fwhm"]) * u.arcsec / pixel_scale
+        fwhm = from_currsys(self.meta["fwhm"], self.cmds) * u.arcsec / pixel_scale
 
         sigma = fwhm.value / 2.35
         kernel = Gaussian2DKernel(sigma, mode="center").array
@@ -313,7 +313,9 @@ class SeeingPSF(AnalyticalPSF):
         return kernel
 
     def plot(self):
-        return super().plot(PoorMansFOV())
+        pixel_scale = from_currsys("!INST.pixel_scale", self.cmds)
+        spec_dict = from_currsys("!SIM.spectral", self.cmds)
+        return super().plot(PoorMansFOV(pixel_scale, spec_dict))
 
 
 class GaussianDiffractionPSF(AnalyticalPSF):
@@ -328,11 +330,11 @@ class GaussianDiffractionPSF(AnalyticalPSF):
         if which == "waveset" and \
                 "waverange" in kwargs and \
                 "pixel_scale" in kwargs:
-            waverange = utils.quantify(kwargs["waverange"], u.um)
-            diameter = utils.quantify(self.meta["diameter"], u.m).to(u.um)
+            waverange = quantify(kwargs["waverange"], u.um)
+            diameter = quantify(self.meta["diameter"], u.m).to(u.um)
             fwhm = 1.22 * (waverange / diameter).value  # in rad
 
-            pixel_scale = utils.quantify(kwargs["pixel_scale"], u.deg)
+            pixel_scale = quantify(kwargs["pixel_scale"], u.deg)
             pixel_scale = pixel_scale.to(u.rad).value
             fwhm_range = np.arange(fwhm[0], fwhm[1], pixel_scale)
             wavelengths = list(fwhm_range / 1.22 * diameter.to(u.m))
@@ -348,12 +350,12 @@ class GaussianDiffractionPSF(AnalyticalPSF):
         # called by .apply_to() from the base PSF class
 
         pixel_scale = fov.header["CDELT1"] * u.deg.to(u.arcsec)
-        pixel_scale = utils.quantify(pixel_scale, u.arcsec)
+        pixel_scale = quantify(pixel_scale, u.arcsec)
 
         wave = 0.5 * (fov.meta["wave_max"] + fov.meta["wave_min"])
 
-        wave = utils.quantify(wave, u.um)
-        diameter = utils.quantify(self.meta["diameter"], u.m).to(u.um)
+        wave = quantify(wave, u.um)
+        diameter = quantify(self.meta["diameter"], u.m).to(u.um)
         fwhm = 1.22 * (wave / diameter) * u.rad.to(u.arcsec) / pixel_scale
 
         sigma = fwhm.value / 2.35
@@ -363,7 +365,9 @@ class GaussianDiffractionPSF(AnalyticalPSF):
         return kernel
 
     def plot(self):
-        return super().plot(PoorMansFOV())
+        pixel_scale = from_currsys("!INST.pixel_scale", self.cmds)
+        spec_dict = from_currsys("!SIM.spectral", self.cmds)
+        return super().plot(PoorMansFOV(pixel_scale, spec_dict))
 
 
 ##############################################################################
@@ -444,7 +448,7 @@ class AnisocadoConstPSF(SemiAnalyticalPSF):
         self.meta.update(kwargs)
 
         self.required_keys = ["filename", "strehl", "wavelength"]
-        utils.check_keys(self.meta, self.required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
         self.nmRms      # check to see if it throws an error
 
         self._psf_object = None
@@ -490,10 +494,10 @@ class AnisocadoConstPSF(SemiAnalyticalPSF):
 
     @property
     def wavelength(self):
-        wave = utils.from_currsys(self.meta["wavelength"])
+        wave = from_currsys(self.meta["wavelength"], self.cmds)
         if isinstance(wave, str) and wave in tu.FILTER_DEFAULTS:
             wave = tu.get_filter_effective_wavelength(wave)
-        wave = utils.quantify(wave, u.um).value
+        wave = quantify(wave, u.um).value
 
         return wave
 
@@ -507,7 +511,7 @@ class AnisocadoConstPSF(SemiAnalyticalPSF):
 
     @property
     def nmRms(self):
-        strehl = utils.from_currsys(self.meta["strehl"])
+        strehl = from_currsys(self.meta["strehl"], self.cmds)
         wave = self.wavelength
         hdu = self._file[0]
         nm_rms = pu.nmrms_from_strehl_and_wavelength(strehl, wave, hdu)
@@ -522,7 +526,7 @@ class AnisocadoConstPSF(SemiAnalyticalPSF):
             wspace=0.05, hspace=0.05)
         # or no height_ratios and bottom=0.1, top=0.9
 
-        pixel_scale = utils.from_currsys("!INST.pixel_scale")
+        pixel_scale = from_currsys("!INST.pixel_scale", self.cmds)
         kernel = self.get_kernel(pixel_scale)
 
         ax = fig.add_subplot(gs[0, 0])
@@ -594,7 +598,7 @@ class FieldConstantPSF(DiscretePSF):
         super().__init__(**kwargs)
 
         self.required_keys = ["filename"]
-        utils.check_keys(self.meta, self.required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
 
         self.meta["z_order"] = [262, 662]
         self._waveset, self.kernel_indexes = pu.get_psf_wave_exts(
@@ -701,7 +705,9 @@ class FieldConstantPSF(DiscretePSF):
         # fits.writeto("test_psfcube.fits", data=self.kernel, overwrite=True)
 
     def plot(self):
-        return super().plot(PoorMansFOV())
+        pixel_scale = from_currsys("!INST.pixel_scale", self.cmds)
+        spec_dict = from_currsys("!SIM.spectral", self.cmds)
+        return super().plot(PoorMansFOV(pixel_scale, spec_dict))
 
 
 class FieldVaryingPSF(DiscretePSF):
@@ -721,7 +727,7 @@ class FieldVaryingPSF(DiscretePSF):
         super().__init__(**kwargs)
 
         self.required_keys = ["filename"]
-        utils.check_keys(self.meta, self.required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
 
         self.meta["z_order"] = [261, 661]
 
@@ -849,4 +855,6 @@ class FieldVaryingPSF(DiscretePSF):
         return self._strehl_imagehdu
 
     def plot(self):
-        return super().plot(PoorMansFOV())
+        pixel_scale = from_currsys("!INST.pixel_scale", self.cmds)
+        spec_dict = from_currsys("!SIM.spectral", self.cmds)
+        return super().plot(PoorMansFOV(pixel_scale, spec_dict))

--- a/scopesim/effects/shifts.py
+++ b/scopesim/effects/shifts.py
@@ -35,7 +35,8 @@ class Shift3D(Effect):
         if self.table is None:
             names = ["wavelength", "dx", "dy"]
             waves = from_currsys(["!SIM.spectral.wave_" + key
-                                  for key in ("min", "mid", "max")])
+                                  for key in ("min", "mid", "max")],
+                                 self.cmds)
             tbl = Table(names=names, data=[waves, [0] * 3, [0] * 3])
         else:
             tbl = self.table

--- a/scopesim/effects/shifts.py
+++ b/scopesim/effects/shifts.py
@@ -132,7 +132,7 @@ class AtmosphericDispersion(Shift3D):
         if len(kwargs) > 0:
             self.meta.update(kwargs)
 
-        airmass = from_currsys(self.meta["airmass"])
+        airmass = from_currsys(self.meta["airmass"], self.cmds)
         atmo_params = {"z0": airmass2zendist(airmass),
                        "temp": self.meta["temperature"],  # in degC
                        "rel_hum": self.meta["humidity"] * 100,  # in %
@@ -140,7 +140,7 @@ class AtmosphericDispersion(Shift3D):
                        "lat": self.meta["latitude"],  # in deg
                        "h": self.meta["altitude"]}  # in m
         self.meta.update(atmo_params)
-        params = from_currsys(self.meta)
+        params = from_currsys(self.meta, self.cmds)
 
         waves, shifts = get_pixel_border_waves_from_atmo_disp(**params)
         dx = shifts * np.sin(np.deg2rad(params["pupil_angle"]))
@@ -194,7 +194,7 @@ class AtmosphericDispersionCorrection(Shift3D):
         # correct fovs CRPIXnD keys
 
         if isinstance(fov, self.apply_to_classes):
-            self.meta = from_currsys(self.meta)
+            self.meta = from_currsys(self.meta, self.cmds)
             atmo_params = {"z0": airmass2zendist(self.meta["airmass"]),
                            "temp": self.meta["temperature"],  # in degC
                            "rel_hum": self.meta["humidity"] * 100,  # in %

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -220,7 +220,7 @@ class SpectralTraceList(Effect):
     @property
     def image_plane_header(self):
         x, y = self.footprint
-        pixel_scale = from_currsys(self.meta["pixel_scale"])
+        pixel_scale = from_currsys(self.meta["pixel_scale"], self.cmds)
         hdr = header_from_list_of_xy(x, y, pixel_scale, "D")
 
         return hdr
@@ -259,13 +259,13 @@ class SpectralTraceList(Effect):
         # keywords for the filter... We try to make it work for METIS
         # and MICADO for the time being.
         try:
-            filter_name = from_currsys("!OBS.filter_name")
+            filter_name = from_currsys("!OBS.filter_name", self.cmds)
         except ValueError:
-            filter_name = from_currsys("!OBS.filter_name_fw1")
+            filter_name = from_currsys("!OBS.filter_name_fw1", self.cmds)
 
         filtcurve = FilterCurve(
             filter_name=filter_name,
-            filename_format=from_currsys("!INST.filter_file_format"))
+            filename_format=from_currsys("!INST.filter_file_format", self.cmds))
         filtwaves = filtcurve.table["wavelength"]
         filtwave = filtwaves[filtcurve.table["transmission"] > 0.01]
         wave_min, wave_max = min(filtwave), max(filtwave)
@@ -296,7 +296,7 @@ class SpectralTraceList(Effect):
         pdu = fits.PrimaryHDU()
         pdu.header["FILETYPE"] = "Rectified spectra"
         # pdu.header["INSTRUME"] = inhdul[0].header["HIERARCH ESO OBS INSTRUME"]
-        # pdu.header["FILTER"] = from_currsys("!OBS.filter_name_fw1")
+        # pdu.header["FILTER"] = from_currsys("!OBS.filter_name_fw1", self.cmds)
         outhdul = fits.HDUList([pdu])
 
         for i, trace_id in tqdm(enumerate(self.spectral_traces, start=1),
@@ -341,9 +341,9 @@ class SpectralTraceList(Effect):
 
         """
         if wave_min is None:
-            wave_min = from_currsys("!SIM.spectral.wave_min")
+            wave_min = from_currsys("!SIM.spectral.wave_min", self.cmds)
         if wave_max is None:
-            wave_max = from_currsys("!SIM.spectral.wave_max")
+            wave_max = from_currsys("!SIM.spectral.wave_max", self.cmds)
 
         if axes is None:
             fig, axes = figure_factory()
@@ -447,7 +447,7 @@ class SpectralTraceListWheel(Effect):
 
         path = self._get_path()
         self.trace_lists = {}
-        for name in from_currsys(self.meta["trace_list_names"]):
+        for name in from_currsys(self.meta["trace_list_names"], self.cmds):
             kwargs["name"] = name
             fname = str(path).format(name)
             self.trace_lists[name] = SpectralTraceList(filename=fname,
@@ -460,7 +460,8 @@ class SpectralTraceListWheel(Effect):
     @property
     def current_trace_list(self):
         trace_list_eff = None
-        trace_list_name = from_currsys(self.meta["current_trace_list"])
+        trace_list_name = from_currsys(self.meta["current_trace_list"],
+                                       self.cmds)
         if trace_list_name is not None:
             trace_list_eff = self.trace_lists[trace_list_name]
         return trace_list_eff

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -141,8 +141,7 @@ class SpectralTraceList(Effect):
             params = {col: row[col] for col in row.colnames}
             params.update(self.meta)
             hdu = self._file[row["extension_id"]]
-            spec_traces[row["description"]] = SpectralTrace(hdu, cmds=self.cmds,
-                                                            **params)
+            spec_traces[row["description"]] = SpectralTrace(hdu, **params)
 
         self.spectral_traces = spec_traces
 

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -141,7 +141,8 @@ class SpectralTraceList(Effect):
             params = {col: row[col] for col in row.colnames}
             params.update(self.meta)
             hdu = self._file[row["extension_id"]]
-            spec_traces[row["description"]] = SpectralTrace(hdu, **params)
+            spec_traces[row["description"]] = SpectralTrace(hdu, cmds=self.cmds,
+                                                            **params)
 
         self.spectral_traces = spec_traces
 
@@ -451,6 +452,7 @@ class SpectralTraceListWheel(Effect):
             kwargs["name"] = name
             fname = str(path).format(name)
             self.trace_lists[name] = SpectralTraceList(filename=fname,
+                                                       cmds=self.cmds,
                                                        **kwargs)
 
     def apply_to(self, obj, **kwargs):

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -54,13 +54,14 @@ class SpectralTrace:
                      "pixel_size": None,
                      "description": "<no description>"}
 
-    def __init__(self, trace_tbl, **kwargs):
+    def __init__(self, trace_tbl, cmds=None, **kwargs):
         # Within scopesim, the actual parameter values are
         # passed as kwargs from the SpectralTraceList.
         # The values need to be here for stand-alone use.
         self.meta = {}
         self.meta.update(self._class_params)
         self.meta.update(kwargs)
+        self.cmds = cmds
 
         if isinstance(trace_tbl, (fits.BinTableHDU, fits.TableHDU)):
             self.table = Table.read(trace_tbl)
@@ -329,7 +330,7 @@ class SpectralTrace:
             bin_width = np.abs(self.dlam_per_pix.y).min()
         logger.info("   Bin width %.02g um", bin_width)
 
-        pixscale = from_currsys(self.meta["pixel_scale"])
+        pixscale = from_currsys(self.meta["pixel_scale"], self.cmds)
 
         # Temporary solution to get slit length
         xi_min = kwargs.get("xi_min", None)
@@ -614,8 +615,8 @@ class SpectralTrace:
             dlam_grad = self.xy2lam.gradient()[0]  # dlam_by_dx
         else:
             dlam_grad = self.xy2lam.gradient()[1]  # dlam_by_dy
-        pixsize = (from_currsys(self.meta["pixel_scale"]) /
-                   from_currsys(self.meta["plate_scale"]))
+        pixsize = (from_currsys(self.meta["pixel_scale"], self.cmds) /
+                   from_currsys(self.meta["plate_scale"], self.cmds))
         self.dlam_per_pix = interp1d(lam,
                                      dlam_grad(x_mm, y_mm) * pixsize,
                                      fill_value="extrapolate")

--- a/scopesim/effects/surface_list.py
+++ b/scopesim/effects/surface_list.py
@@ -29,7 +29,7 @@ class SurfaceList(TERCurve):
         wave_edges = []
         if which == "waveset":
             self.meta.update(kwargs)
-            self.meta = from_currsys(self.meta)
+            self.meta = from_currsys(self.meta, self.cmds)
             wave_min = quantify(self.meta["wave_min"], u.um)
             wave_max = quantify(self.meta["wave_max"], u.um)
             # ..todo:: add 1001 to default.yaml somewhere
@@ -58,7 +58,8 @@ class SurfaceList(TERCurve):
     def emission(self):
         if "etendue" not in self.meta:
             raise ValueError("self.meta['etendue'] must be set")
-        etendue = quantify(from_currsys(self.meta["etendue"]), "m2 arcsec2")
+        etendue = quantify(from_currsys(self.meta["etendue"], self.cmds),
+                           "m2 arcsec2")
         if self._emission is None:
             self._emission = self.get_emission(etendue)
 

--- a/scopesim/effects/surface_list.py
+++ b/scopesim/effects/surface_list.py
@@ -20,7 +20,8 @@ class SurfaceList(TERCurve):
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        self.surfaces = rad_utils.make_surface_dict_from_table(self.table)
+        tbl = from_currsys(self.table, self.cmds)
+        self.surfaces = rad_utils.make_surface_dict_from_table(tbl)
         self._surface = None
         self._throughput = None
         self._emission = None

--- a/scopesim/effects/surface_list.py
+++ b/scopesim/effects/surface_list.py
@@ -133,8 +133,8 @@ class SurfaceList(TERCurve):
     def add_surface_list(self, surface_list, prepend=False):
         if isinstance(surface_list, SurfaceList):
             self.surfaces.update(surface_list.surfaces)
-            self.table = rad_utils.combine_tables(surface_list.table,
-                                                  self.table, prepend)
+            new_tbl = from_currsys(surface_list.table, self.cmds),
+            self.table = rad_utils.combine_tables(new_tbl, self.table, prepend)
 
     def plot(self, which="x", wavelength=None, *, axes=None, **kwargs):
         """Plot TER curves.

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -396,11 +396,12 @@ class FilterCurve(TERCurve):
     """
 
     def __init__(self, **kwargs):
+        # super().__init__(**kwargs)
         if not np.any([key in kwargs for key in ["filename", "table",
                                                  "array_dict"]]):
             if "filter_name" in kwargs and "filename_format" in kwargs:
-                filt_name = from_currsys(kwargs["filter_name"], self.cmds)
-                file_format = from_currsys(kwargs["filename_format"], self.cmds)
+                filt_name = from_currsys(kwargs["filter_name"], kwargs["cmds"])
+                file_format = from_currsys(kwargs["filename_format"], kwargs["cmds"])
                 kwargs["filename"] = file_format.format(filt_name)
             else:
                 raise ValueError("FilterCurve must be passed one of "

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -508,6 +508,7 @@ class TopHatFilterCurve(FilterCurve):
     def __init__(self, **kwargs):
         required_keys = ["transmission", "blue_cutoff", "red_cutoff"]
         check_keys(kwargs, required_keys, action="error")
+        self.cmds = kwargs.get("cmds", None)
 
         wave_min = from_currsys("!SIM.spectral.wave_min", self.cmds)
         wave_max = from_currsys("!SIM.spectral.wave_max", self.cmds)
@@ -522,7 +523,7 @@ class TopHatFilterCurve(FilterCurve):
         tbl = Table(names=["wavelength", "transmission"],
                     data=[waveset, transmission])
         super().__init__(table=tbl, wavelength_unit="um",
-                         action="transmission")
+                         action="transmission", cmds=self.cmds)
         self.meta.update(kwargs)
 
 

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -863,10 +863,11 @@ class PupilTransmission(TERCurve):
     The emissivity is set to zero, assuming that the mask is cold.
     """
 
-    def __init__(self, transmission, **kwargs):
+    def __init__(self, transmission, cmds=None, **kwargs):
         self.params = {"wave_min": "!SIM.spectral.wave_min",
                        "wave_max": "!SIM.spectral.wave_max"}
         self.params.update(kwargs)
+        self.cmds = cmds
         wave_min = from_currsys(self.params["wave_min"], self.cmds) * u.um
         wave_max = from_currsys(self.params["wave_max"], self.cmds) * u.um
         transmission = from_currsys(transmission)

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -43,7 +43,7 @@ class FieldOfView(FieldOfViewBase):
 
     """
 
-    def __init__(self, header, waverange, detector_header=None, **kwargs):
+    def __init__(self, header, waverange, detector_header=None, cmds=None, **kwargs):
         self.meta = {
             "id": None,
             "wave_min": quantify(waverange[0], u.um),
@@ -64,6 +64,8 @@ class FieldOfView(FieldOfViewBase):
             "aperture_id": None,
         }
         self.meta.update(kwargs)
+
+        self.cmds = cmds
 
         if not any((has_needed_keywords(header, s) for s in ["", "S"])):
             raise ValueError(
@@ -365,7 +367,7 @@ class FieldOfView(FieldOfViewBase):
             [ph s-1 pixel-1] or PHOTLAM (if use_photlam=True)
 
         """
-        spline_order = from_currsys("!SIM.computing.spline_order", self.cmds)
+        spline_order = from_currsys("!SIM.computing.spline_order")
 
         # Make waveset and canvas image
         fov_waveset = self.waveset

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -321,7 +321,7 @@ class FieldOfView(FieldOfViewBase):
             xpix, ypix = imp_utils.val2pix(self.header,
                                            field["x"] / 3600,
                                            field["y"] / 3600)
-            if from_currsys(self.meta["sub_pixel"]):
+            if from_currsys(self.meta["sub_pixel"], self.cmds):
                 for idx, row in enumerate(field):
                     xs, ys, fracs = imp_utils.sub_pixel_fractions(xpix[idx],
                                                                   ypix[idx])
@@ -365,13 +365,13 @@ class FieldOfView(FieldOfViewBase):
             [ph s-1 pixel-1] or PHOTLAM (if use_photlam=True)
 
         """
-        spline_order = from_currsys("!SIM.computing.spline_order")
+        spline_order = from_currsys("!SIM.computing.spline_order", self.cmds)
 
         # Make waveset and canvas image
         fov_waveset = self.waveset
         bin_widths = np.diff(fov_waveset)       # u.um
         bin_widths = 0.5 * (np.r_[0, bin_widths] + np.r_[bin_widths, 0])
-        area = from_currsys(self.meta["area"])    # u.m2
+        area = from_currsys(self.meta["area"], self.cmds)    # u.m2
 
         # PHOTLAM * u.um * u.m2 --> ph / s
         specs = {ref: spec(fov_waveset) if use_photlam

--- a/scopesim/optics/fov_manager.py
+++ b/scopesim/optics/fov_manager.py
@@ -75,7 +75,7 @@ class FOVManager:
 
     """
 
-    def __init__(self, effects=None, **kwargs):
+    def __init__(self, effects=None, cmds=None, **kwargs):
         self.meta = {"area": "!TEL.area",
                      "pixel_scale": "!INST.pixel_scale",
                      "plate_scale": "!INST.plate_scale",
@@ -90,18 +90,21 @@ class FOVManager:
                      "decouple_sky_det_hdrs": "!INST.decouple_detector_from_sky_headers",
                      "aperture_id": 0}
         self.meta.update(kwargs)
+        self.cmds = cmds
 
         params = from_currsys({"wave_min": self.meta["wave_min"],
-                               "wave_max": self.meta["wave_max"]})
+                               "wave_max": self.meta["wave_max"]},
+                              self.cmds)
         fvl_meta = ["area", "pixel_scale", "aperture_id"]
-        params["meta"] = from_currsys({key: self.meta[key] for key in fvl_meta})
+        params["meta"] = from_currsys({key: self.meta[key] for key in fvl_meta},
+                                      self.cmds)
         self.volumes_list = FovVolumeList(initial_volume=params)
 
         self.effects = effects or []
         self._fovs_list = []
         self.is_spectroscope = eu.is_spectroscope(self.effects)
 
-        if from_currsys(self.meta["preload_fovs"]) is True:
+        if from_currsys(self.meta["preload_fovs"], self.cmds):
             self._fovs_list = self.generate_fovs_list()
 
     def generate_fovs_list(self):
@@ -120,11 +123,11 @@ class FOVManager:
             self.volumes_list = effect.apply_to(self.volumes_list, **params)
 
         # ..todo: add catch to split volumes larger than chunk_size
-        pixel_scale = from_currsys(self.meta["pixel_scale"])
-        plate_scale = from_currsys(self.meta["plate_scale"])
+        pixel_scale = from_currsys(self.meta["pixel_scale"], self.cmds)
+        plate_scale = from_currsys(self.meta["plate_scale"], self.cmds)
 
-        chunk_size = from_currsys(self.meta["chunk_size"])
-        max_seg_size = from_currsys(self.meta["max_segment_size"])
+        chunk_size = from_currsys(self.meta["chunk_size"], self.cmds)
+        max_seg_size = from_currsys(self.meta["max_segment_size"], self.cmds)
 
         split_xs = []
         split_ys = []
@@ -155,7 +158,7 @@ class FOVManager:
             # useful for spectroscopy mode where slit dimensions is not the same
             # as detector dimensions
             # ..todo: Make sure this changes for multiple image planes
-            if from_currsys(self.meta["decouple_sky_det_hdrs"]) is True:
+            if from_currsys(self.meta["decouple_sky_det_hdrs"], self.cmds):
                 det_eff = eu.get_all_effects(self.effects, DetectorList)[0]
                 dethdr = det_eff.image_plane_header
 
@@ -166,7 +169,7 @@ class FOVManager:
 
     @property
     def fovs(self):
-        if from_currsys(self.meta["preload_fovs"]) is False:
+        if not from_currsys(self.meta["preload_fovs"], self.cmds):
             self._fovs_list = self.generate_fovs_list()
         return self._fovs_list
 

--- a/scopesim/optics/optical_element.py
+++ b/scopesim/optics/optical_element.py
@@ -27,7 +27,6 @@ class OpticalElement:
     ``Effects`` along with a set of local properties e.g. temperature, etc
     which are common to more than one Effect
 
-
     Parameters
     ----------
     yaml_dict : dict
@@ -36,9 +35,9 @@ class OpticalElement:
     kwargs : dict
         Optical Element specific information which has no connection to the
         effects that are passed. Any global values, e.g. airmass
-        (i.e. bang strings) are passed on to the individual effect, where the
-        relevant values are then pulled from rc.__currsys__
-
+        (i.e. bang strings) are passed on to the individual effect which can
+        extract the relevant bang_string from the UserCommands object held in
+        self.cmds
 
     Attributes
     ----------
@@ -58,11 +57,12 @@ class OpticalElement:
 
     """
 
-    def __init__(self, yaml_dict=None, **kwargs):
+    def __init__(self, yaml_dict=None, cmds=None, **kwargs):
         self.meta = {"name": "<empty>"}
         self.meta.update(kwargs)
         self.properties = {}
         self.effects = []
+        self.cmds = cmds
 
         if isinstance(yaml_dict, dict):
             self.meta.update({key: yaml_dict[key] for key in yaml_dict
@@ -73,12 +73,13 @@ class OpticalElement:
                 self.properties["element_name"] = yaml_dict["name"]
             if "effects" in yaml_dict and len(yaml_dict["effects"]) > 0:
                 for eff_dic in yaml_dict["effects"]:
-                    if "name" in eff_dic and hasattr(rc.__currsys__,
+                    if "name" in eff_dic and hasattr(self.cmds,
                                                      "ignore_effects"):
-                        if eff_dic["name"] in rc.__currsys__.ignore_effects:
+                        if eff_dic["name"] in self.cmds.ignore_effects:
                             eff_dic["include"] = False
 
                     self.effects.append(make_effect(eff_dic,
+                                                    self.cmds,
                                                     **self.properties))
 
     def add_effect(self, effect):

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -194,7 +194,7 @@ class OpticalTrain:
         if update:
             self.update(**kwargs)
 
-        self.set_focus(**kwargs)    # put focus back on current instrument package
+        # self.set_focus(**kwargs)    # put focus back on current instrument package
 
         # Make a copy of the Source and prepare for observation (convert to
         # internally used units, sample to internal wavelength grid)
@@ -487,12 +487,12 @@ class OpticalTrain:
 
         return hdulist
 
-    def set_focus(self, **kwargs):
-        self.cmds.update(**kwargs)
-        dy = self.cmds.default_yamls
-        if len(dy) > 0 and "packages" in dy:
-            self.cmds.update(packages=self.default_yamls[0]["packages"])
-        rc.__currsys__ = self.cmds
+    # def set_focus(self, **kwargs):
+    #     self.cmds.update(**kwargs)
+    #     dy = self.cmds.default_yamls
+    #     if len(dy) > 0 and "packages" in dy:
+    #         self.cmds.update(packages=self.default_yamls[0]["packages"])
+    #     rc.__currsys__ = self.cmds
 
     def shutdown(self):
         """

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -25,7 +25,7 @@ from .. import rc
 import multiprocessing as mp
 
 N_PROCESSES = mp.cpu_count() - 1
-USE_MULTIPROCESSING = True
+USE_MULTIPROCESSING = False
 
 def extract_source(fov, source):
     fov.extract_from(source)

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -38,11 +38,15 @@ class OpticsManager:
 
     def __init__(self, yaml_dicts=None, cmds=None, **kwargs):
         self.optical_elements = []
-        self.cmds = cmds
         self.meta = {}
         self.meta.update(kwargs)
         self._surfaces_table = None
         self._surface_like_effects = None
+
+        self.cmds = cmds
+        if self.cmds is None:
+            logger.warning("No UserCommands object was passed when initialising OpticsManager")
+            self.cmds = rc.__currsys__
 
         if yaml_dicts is not None:
             self.load_effects(yaml_dicts, **self.meta)

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -36,8 +36,9 @@ class OpticsManager:
 
     """
 
-    def __init__(self, yaml_dicts=None, **kwargs):
+    def __init__(self, yaml_dicts=None, cmds=None, **kwargs):
         self.optical_elements = []
+        self.cmds = cmds
         self.meta = {}
         self.meta.update(kwargs)
         self._surfaces_table = None
@@ -50,15 +51,15 @@ class OpticsManager:
 
     def set_derived_parameters(self):
 
-        if "!INST.pixel_scale" not in rc.__currsys__:
+        if "!INST.pixel_scale" not in self.cmds:
             raise ValueError("'!INST.pixel_scale' is missing from the current"
                              "system. Please add this to the instrument (INST)"
                              "properties dict for the system.")
-        pixel_scale = rc.__currsys__["!INST.pixel_scale"] * u.arcsec
+        pixel_scale = self.cmds["!INST.pixel_scale"] * u.arcsec
         area = self.area
         etendue = area * pixel_scale**2
-        rc.__currsys__["!TEL.etendue"] = etendue
-        rc.__currsys__["!TEL.area"] = area
+        self.cmds["!TEL.etendue"] = etendue
+        self.cmds["!TEL.area"] = area
 
         params = {"area": area, "pixel_scale": pixel_scale, "etendue": etendue}
         self.meta.update(params)
@@ -260,10 +261,10 @@ class OpticsManager:
     @property
     def system_transmission(self):
 
-        wave_unit = u.Unit(rc.__currsys__["!SIM.spectral.wave_unit"])
-        dwave = rc.__currsys__["!SIM.spectral.spectral_bin_width"]
-        wave_min = rc.__currsys__["!SIM.spectral.wave_min"]
-        wave_max = rc.__currsys__["!SIM.spectral.wave_max"]
+        wave_unit = u.Unit(from_currsys("!SIM.spectral.wave_unit", self.cmds))
+        dwave = from_currsys("!SIM.spectral.spectral_bin_width", self.cmds)
+        wave_min = from_currsys("!SIM.spectral.wave_min", self.cmds)
+        wave_max = from_currsys("!SIM.spectral.wave_max", self.cmds)
         wave = np.arange(wave_min, wave_max, dwave)
         trans = np.ones_like(wave)
         sys_trans = SpectralElement(Empirical1D, points=wave*u.Unit(wave_unit),
@@ -303,7 +304,7 @@ class OpticsManager:
 
         colnames = ["element", "name", "class", "included"]     #, "z_orders"
         data = [elements, names, classes, included]             #, z_orders
-        data = from_currsys(data)
+        data = from_currsys(data, self.cmds)
         tbl = Table(names=colnames, data=data, copy=False)
 
         return tbl

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -244,7 +244,7 @@ class OpticsManager:
         for eff in sle_list:
             if isinstance(eff, efs.SurfaceList):
                 eff_copy = deepcopy(eff)
-                eff_copy.table = from_currsys(eff.table)
+                eff_copy.table = from_currsys(eff.table, self.cmds)
             else:
                 # Avoid infinite recursion in Wheel effects (filter, adc)
                 eff_copy = eff

--- a/scopesim/optics/radiometry_utils.py
+++ b/scopesim/optics/radiometry_utils.py
@@ -103,7 +103,6 @@ def combine_tables(new_tables, old_table=None, prepend=False):
         if old_table is None:
             old_table = new_table
         else:
-            new_table = from_currsys(new_table)
             if prepend:
                 old_table = vstack([new_table, old_table])
             else:

--- a/scopesim/optics/surface.py
+++ b/scopesim/optics/surface.py
@@ -277,7 +277,7 @@ class SpectralSurface:
             val_out = None
         else:
             raise ValueError(f"{colname} must be of type: Quantity, array, "
-                             f"list, tuple, but is {type(colname)}")
+                             f"list, tuple, but is {type(val)}")
 
         return val_out
 

--- a/scopesim/tests/test_basic_instrument/test_basic_instrument.py
+++ b/scopesim/tests/test_basic_instrument/test_basic_instrument.py
@@ -183,4 +183,4 @@ class TestFitsHeader:
         assert hdr["SIM SRC0 object"] == 'star'
         assert hdr["SIM EFF14 class"] == 'SourceDescriptionFitsKeywords'
         assert hdr["SIM CONFIG OBS filter_name"] == 'J'
-        assert hdr["ESO ATM SEEING"] == sim.utils.from_currsys("!OBS.psf_fwhm")
+        assert hdr["ESO ATM SEEING"] == opt.cmds["!OBS.psf_fwhm"]

--- a/scopesim/tests/test_utils_functions.py
+++ b/scopesim/tests/test_utils_functions.py
@@ -206,3 +206,16 @@ class TestLoadExampleOptTrain:
 
         assert isinstance(opt, OpticalTrain)
         assert from_currsys(opt["slit_wheel"].include)
+
+    def test_loads_ifu_optical_train_object(self):
+        opt = load_example_optical_train(set_modes=["ifu"])
+
+        assert isinstance(opt, OpticalTrain)
+        assert from_currsys(opt["ifu_spectral_traces"].include)
+
+    @pytest.mark.xfail
+    def test_loads_mos_optical_train_object(self):
+        opt = load_example_optical_train(set_modes=["mos"])
+
+        assert isinstance(opt, OpticalTrain)
+        assert from_currsys(opt["slit_wheel"].include)

--- a/scopesim/tests/tests_optics/test_OpticalElement.py
+++ b/scopesim/tests/tests_optics/test_OpticalElement.py
@@ -42,12 +42,14 @@ class TestOpticalElementInit:
         assert len(opt_el.effects) == 3
         assert opt_el.effects[2].include is False
 
+    # TODO: Check whether the test below actually does what I think it's testing.
+    # Should be obsolete once the currsys is removed from rc
     def test_currsys_ignore_effects_have_false_include_flag(self, atmo_yaml_dict):
         with patch("scopesim.rc.__currsys__", UserCommands()) as patched:
-            patched.ignore_effects = ["super_psf", "atmo_dispersion"]
-            opt_el = opt_elem.OpticalElement(atmo_yaml_dict)
-            for ii in range(2):
-                assert opt_el.effects[ii].include is False
+            patched.ignore_effects = ["super_psf"]
+            opt_el = opt_elem.OpticalElement(atmo_yaml_dict, cmds=patched)
+            for ii in patched.ignore_effects:
+                assert opt_el["super_psf"].include is False
 
 
 @pytest.mark.usefixtures("patch_mock_path")

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -478,7 +478,9 @@ def find_file(filename, path=None, silent=False):
         return None
 
     if filename.startswith("!"):
-        filename = from_currsys(filename)
+        raise ValueError(f"!-string filename should be resolved upstream: "
+                         f"{filename}")
+        # filename = from_currsys(filename)
     # Turn into pathlib.Path object for better manipulation afterwards
     filename = Path(filename)
 
@@ -510,6 +512,7 @@ def find_file(filename, path=None, silent=False):
     if not silent:
         logger.error(msg)
 
+    # TODO: Not sure what to do here
     if from_currsys("!SIM.file.error_on_missing_file"):
         raise ValueError(msg)
 
@@ -645,7 +648,8 @@ def get_meta_quantity(meta_dict, name, fallback_unit=""):
 
     """
     if isinstance(meta_dict[name], str) and meta_dict[name].startswith("!"):
-        meta_dict[name] = from_currsys(meta_dict[name])
+        raise ValueError(f"!-strings should be resolved upstream: "
+                         f"{meta_dict[name]}")
 
     if isinstance(meta_dict[name], u.Quantity):
         unit = meta_dict[name].unit

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -869,8 +869,10 @@ def from_currsys(item, cmds=None):
     if isinstance(item, str) and len(item) and item.startswith("!"):
         # if not isinstance(cmds, UserCommands)
         #     raise TypeError
+
         if not cmds:
             cmds = rc.__currsys__
+            # raise ValueError(f"No cmds dict passed for resolving {item}")
 
         if item in cmds:
             item = cmds[item]
@@ -888,6 +890,10 @@ def from_currsys(item, cmds=None):
             pass
 
     return item
+
+
+def from_rc_config(item):
+    return from_currsys(item, rc.__config__)
 
 
 def check_keys(input_dict, required_keys, action="error", all_any="all"):

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -663,7 +663,7 @@ def get_meta_quantity(meta_dict, name, fallback_unit=""):
     return quant
 
 
-def quantify(item, unit):
+def quantify(item, unit, cmds=None):
     """
     Ensure an item is a Quantity.
 
@@ -678,7 +678,8 @@ def quantify(item, unit):
 
     """
     if isinstance(item, str) and item.startswith("!"):
-        item = from_currsys(item)
+        raise ValueError(f"Quantify cannot resolve {item}")
+        # item = from_currsys(item, cmds)
     if isinstance(item, u.Quantity):
         quant = item.to(u.Unit(unit))
     else:

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -840,29 +840,34 @@ def clean_dict(orig_dict, new_entries):
     return orig_dict
 
 
-def from_currsys(item):
+def from_currsys(item, cmds=None):
     """Return the current value of a bang-string from ``rc.__currsys__``."""
     if isinstance(item, Table):
         tbl_dict = {col: item[col].data for col in item.colnames}
-        tbl_dict = from_currsys(tbl_dict)
+        tbl_dict = from_currsys(tbl_dict, cmds)
         item_meta = item.meta
         item = Table(data=list(tbl_dict.values()),
                      names=list(tbl_dict.keys()))
         item.meta = item_meta
 
     if isinstance(item, np.ndarray) and not isinstance(item, u.Quantity):
-        item = np.array([from_currsys(x) for x in item])
+        item = np.array([from_currsys(x, cmds) for x in item])
 
     if isinstance(item, list):
-        item = [from_currsys(x) for x in item]
+        item = [from_currsys(x, cmds) for x in item]
 
     if isinstance(item, dict):
         for key in item:
-            item[key] = from_currsys(item[key])
+            item[key] = from_currsys(item[key], cmds)
 
     if isinstance(item, str) and len(item) and item.startswith("!"):
-        if item in rc.__currsys__:
-            item = rc.__currsys__[item]
+        # if not isinstance(cmds, UserCommands)
+        #     raise TypeError
+        if not cmds:
+            cmds = rc.__currsys__
+
+        if item in cmds:
+            item = cmds[item]
             if isinstance(item, str) and item.startswith("!"):
                 item = from_currsys(item)
         else:


### PR DESCRIPTION
# Remove the cursed `rc.currsys` object from the global namespace.
## Rational: 
In order to allow multi-core processing, we cannot rely on global properties.
Most `Effect` objects make a call to the utility function `from_currsys` in order to resolve an `!`-strings.
This function tracks down the value(s) that any (chain of) bang-strings refers to. 
The current system (`__currsys__`) acts as a member of the `rc` submodule, and acts essentially as a global variable.
This gets in when generating sub-processes to split up the workload of the loops found in the `OpticalTrain.observe` function.
An additional side-effect of having a global-esque commands dictionary, is that instances of `OpticalTrain` are not self-contained.
As such a user cannot reliably use multiple instances of an `OpticalTrain` in a script of notebook.
This prohibits efficient re-use of an already created system, and means ScopeSim fails to achieve the goal of enabling single `Source` objects to be observed with multiple instruments in the same session.
Facit: Not User Freindly

## Implemention
The work around here contains two parts:

1. Add the option to pass a commands object, i.e. the self.cmds object from the top-level of a `OpticalTrain` object to the `from_currsys` function, and bypass the call to the global dict stored in `rc.__currsys__`.
2. Propogate the `UserCommands` object down through all layers such that each `Effect` object also references the top-level `self.cmds` dict.

## Goal
Ideally if I have done this correctly, the `rc.__currsys__` dict should not be needed now, and can therefore be deleted.

How to test this:

- Delete `rc.__currsys__`
- Remove the fallback option to use `rc.__currsys__` from `from_currsys()`
- Remove the `set_focus` method from `OpticalTrain`

## Exceptions
There are occasional calls to `!SIM` keywords. These should be kept in a global level dictionary as they pertain to how scopesim runs. There should be no instrument specific parameters in the `!SIM` dict.



