### PR TITLE
Fix RTD Poetry configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,12 +13,12 @@ build:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
     post_install:
       # Install dependencies with 'docs' dependency group
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry install --with docs
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
This follows a change in RTD's user guide found at https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry, which they changed in https://github.com/readthedocs/readthedocs.org/pull/11152 following a breaking change introduced by Poetry 1.8.

If this works, we should roll this change out to all our packages using Poetry to build doc, as the same error also occurs elsewhere (see e.g. https://readthedocs.org/projects/skycalc-ipy/builds/23587453/)