### PR TITLE
Use ChainMap for UserCommands

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -142,13 +142,13 @@ test = ["dateparser (==1.*)", "pre-commit", "pytest", "pytest-cov", "pytest-mock
 
 [[package]]
 name = "astar-utils"
-version = "0.2.1"
+version = "0.2.2"
 description = "Contains commonly-used utilities for AstarVienna's projects."
 optional = false
 python-versions = ">=3.9,<4.0"
 files = [
-    {file = "astar_utils-0.2.1-py3-none-any.whl", hash = "sha256:29428d3629337093c14f5283ee9f5d424cb194530adc16ab3632b8205aa385b2"},
-    {file = "astar_utils-0.2.1.tar.gz", hash = "sha256:edae507fd3d5589640c2d60eb1b3880c50a6e1ac76fbe8efcfffe6b7e1fd573a"},
+    {file = "astar_utils-0.2.2-py3-none-any.whl", hash = "sha256:5f408c187a84d4cf40f49020886957c6eaeb92479d98c993a6285ff292661eda"},
+    {file = "astar_utils-0.2.2.tar.gz", hash = "sha256:21872a30767c158eaf640b2321b43f92ec7e706ac7e0950f7ddf9e2a9ffe221a"},
 ]
 
 [package.dependencies]
@@ -1764,6 +1764,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -2682,7 +2692,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -3723,4 +3732,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "ceba4b1307de878693215268470e2572645d11b00c73832bcfae3fa9820b43c1"
+content-hash = "a4f06e6eddcee777404dfd0b3597d1937d285b6df2fccf923475efdd70ac02d5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ tqdm = "^4.66.1"
 synphot = "^1.2.1"
 skycalc_ipy = ">=0.4.0"
 anisocado = ">=0.3.0"
-astar-utils = ">=0.2.0"
+astar-utils = ">=0.2.2"
 
 [tool.poetry.group.dev]
 optional = true

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -171,7 +171,7 @@ class UserCommands(NestedChainMap):
         self.update(**kwargs)
 
     def _load_yaml_dict(self, yaml_dict):
-        logger.info("    called load dict yaml")
+        logger.debug("    called load dict yaml")
 
         # FIXME: See if this occurs outside the test_package. If not, remove
         #        the if statement and the logging call and just put the assert
@@ -186,37 +186,37 @@ class UserCommands(NestedChainMap):
         self.yaml_dicts.append(yaml_dict)
 
         if "packages" in yaml_dict:
-            logger.info("        found packages")
+            logger.debug("        found packages")
             self.update(packages=yaml_dict["packages"])
 
         # recursive
         sub_yamls = yaml_dict.get("yamls", [])
-        logger.info("      found %d sub-yamls", len(sub_yamls))
+        logger.debug("      found %d sub-yamls", len(sub_yamls))
         self._load_yamls(sub_yamls)
 
         if "mode_yamls" in yaml_dict:
-            logger.info("        found mode_yamls")
+            logger.debug("        found mode_yamls")
             self.update(mode_yamls=yaml_dict["mode_yamls"])
-        logger.info("      dict yaml done")
+        logger.debug("      dict yaml done")
 
     def _load_yamls(self, yamls: Collection) -> None:
-        logger.info("called load yaml with %d yamls", len(yamls))
+        logger.debug("called load yaml with %d yamls", len(yamls))
         for yaml_input in yamls:
             if isinstance(yaml_input, str):
-                logger.info("  found str yaml: %s", yaml_input)
+                logger.debug("  found str yaml: %s", yaml_input)
                 if (yaml_file := find_file(yaml_input)) is None:
                     logger.error("%s could not be found.", yaml_input)
                     continue
 
                 yaml_dicts = load_yaml_dicts(yaml_file)
-                logger.info("  loaded %d yamls from %s", len(yaml_dicts), yaml_input)
+                logger.debug("  loaded %d yamls from %s", len(yaml_dicts), yaml_input)
                 # recursive
                 for yaml_dict in yaml_dicts:
                     self._load_yaml_dict(yaml_dict)
                 if yaml_input == "default.yaml":
-                    logger.info("    setting default yaml")
+                    logger.debug("    setting default yaml")
                     self.default_yamls = yaml_dicts
-                logger.info("  str yaml done")
+                logger.debug("  str yaml done")
 
             elif isinstance(yaml_input, Mapping):
                 self._load_yaml_dict(yaml_input)
@@ -295,7 +295,7 @@ class UserCommands(NestedChainMap):
             new_dict = new_dict.dic  # Avoid updating with another one
 
         if alias := new_dict.get("alias"):
-            logger.info("updating alias %s", alias)
+            logger.debug("updating alias %s", alias)
             propdict = new_dict.get("properties", {})
             if alias in mapping:
                 mapping[alias] = recursive_update(mapping[alias], propdict)

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -185,15 +185,18 @@ class UserCommands(NestedChainMap):
         self.update_alias(self.maps[0], yaml_dict)
         self.yaml_dicts.append(yaml_dict)
 
+        if "packages" in yaml_dict:
+            logger.info("        found packages")
+            self.update(packages=yaml_dict["packages"])
+
         # recursive
         sub_yamls = yaml_dict.get("yamls", [])
         logger.info("      found %d sub-yamls", len(sub_yamls))
         self._load_yamls(sub_yamls)
 
-        for key in ["packages", "mode_yamls"]:
-            if key in yaml_dict:
-                logger.info("        found %s", key)
-                self.update(**{key: yaml_dict[key]})
+        if "mode_yamls" in yaml_dict:
+            logger.info("        found mode_yamls")
+            self.update(mode_yamls=yaml_dict["mode_yamls"])
         logger.info("      dict yaml done")
 
     def _load_yamls(self, yamls: Collection) -> None:

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -160,7 +160,9 @@ class UserCommands(NestedChainMap):
         super().__init__(RecursiveNestedMapping(title="CurrSys"), *maps)
 
         self.yaml_dicts = []
-        self._kwargs = kwargs
+        # HACK: the deepcopy is necessary because otherwise some subdicts
+        #       e.g. properties gets emptied, not sure why
+        self._kwargs = deepcopy(kwargs)
         self.ignore_effects = []
         self.package_name = ""
         self.default_yamls = []

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -317,7 +317,6 @@ class UserCommands(NestedChainMap):
             if len(new_dict) > 0:
                 mapping = recursive_update(mapping, new_dict)
 
-
     def set_modes(self, *modes) -> None:
         """Reload with the specified `modes`.
 
@@ -326,6 +325,16 @@ class UserCommands(NestedChainMap):
         This used to take a single list-like argument, now used a "*args"
         approach to deal with multiple modes.
         """
+        # TODO: Remove this as soon as we can be sure enough it won't break
+        #       stuff or annoy anyone too badly.
+        if (len(modes) == 1 and isinstance(modes, Iterable)
+                and not isinstance(modes[0], str)):
+            warn(
+                "Passing a list to set_modes is deprecated and will no longer "
+                "work in future versions. Please just pass all modes as "
+                "arguments instead.", DeprecationWarning, stacklevel=2)
+            modes = modes[0]
+
         for defyam in self.default_yamls:
             if "properties" not in defyam:
                 continue

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -1,9 +1,17 @@
+# -*- coding: utf-8 -*-
+"""Contains the UserCommands class and some helper functions."""
+
+from warnings import warn
 from copy import deepcopy
 from pathlib import Path
-from collections.abc import Mapping
+from collections.abc import Iterable, Collection, Mapping, MutableMapping
+from typing import Any
 
 import yaml
 import httpx
+
+from astar_utils import NestedMapping, RecursiveNestedMapping, NestedChainMap
+from astar_utils.nested_mapping import recursive_update, is_bangkey
 
 from .. import rc
 from ..utils import find_file, top_level_catch, get_logger
@@ -14,11 +22,11 @@ logger = get_logger(__name__)
 __all__ = ["UserCommands"]
 
 
-class UserCommands:
+class UserCommands(NestedChainMap):
     """
-    Contains all the setting that a user may wish to alter for an optical train
+    Contains all the setting a user may wish to alter for an optical train.
 
-    Most of the important settings are kept in the ``.cmds`` system dictionary
+    Most of the important settings are kept in the internal nested dictionary.
     Setting can be accessed by using the alias names. Currently these are:
 
     - ATMO: atmospheric and observatory location settings
@@ -82,7 +90,7 @@ class UserCommands:
 
     Attributes
     ----------
-    cmds : NestedMapping
+    cmds : RecursiveNestedMapping
         Built from the ``properties`` dictionary of a yaml dictionary. All
         values here are accessible globally by all ``Effects`` objects in an
         ``OpticalTrain`` once the ``UserCommands`` has been passed to the
@@ -140,14 +148,19 @@ class UserCommands:
         If you use a custom ``yaml`` configuration file, you can also add this
         keyword to the ``properties`` section of the ``yaml`` file.
 
+    .. versionchanged:: PLACEHOLDER_NEXT_STABLE_VERSION
+
+    This now inherits from (a subclass of) `collections.ChainMap`.
     """
 
     @top_level_catch
-    def __init__(self, **kwargs):
+    def __init__(self, *maps, **kwargs):
+        if not maps:
+            maps = [rc.__config__]
+        super().__init__(RecursiveNestedMapping(title="CurrSys"), *maps)
 
-        self.cmds = deepcopy(rc.__config__)
         self.yaml_dicts = []
-        self.kwargs = kwargs
+        self._kwargs = kwargs
         self.ignore_effects = []
         self.package_name = ""
         self.default_yamls = []
@@ -155,12 +168,66 @@ class UserCommands:
 
         self.update(**kwargs)
 
-    def update(self, **kwargs):
+    def _load_yaml_dict(self, yaml_dict):
+        logger.info("    called load dict yaml")
+
+        # FIXME: See if this occurs outside the test_package. If not, remove
+        #        the if statement and the logging call and just put the assert
+        #        back in, which is more efficient.
+        # assert "alias" in yaml_dict, f"no alias found in {yaml_dict}"
+        if "alias" not in yaml_dict:
+            logger.error(
+                "No 'alias' found in %s. This shouldn't happen outside testing"
+                "and mocking.", yaml_dict)
+
+        self.update_alias(self.maps[0], yaml_dict)
+        self.yaml_dicts.append(yaml_dict)
+
+        # recursive
+        sub_yamls = yaml_dict.get("yamls", [])
+        logger.info("      found %d sub-yamls", len(sub_yamls))
+        self._load_yamls(sub_yamls)
+
+        for key in ["packages", "mode_yamls"]:
+            if key in yaml_dict:
+                logger.info("        found %s", key)
+                self.update(**{key: yaml_dict[key]})
+        logger.info("      dict yaml done")
+
+    def _load_yamls(self, yamls: Collection) -> None:
+        logger.info("called load yaml with %d yamls", len(yamls))
+        for yaml_input in yamls:
+            if isinstance(yaml_input, str):
+                logger.info("  found str yaml: %s", yaml_input)
+                if (yaml_file := find_file(yaml_input)) is None:
+                    logger.error("%s could not be found.", yaml_input)
+                    continue
+
+                yaml_dicts = load_yaml_dicts(yaml_file)
+                logger.info("  loaded %d yamls from %s", len(yaml_dicts), yaml_input)
+                # recursive
+                for yaml_dict in yaml_dicts:
+                    self._load_yaml_dict(yaml_dict)
+                if yaml_input == "default.yaml":
+                    logger.info("    setting default yaml")
+                    self.default_yamls = yaml_dicts
+                logger.info("  str yaml done")
+
+            elif isinstance(yaml_input, Mapping):
+                self._load_yaml_dict(yaml_input)
+            else:
+                raise ValueError("yaml_dicts must be a filename or a "
+                                 f"mapping (dict): {yaml_input}")
+
+    def update(self, other=None, /, **kwargs):
         """
         Update the current parameters with a yaml dictionary.
 
         See the ``UserCommands`` main docstring for acceptable kwargs
         """
+        if other is not None:
+            self.update(**other)
+
         if "use_instrument" in kwargs:
             self.package_name = kwargs["use_instrument"]
             self.update(packages=[kwargs["use_instrument"]],
@@ -172,113 +239,143 @@ class UserCommands:
             add_packages_to_rc_search(self["!SIM.file.local_packages_path"],
                                       kwargs["packages"])
 
-        if "yamls" in kwargs:
-            for yaml_input in kwargs["yamls"]:
-                if isinstance(yaml_input, str):
-                    yaml_file = find_file(yaml_input)
-                    if yaml_file is not None:
-                        yaml_dict = load_yaml_dicts(yaml_file)
-                        self.update(yamls=yaml_dict)
-                        if yaml_input == "default.yaml":
-                            self.default_yamls = yaml_dict
-                    else:
-                        logger.warning("%s could not be found", yaml_input)
+        self._load_yamls(kwargs.get("yamls", []))
 
-                elif isinstance(yaml_input, Mapping):
-                    self.cmds.update(yaml_input)
-                    self.yaml_dicts.append(yaml_input)
-
-                    for key in ["packages", "yamls", "mode_yamls"]:
-                        if key in yaml_input:
-                            self.update(**{key: yaml_input[key]})
-
-                else:
-                    raise ValueError("yaml_dicts must be a filename or a "
-                                     f"dictionary: {yaml_input}")
-
-        if "mode_yamls" in kwargs:
+        if mode_yamls := kwargs.get("mode_yamls"):
             # Convert the yaml list of modes to a dict object
-            self.modes_dict = {my["name"]: my for my in kwargs["mode_yamls"]}
-            if "modes" in self.cmds["!OBS"]:
-                if not isinstance(self.cmds["!OBS.modes"], list):
-                    self.cmds["!OBS.modes"] = [self.cmds["!OBS.modes"]]
-                for mode_name in self.cmds["!OBS.modes"]:
+            # TODO: Why isn't this a dict with name as key to begin with???
+            #       But that's an IRDB thing...
+            #       Also, is the "name" needed in the dict later? If yes, put
+            #       this back to where it was:
+            # Update on this: so the original was needed because during the
+            #       set_modes call, this gets called again, and now thows an
+            #       error because the name key is no longer there.....
+            self.modes_dict = {mode["name"]: mode for mode in mode_yamls}
+            # self.modes_dict = {mode.pop("name"): mode for mode in mode_yamls}
+
+            if "modes" in self["!OBS"]:
+                # This shouldn't be necessary, i.e. we might want to see that
+                # error if it occurs...
+                # if not isinstance(self["!OBS.modes"], list):
+                #     self["!OBS.modes"] = [self["!OBS.modes"]]
+                for mode_name in self["!OBS.modes"]:
                     mode_yaml = self.modes_dict[mode_name]
-                    self.update(yamls=[mode_yaml])
+                    self._load_yaml_dict(mode_yaml)
 
-        if "set_modes" in kwargs:
-            self.set_modes(modes=kwargs["set_modes"])
+        if modes := kwargs.get("set_modes"):
+            self.set_modes(*modes)
 
-        if "properties" in kwargs:
-            self.cmds.update(kwargs["properties"])
+        # Calling underlying NestedMapping's update method to avoid recursion
+        self.maps[0].update(kwargs.get("properties", {}))
 
-        if "ignore_effects" in kwargs:
-            self.ignore_effects = kwargs["ignore_effects"]
+        self.ignore_effects = kwargs.get("ignore_effects", [])
 
         if "add_effects" in kwargs:
-            # ..todo: implement this
-            pass
+            raise NotImplementedError(
+                "The 'add_effects' keyword is not yet supported.")
 
         if "override_effect_values" in kwargs:
-            # ..todo: implement this
-            pass
+            raise NotImplementedError(
+                "The 'override_effect_values' keyword is not yet supported.")
 
-    def set_modes(self, modes=None):
-        if not isinstance(modes, list):
-            modes = [modes]
-        for defyam in self.default_yamls:
-            if "properties" in defyam and "modes" in defyam["properties"]:
-                defyam["properties"]["modes"] = []
-                for mode in modes:
-                    if mode in self.modes_dict:
-                        defyam["properties"]["modes"].append(mode)
-                        if "deprecate" in self.modes_dict[mode]:
-                            logger.warning(self.modes_dict[mode]["deprecate"])
-                    else:
-                        raise ValueError(f"mode '{mode}' was not recognised")
+    @staticmethod
+    def update_alias(mapping: MutableMapping, new_dict: Mapping) -> None:
+        """Update a dict-like according to the alias-properties syntax.
 
-        self.__init__(yamls=self.default_yamls)
+        This used to be part of `astar_utils.NestedMapping`, but is specific to
+        ScopeSim and thus belongs somewhere here. It should only be used in the
+        context of YAML-dicts loaded by UserCommands, hence it was put here.
+        """
+        if isinstance(new_dict, NestedMapping):
+            new_dict = new_dict.dic  # Avoid updating with another one
 
-    def list_modes(self):
-        if isinstance(self.modes_dict, Mapping):
-            modes = {}
-            for mode_name in self.modes_dict:
-                dic = self.modes_dict[mode_name]
-                desc = dic["description"] if "description" in dic else "<None>"
-                modes[mode_name] = desc
-                if "deprecate" in dic:
-                    modes[mode_name] += " (deprecated)"
-
-            msg = "\n".join([f"{key}: {value}" for key, value in modes.items()])
+        if alias := new_dict.get("alias"):
+            logger.info("updating alias %s", alias)
+            propdict = new_dict.get("properties", {})
+            if alias in mapping:
+                mapping[alias] = recursive_update(mapping[alias], propdict)
+            else:
+                mapping[alias] = propdict
         else:
-            msg = "No modes found"
-        return msg
+            # Catch any bang-string properties keys
+            to_pop = []
+            for key in new_dict:
+                if is_bangkey(key):
+                    logger.debug(
+                        "Bang-string key %s was seen in .update. This should "
+                        "not occur outside mocking in testing!", key)
+                    mapping[key] = new_dict[key]
+                    to_pop.append(key)
+            for key in to_pop:
+                new_dict.pop(key)
+
+            if len(new_dict) > 0:
+                mapping = recursive_update(mapping, new_dict)
+
+
+    def set_modes(self, *modes) -> None:
+        """Reload with the specified `modes`.
+
+        .. versionchanged:: PLACEHOLDER_NEXT_STABLE_VERSION
+
+        This used to take a single list-like argument, now used a "*args"
+        approach to deal with multiple modes.
+        """
+        for defyam in self.default_yamls:
+            if "properties" not in defyam:
+                continue
+            if "modes" not in defyam["properties"]:
+                continue
+
+            defyam["properties"]["modes"].clear()
+            for mode in modes:
+                if mode not in self.modes_dict:
+                    raise ValueError(f"mode '{mode}' was not recognised")
+
+                defyam["properties"]["modes"].append(mode)
+                if depmsg := self.modes_dict[mode].get("deprecate"):
+                    warn(depmsg, DeprecationWarning, stacklevel=2)
+
+        # Note: This used to completely reset the instance via the line below.
+        #       Calling init like this is bad design, so I replaced is with a
+        #       more manual reset.
+        #       TLDR: If weird things start happening, look here...
+        # self.__init__(yamls=self.default_yamls)
+        self.yaml_dicts.clear()
+        self._load_yamls(self.default_yamls)
+
+    def list_modes(self) -> Iterable[tuple[str, ...]]:
+        """Yield tuples of length >= 2 with mode names and descriptions.
+
+        .. versionchanged:: PLACEHOLDER_NEXT_STABLE_VERSION
+
+        This used to return the formatted string. For a broader range of use
+        cases, it now returns a generator of tuples of strings.
+        """
+        for mode, subdict in self.modes_dict.items():
+            desc = (subdict.get("description", "<None>") +
+                    ":DEPRECATED" * ("deprecate" in subdict))
+            yield mode, *(s.strip() for s in desc.split(":"))
 
     @property
-    def modes(self):
-        print(self.list_modes())
-
-    def __setitem__(self, key, value):
-        self.cmds.__setitem__(key, value)
-
-    def __getitem__(self, item):
-        return self.cmds.__getitem__(item)
-
-    def __contains__(self, item):
-        return self.cmds.__contains__(item)
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}(**{self.kwargs!r})"
-
-    def __str__(self):
-        return str(self.cmds)
-
-    def _repr_pretty_(self, p, cycle):
-        """For ipython"""
-        if cycle:
-            p.text("UserCommands(...)")
+    def modes(self) -> None:
+        """Print all modes, if any."""
+        modes = "\n".join(f"{mode}: {', '.join(desc)}"
+                          for mode, *desc in self.list_modes())
+        if modes:
+            print(modes)
         else:
-            p.text(str(self))
+            print("<No modes found>")
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(**{self._kwargs!r})"
+
+    def _repr_pretty_(self, printer, cycle):  # inheritance dosen't work here??
+        """For ipython."""
+        if cycle:
+            printer.text("UserCommands(...)")
+        else:
+            printer.text(str(self))
 
 
 def check_for_updates(package_name):
@@ -368,7 +465,7 @@ def add_packages_to_rc_search(local_path, package_list):
         rc.__search_path__.append_first(pkg_dir)
 
 
-def load_yaml_dicts(filename):
+def load_yaml_dicts(filename: str) -> list[dict[str, Any]]:
     """
     Load one or more dicts stored in a YAML file under `filename`.
 
@@ -383,11 +480,8 @@ def load_yaml_dicts(filename):
         A list of dicts
 
     """
-    yaml_dicts = []
-    with open(filename) as f:
-        yaml_dicts += [dic for dic in yaml.full_load_all(f)]
-
-    return yaml_dicts
+    with open(filename, encoding="utf-8") as file:
+        return list(yaml.full_load_all(file))
 
 
 def list_local_packages(action="display"):

--- a/scopesim/defaults.yaml
+++ b/scopesim/defaults.yaml
@@ -105,6 +105,23 @@ properties :
 
 
 ---
+### OBSERVATION PARAMETERS
+object : observation
+name : default_observation_config
+alias : OBS
+description : observation confiugration parameters
+
+packages : []
+yamls : []
+properties : {}
+
+use_instrument : ""
+ignore_effects : []
+add_effects : []
+override_effect_values : []
+
+
+---
 # MANDATORY TELESCOPE PARAMETERS
 alias : TEL
 

--- a/scopesim/defaults.yaml
+++ b/scopesim/defaults.yaml
@@ -105,23 +105,6 @@ properties :
 
 
 ---
-### OBSERVATION PARAMETERS
-object : observation
-name : default_observation_config
-alias : OBS
-description : observation confiugration parameters
-
-packages : []
-yamls : []
-properties : {}
-
-use_instrument : ""
-ignore_effects : []
-add_effects : []
-override_effect_values : []
-
-
----
 # MANDATORY TELESCOPE PARAMETERS
 alias : TEL
 

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -610,7 +610,13 @@ class SimulationConfigFitsKeywords(ExtraFitsKeywords):
         """See parent docstring."""
         opt_train = kwargs.get("optical_train")
         if isinstance(hdul, fits.HDUList) and opt_train is not None:
-            cmds = opt_train.cmds.cmds.dic
+            # HACK: This workaround was added after the ChainMap change, to
+            #       have a simply but save way of getting the final dict out.
+            # TODO: Improve this at some point.....
+            cmds = deepcopy(opt_train.cmds.maps[-1].dic)
+            for m in opt_train.cmds.maps[-2::-1]:
+                cmds |= deepcopy(m.dic)
+
             sim_prefix = self.meta["keyword_prefix"]
             resolve_prefix = "unresolved_" if not self.meta["resolve"] else ""
             # needed for the super().apply_to method

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -487,13 +487,6 @@ class OpticalTrain:
 
         return hdulist
 
-    # def set_focus(self, **kwargs):
-    #     self.cmds.update(**kwargs)
-    #     dy = self.cmds.default_yamls
-    #     if len(dy) > 0 and "packages" in dy:
-    #         self.cmds.update(packages=self.default_yamls[0]["packages"])
-    #     rc.__currsys__ = self.cmds
-
     def shutdown(self):
         """
         Shut down the instrument.

--- a/scopesim/tests/tests_commands/test_UserCommands.py
+++ b/scopesim/tests/tests_commands/test_UserCommands.py
@@ -76,9 +76,7 @@ class TestInit:
         """Check whether we can recreate a UserCommand by evaluating its __repr__."""
         cmd1 = UserCommands(use_instrument="test_package")
         cmd2 = eval(repr(cmd1))
-        # TODO: Create a proper __eq__ so we can assert cmd1 == cmd2
-        assert str(cmd1) == str(cmd2)
-        assert cmd1.cmds == cmd2.cmds
+        assert cmd1 == cmd2
 
 
 @pytest.mark.usefixtures("patch_all_mock_paths")


### PR DESCRIPTION
This makes `UserCommands` a subclass of `astar_utils.NestedChainMap`, which is a bang-string-key variant subclass of the standard library's `collections.ChainMap`. This enables a separation of configuration "layers" into global settings and default, optical train-wide settings and, in the future, effect-level properties and kwargs. Any changes applied through simple assignment (i.e. `__setitem__`, e.g. `cmd["foo"] = 42`) will only modify the top layer of this object, thus not influence any other instance building on the same base layer. The individual levels are "by ref", so any change that _is_ applied to the global settings (e.g. logging level) will be seen by all instances. All of this is an advantage over just updating dicts, and potentially making deep copies to avoid cross-contamination.

Additionally, I made some refactoring changes to the rather convoluted `.update()` method of `UserCommands`. It's still not quite where I want it to be, but one step at a time. I also added a whole bunch of debug-level logging to, well, debug the YAML loading process, mostly. This could be reduced again in the future, once it's more stable (or once [if] we change the way instrument packages are handled anyway...).

This also bumps the required version of astar-utils to 0.2.2, to include the new bang-string classes from there.