### PR TITLE
Remove unused and broken `make_imagehdu_from_table()`

### DIFF
--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -149,18 +149,8 @@ class TERCurve(Effect):
     @property
     def background_source(self):
         if self._background_source is None:
-            # add a single pixel ImageHDU for the extended background with a
-            # size of 1 degree
-            # bg_cell_width = from_currsys(self.meta["bg_cell_width"])
-
             flux = self.emission
             bg_hdu = fits.ImageHDU()
-            # TODO: The make_imagehdu_from_table below has been replaced with
-            #       the empty ImageHDU above in fbca416. That change might,
-            #       have been fine (or not?), but now there is no use anywhere
-            #       in the code of make_imagehdu_from_table or bg_cell_width,
-            #       so maybe these need to be removed?
-            # bg_hdu = make_imagehdu_from_table([0], [0], [1], bg_cell_width * u.arcsec)
 
             bg_hdu.header.update({"BG_SRC": True,
                                   "BG_SURF": self.display_name,

--- a/scopesim/source/source_utils.py
+++ b/scopesim/source/source_utils.py
@@ -126,40 +126,6 @@ def photons_in_range(spectra, wave_min, wave_max, area=None, bandpass=None):
     return counts
 
 
-def make_imagehdu_from_table(x, y, flux, pix_scale=1*u.arcsec):
-
-    pix_scale = pix_scale.to(u.deg)
-    unit = pix_scale.unit
-    x = quantify(x, unit)
-    y = quantify(y, unit)
-
-    xpixmin = int(np.floor(np.min(x) / pix_scale))
-    ypixmin = int(np.floor(np.min(y) / pix_scale))
-    xvalmin = (xpixmin * pix_scale).value
-    yvalmin = (ypixmin * pix_scale).value
-
-    the_wcs = wcs.WCS(naxis=2)
-    the_wcs.wcs.crpix = [0.25, 0.25]
-    the_wcs.wcs.cdelt = [pix_scale.value, pix_scale.value]
-    the_wcs.wcs.crval = [xvalmin, yvalmin]
-    the_wcs.wcs.cunit = [unit, unit]
-    the_wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
-
-    xpix, ypix = the_wcs.wcs_world2pix(x.to(u.deg), y.to(u.deg), 1)
-    yint, xint  = ypix.astype(int), xpix.astype(int)
-
-    image = np.zeros((np.max(xint) + 1, np.max(yint) + 1))
-    for xi, yi, fluxi in zip(xint, yint, flux):
-        # To prevent adding array values in this manner.
-        assert not isinstance(xi, Iterable), "xi should be integer"
-        image[xi, yi] += fluxi
-
-    hdu = fits.ImageHDU(data=image)
-    hdu.header.extend(the_wcs.to_header())
-
-    return hdu
-
-
 def scale_imagehdu(imagehdu, waverange, area=None):
     # ..todo: implement this
     # For the moment, all imagehdu must be accompanied by a spectrum in PHOTLAM

--- a/scopesim/source/source_utils.py
+++ b/scopesim/source/source_utils.py
@@ -145,7 +145,7 @@ def make_imagehdu_from_table(x, y, flux, pix_scale=1*u.arcsec):
     the_wcs.wcs.cunit = [unit, unit]
     the_wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
 
-    ypix, xpix = the_wcs.wcs_world2pix(y.to(u.deg), x.to(u.deg), 1)
+    xpix, ypix = the_wcs.wcs_world2pix(x.to(u.deg), y.to(u.deg), 1)
     yint, xint  = ypix.astype(int), xpix.astype(int)
 
     image = np.zeros((np.max(xint) + 1, np.max(yint) + 1))

--- a/scopesim/tests/tests_source/test_source_Source.py
+++ b/scopesim/tests/tests_source/test_source_Source.py
@@ -388,61 +388,6 @@ class TestPhotonsInRange:
         assert counts.value == approx(expected)
 
 
-class TestMakeImageFromTable:
-    def test_returned_object_is_image_hdu(self):
-        hdu = source_utils.make_imagehdu_from_table(x=[0], y=[0], flux=[1])
-        assert isinstance(hdu, fits.ImageHDU)
-
-    def test_imagehdu_has_wcs(self):
-        hdu = source_utils.make_imagehdu_from_table(x=[0], y=[0], flux=[1])
-        wcs_keys = ["CRPIX1", "CRVAL1", "CDELT1", "CUNIT1"]
-        assert np.all([key in hdu.header.keys() for key in wcs_keys])
-
-    def test_stars_are_at_correct_position_for_no_subpixel_accuracy(self):
-        # weird behaviour for exactly integer coords e.g. (0, 0)
-        x = np.linspace(-1.0001, 1.0001, 9)*u.arcsec
-        y = np.linspace(-1.0001, 1.0001, 9)*u.arcsec
-        flux = np.ones(len(x))
-        hdu = source_utils.make_imagehdu_from_table(x=x, y=y, flux=flux,
-                                                    pix_scale=0.25*u.arcsec)
-        the_wcs = wcs.WCS(hdu)
-        xx, yy = the_wcs.wcs_world2pix(x.to(u.deg), y.to(u.deg), 1)
-        xx = np.floor(xx).astype(int)
-        yy = np.floor(yy).astype(int)
-        assert np.all(hdu.data[xx, yy])
-
-    @pytest.mark.parametrize("ii", np.arange(20))
-    def test_wcs_returns_correct_pixel_values_for_random_coords(self, ii):
-        x = np.random.random(11)*u.arcsec
-        y = np.random.random(11)*u.arcsec
-        flux = np.ones(len(x))
-        hdu = source_utils.make_imagehdu_from_table(x=x, y=y, flux=flux,
-                                                    pix_scale=0.1*u.arcsec)
-        the_wcs = wcs.WCS(hdu)
-        xx, yy = the_wcs.wcs_world2pix(x.to(u.deg), y.to(u.deg), 1)
-        assert (xx > 0).all()
-        assert (yy > 0).all()
-        xx = xx.astype(int)
-        yy = yy.astype(int)
-        assert np.all(hdu.data[xx, yy])
-
-        # When plotting the image vs the scatter plot
-        # The dots match up with a 0.5 px shift, When we intruduce the shift to
-        # the test, the dots are on top of the image, but the test fails
-        # when using
-        # the_wcs.wcs.crpix = [0.5, 0.5]
-        # Returning to normal the test passes when (albeit with an image offset)
-        # the_wcs.wcs.crpix = [0., 0.]
-        #
-        # print(hdu.data, flush=True)
-        # print(x, y, flush=True)
-        # import matplotlib.pyplot as plt
-        # plt.subplot(projection=the_wcs)
-        # plt.scatter(y*10, x*10)
-        # plt.scatter(yy , xx)
-        # plt.imshow(hdu.data)
-        # plt.show()
-
 #
 # class TestScaleImageHDU:
 #     def test_scaling_properly_for_si_photlam_in_header(self):

--- a/scopesim/tests/tests_source/test_source_Source.py
+++ b/scopesim/tests/tests_source/test_source_Source.py
@@ -406,7 +406,7 @@ class TestMakeImageFromTable:
         hdu = source_utils.make_imagehdu_from_table(x=x, y=y, flux=flux,
                                                     pix_scale=0.25*u.arcsec)
         the_wcs = wcs.WCS(hdu)
-        yy, xx = the_wcs.wcs_world2pix(y.to(u.deg), x.to(u.deg), 1)
+        xx, yy = the_wcs.wcs_world2pix(x.to(u.deg), y.to(u.deg), 1)
         xx = np.floor(xx).astype(int)
         yy = np.floor(yy).astype(int)
         assert np.all(hdu.data[xx, yy])
@@ -419,7 +419,9 @@ class TestMakeImageFromTable:
         hdu = source_utils.make_imagehdu_from_table(x=x, y=y, flux=flux,
                                                     pix_scale=0.1*u.arcsec)
         the_wcs = wcs.WCS(hdu)
-        yy, xx = the_wcs.wcs_world2pix(y.to(u.deg), x.to(u.deg), 1)
+        xx, yy = the_wcs.wcs_world2pix(x.to(u.deg), y.to(u.deg), 1)
+        assert (xx > 0).all()
+        assert (yy > 0).all()
         xx = xx.astype(int)
         yy = yy.astype(int)
         assert np.all(hdu.data[xx, yy])


### PR DESCRIPTION
There was a bug in `make_imagehdu_from_table()`: the coordinates were swapped in the `wcs_world2pix()` call. Therefore it would use bogus coordinates for the sources. In particular, it would result in negative values for the y pixel coordinate.

This bug triggered a test failure in `test_wcs_returns_correct_pixel_values_for_random_coords()`, because one of the random coordinates would not fall on the image about once every 300 times the test was run.

So I fixed the bug in https://github.com/AstarVienna/ScopeSim/commit/08e25637a49122ef7d3125c4d8eefefbb357acbf .

Then I went looking for other occurrences of `make_imagehdu_from_table()` that might be broken too, only to realize that the function is never used in our entire codebase, also not in other packages. So I removed the entire function in https://github.com/AstarVienna/ScopeSim/commit/333618248264b711b16396d4341f9f7e3038cbf1 .

Perhaps there is someone out there somewhere who uses this function. Then their code was broken to begin with, because this function did not actually work, so nothing of value would be lost.

The actual bug was in the use of `wcs_world2pix()`, and I've verified that all other use of that function in ScopeSim is correct.
