### PR TITLE
Make `required_keys` always a `set`

### DIFF
--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -78,6 +78,8 @@ class ApertureMask(Effect):
 
     """
 
+    required_keys = {"filename", "table", "array_dict"}
+
     def __init__(self, **kwargs):
         if not np.any([key in kwargs for key in ["filename", "table",
                                                  "array_dict"]]):
@@ -108,7 +110,6 @@ class ApertureMask(Effect):
         self._mask = None
         self.mask_sum = None
 
-        self.required_keys = ["filename", "table", "array_dict"]
         check_keys(kwargs, self.required_keys, "warning", all_any="any")
 
     def apply_to(self, obj, **kwargs):
@@ -200,13 +201,15 @@ class ApertureMask(Effect):
 
 
 class RectangularApertureMask(ApertureMask):
+    required_keys = {"x", "y", "width", "height"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         params = {"x_unit": "arcsec",
                   "y_unit": "arcsec"}
         self.meta.update(params)
         self.meta.update(kwargs)
-        check_keys(self.meta, ["x", "y", "width", "height"])
+        check_keys(self.meta, self.required_keys)
 
         self.table = self.get_table(**kwargs)
 
@@ -284,8 +287,9 @@ class ApertureList(Effect):
         self.meta.update(kwargs)
 
         if self.table is not None:
-            required_keys = ["id", "left", "right", "top", "bottom", "angle",
-                             "conserve_image", "shape"]
+            # Why not always?
+            required_keys = {"id", "left", "right", "top", "bottom", "angle",
+                             "conserve_image", "shape"}
             check_keys(self.table.colnames, required_keys)
 
     def apply_to(self, obj, **kwargs):

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -34,6 +34,8 @@ class Effect(DataContainer):
 
     """
 
+    required_keys = set()
+
     def __init__(self, filename=None, **kwargs):
         super().__init__(filename=filename, **kwargs)
         self.meta["z_order"] = []

--- a/scopesim/effects/electronic.py
+++ b/scopesim/effects/electronic.py
@@ -84,14 +84,15 @@ class DetectorModePropertiesSetter(Effect):
 
     """
 
+    required_keys = {"mode_properties"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         params = {"z_order": [299, 900]}
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        required_keys = ["mode_properties"]
-        check_keys(self.meta, required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
 
         self.mode_properties = kwargs["mode_properties"]
 
@@ -176,6 +177,8 @@ class AutoExposure(Effect):
 
     """
 
+    required_keys = {"fill_frac", "full_well", "mindit"}
+
     def __init__(self, **kwargs):
         """
         The effect is the first detector effect, hence essentially operates
@@ -189,8 +192,7 @@ class AutoExposure(Effect):
             from scopesim import UserCommands
             self.cmds = UserCommands()
 
-        required_keys = ["fill_frac", "full_well", "mindit"]
-        check_keys(self.meta, required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
 
     def apply_to(self, obj, **kwargs):
         if isinstance(obj, (ImagePlaneBase, DetectorBase)):
@@ -238,14 +240,15 @@ class AutoExposure(Effect):
 class SummedExposure(Effect):
     """Simulates a summed stack of ``ndit`` exposures."""
 
+    required_keys = {"dit", "ndit"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         params = {"z_order": [860]}
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        required_keys = ["dit", "ndit"]
-        check_keys(self.meta, required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
 
     def apply_to(self, obj, **kwargs):
         if isinstance(obj, DetectorBase):
@@ -260,14 +263,15 @@ class SummedExposure(Effect):
 class Bias(Effect):
     """Adds a constant bias level to readout."""
 
+    required_keys = {"bias"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         params = {"z_order": [855]}
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        required_keys = ["bias"]
-        check_keys(self.meta, required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
 
     def apply_to(self, obj, **kwargs):
         if isinstance(obj, DetectorBase):
@@ -277,20 +281,23 @@ class Bias(Effect):
         return obj
 
 class PoorMansHxRGReadoutNoise(Effect):
+    required_keys = {"noise_std", "n_channels", "ndit"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        params = {"z_order": [811],
-                  "pedestal_fraction": 0.3,
-                  "read_fraction": 0.4,
-                  "line_fraction": 0.25,
-                  "channel_fraction": 0.05,
-                  "random_seed": "!SIM.random.seed",
-                  "report_plot_include": False,
-                  "report_table_include": False}
+        params = {
+            "z_order": [811],
+            "pedestal_fraction": 0.3,
+            "read_fraction": 0.4,
+            "line_fraction": 0.25,
+            "channel_fraction": 0.05,
+            "random_seed": "!SIM.random.seed",
+            "report_plot_include": False,
+            "report_table_include": False,
+        }
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        self.required_keys = ["noise_std", "n_channels", "ndit"]
         check_keys(self.meta, self.required_keys, action="error")
 
     def apply_to(self, det, **kwargs):
@@ -332,13 +339,14 @@ class PoorMansHxRGReadoutNoise(Effect):
 class BasicReadoutNoise(Effect):
     """Readout noise computed as: ron * sqrt(NDIT)."""
 
+    required_keys = {"noise_std", "ndit"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.meta["z_order"] = [811]
         self.meta["random_seed"] = "!SIM.random.seed"
         self.meta.update(kwargs)
 
-        self.required_keys = ["noise_std", "ndit"]
         check_keys(self.meta, self.required_keys, action="error")
 
     def apply_to(self, det, **kwargs):
@@ -417,12 +425,14 @@ class DarkCurrent(Effect):
     """
     required: dit, ndit, value
     """
+
+    required_keys = {"value", "dit", "ndit"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.meta["z_order"] = [830]
 
-        required_keys = ["value", "dit", "ndit"]
-        check_keys(self.meta, required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
 
     def apply_to(self, obj, **kwargs):
         if isinstance(obj, DetectorBase):
@@ -487,6 +497,8 @@ class LinearityCurve(Effect):
 
     """
 
+    required_keys = {"ndit"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         params = {
@@ -497,7 +509,6 @@ class LinearityCurve(Effect):
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        self.required_keys = ["ndit"]
         check_keys(self.meta, self.required_keys, action="error")
 
     def apply_to(self, obj, **kwargs):
@@ -562,11 +573,12 @@ class ReferencePixelBorder(Effect):
 
 
 class BinnedImage(Effect):
+    required_keys = {"bin_size"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.meta["z_order"] = [870]
 
-        self.required_keys = ["bin_size"]
         check_keys(self.meta, self.required_keys, action="error")
 
     def apply_to(self, det, **kwargs):
@@ -580,11 +592,12 @@ class BinnedImage(Effect):
         return det
 
 class UnequalBinnedImage(Effect):
+    required_keys = {"binx","biny"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.meta["z_order"] = [870]
 
-        self.required_keys = ["binx","biny"]
         check_keys(self.meta, self.required_keys, action="error")
 
     def apply_to(self, det, **kwargs):

--- a/scopesim/effects/obs_strategies.py
+++ b/scopesim/effects/obs_strategies.py
@@ -50,8 +50,10 @@ class ChopNodCombiner(Effect):
 
     """
 
+    required_keys = {"chop_offsets", "pixel_scale"}
+
     def __init__(self, **kwargs):
-        check_keys(kwargs, ["chop_offsets", "pixel_scale"])
+        check_keys(kwargs, self.required_keys)
 
         super().__init__(**kwargs)
         params = {

--- a/scopesim/effects/psfs.py
+++ b/scopesim/effects/psfs.py
@@ -166,13 +166,14 @@ class AnalyticalPSF(PSF):
 class Vibration(AnalyticalPSF):
     """Creates a wavelength independent kernel image."""
 
+    required_keys = {"fwhm", "pixel_scale"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.meta["z_order"] = [244, 744]
         self.meta["width_n_fwhms"] = 4
         self.convolution_classes = ImagePlaneBase
 
-        self.required_keys = ["fwhm", "pixel_scale"]
         check_keys(self.meta, self.required_keys, action="error")
         self.kernel = None
 
@@ -197,6 +198,8 @@ class NonCommonPathAberration(AnalyticalPSF):
     Accepted: kernel_width, strehl_drift
     """
 
+    required_keys = {"pixel_scale"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.meta["z_order"] = [241, 641]
@@ -210,7 +213,6 @@ class NonCommonPathAberration(AnalyticalPSF):
         self.valid_waverange = [0.1 * u.um, 0.2 * u.um]
 
         self.convolution_classes = FieldOfViewBase
-        self.required_keys = ["pixel_scale"]
         check_keys(self.meta, self.required_keys, action="error")
 
     def fov_grid(self, which="waveset", **kwargs):
@@ -435,6 +437,8 @@ class AnisocadoConstPSF(SemiAnalyticalPSF):
 
     """
 
+    required_keys = {"filename", "strehl", "wavelength"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         params = {
@@ -446,7 +450,6 @@ class AnisocadoConstPSF(SemiAnalyticalPSF):
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        self.required_keys = ["filename", "strehl", "wavelength"]
         check_keys(self.meta, self.required_keys, action="error")
         self.nmRms      # check to see if it throws an error
 
@@ -593,11 +596,13 @@ class FieldConstantPSF(DiscretePSF):
     For spectroscopy, a wavelength-dependent PSF cube is built, where for each
     wavelength the reference PSF is scaled proportional to wavelength.
     """
+
+    required_keys = {"filename"}
+
     def __init__(self, **kwargs):
         # sub_pixel_flag and flux_accuracy are taken care of in PSF base class
         super().__init__(**kwargs)
 
-        self.required_keys = ["filename"]
         check_keys(self.meta, self.required_keys, action="error")
 
         self.meta["z_order"] = [262, 662]
@@ -723,11 +728,12 @@ class FieldVaryingPSF(DiscretePSF):
 
     """
 
+    required_keys = {"filename"}
+
     def __init__(self, **kwargs):
         # sub_pixel_flag and flux_accuracy are taken care of in PSF base class
         super().__init__(**kwargs)
 
-        self.required_keys = ["filename"]
         check_keys(self.meta, self.required_keys, action="error")
 
         self.meta["z_order"] = [261, 661]

--- a/scopesim/effects/rotation.py
+++ b/scopesim/effects/rotation.py
@@ -23,14 +23,15 @@ class Rotate90CCD(Effect):
 
     """
 
+    required_keys = {"rotations"}
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         params = {"z_order": [809]}
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        required_keys = ["rotations"]
-        utils.check_keys(self.meta, required_keys, action="error")
+        utils.check_keys(self.meta, self.required_keys, action="error")
 
     def apply_to(self, obj, **kwargs):
         """See parent docstring."""

--- a/scopesim/effects/shifts.py
+++ b/scopesim/effects/shifts.py
@@ -102,6 +102,17 @@ class AtmosphericDispersion(Shift3D):
 
     """
 
+    required_keys = {
+        "airmass",
+        "temperature",
+        "humidity",
+        "pressure",
+        "latitude",
+        "altitude",
+        "pupil_angle",
+        "pixel_scale",
+    }
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         params = {
@@ -115,9 +126,7 @@ class AtmosphericDispersion(Shift3D):
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        required_keys = ["airmass", "temperature", "humidity", "pressure",
-                         "latitude", "altitude", "pupil_angle", "pixel_scale"]
-        check_keys(self.meta, required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
 
     def get_table(self, **kwargs):
         """
@@ -172,6 +181,18 @@ class AtmosphericDispersionCorrection(Shift3D):
     kwargs
     """
 
+    required_keys = {
+        "airmass",
+        "temperature",
+        "humidity",
+        "pressure",
+        "latitude",
+        "altitude",
+        "pupil_angle",
+        "pixel_scale",
+        "wave_mid",
+    }
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.meta["z_order"] = [632]
@@ -181,10 +202,7 @@ class AtmosphericDispersionCorrection(Shift3D):
             self.meta["efficiency"] = 1
         self.apply_to_classes = FieldOfViewBase
 
-        required_keys = ["airmass", "temperature", "humidity", "pressure",
-                         "latitude", "altitude", "pupil_angle", "pixel_scale",
-                         "wave_mid"]
-        check_keys(self.meta, required_keys, action="error")
+        check_keys(self.meta, self.required_keys, action="error")
 
         if self.table is None:
             self.table = self.get_table()

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -505,7 +505,6 @@ class TopHatFilterCurve(FilterCurve):
     required_keys = {"transmission", "blue_cutoff", "red_cutoff"}
 
     def __init__(self, cmds=None, **kwargs):
-        required_keys = ["transmission", "blue_cutoff", "red_cutoff"]
         check_keys(kwargs, self.required_keys, action="error")
         self.cmds = cmds
 

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -502,9 +502,11 @@ class TopHatFilterCurve(FilterCurve):
 
     """
 
+    required_keys = {"transmission", "blue_cutoff", "red_cutoff"}
+
     def __init__(self, cmds=None, **kwargs):
         required_keys = ["transmission", "blue_cutoff", "red_cutoff"]
-        check_keys(kwargs, required_keys, action="error")
+        check_keys(kwargs, self.required_keys, action="error")
         self.cmds = cmds
 
         wave_min = from_currsys("!SIM.spectral.wave_min", self.cmds)
@@ -525,9 +527,10 @@ class TopHatFilterCurve(FilterCurve):
 
 
 class DownloadableFilterCurve(FilterCurve):
+    required_keys = {"filter_name", "filename_format"}
+
     def __init__(self, **kwargs):
-        required_keys = ["filter_name", "filename_format"]
-        check_keys(kwargs, required_keys, action="error")
+        check_keys(kwargs, self.required_keys, action="error")
         filt_str = kwargs["filename_format"].format(kwargs["filter_name"])
         tbl = download_svo_filter(filt_str, return_style="table")
         super().__init__(table=tbl, **kwargs)
@@ -556,9 +559,10 @@ class SpanishVOFilterCurve(FilterCurve):
 
     """
 
+    required_keys = {"observatory", "instrument", "filter_name"}
+
     def __init__(self, **kwargs):
-        required_keys = ["observatory", "instrument", "filter_name"]
-        check_keys(kwargs, required_keys, action="error")
+        check_keys(kwargs, self.required_keys, action="error")
         filt_str = "{}/{}.{}".format(kwargs["observatory"],
                                      kwargs["instrument"],
                                      kwargs["filter_name"])

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -576,7 +576,6 @@ class SpanishVOFilterCurve(FilterCurve):
 class FilterWheelBase(Effect):
     """Base class for Filter Wheels."""
 
-    required_keys = set()
     _current_str = "current_filter"
 
     def __init__(self, **kwargs):

--- a/scopesim/optics/fov_manager_utils.py
+++ b/scopesim/optics/fov_manager_utils.py
@@ -38,8 +38,13 @@ def get_3d_shifts(effects, **kwargs):
     - x_shift, y_shift: [deg]
 
     """
-    required_keys = ["wave_min", "wave_mid", "wave_max",
-                     "sub_pixel_fraction", "pixel_scale"]
+    required_keys = {
+        "wave_min",
+        "wave_mid",
+        "wave_max",
+        "sub_pixel_fraction",
+        "pixel_scale",
+    }
     check_keys(kwargs, required_keys, action="warning")
 
     effects = get_all_effects(effects, efs.Shift3D)
@@ -100,7 +105,7 @@ def get_imaging_waveset(effects_list, **kwargs):
         [um] list of wavelengths
 
     """
-    required_keys = ["wave_min", "wave_max"]
+    required_keys = {"wave_min", "wave_max"}
     check_keys(kwargs, required_keys, action="error")
 
     # get the filter wavelengths first to set (wave_min, wave_max)
@@ -163,8 +168,12 @@ def get_imaging_headers(effects, **kwargs):
     #   if larger than max_chunk_size, split into smaller headers
     # add image plane WCS information for a direct projection
 
-    required_keys = ["pixel_scale", "plate_scale",
-                     "chunk_size", "max_segment_size"]
+    required_keys = {
+        "pixel_scale",
+        "plate_scale",
+        "chunk_size",
+        "max_segment_size",
+    }
     check_keys(kwargs, required_keys, action="error")
 
     plate_scale = kwargs["plate_scale"]     # ["/mm]
@@ -284,8 +293,12 @@ def get_imaging_fovs(headers, waveset, shifts, **kwargs):
 
 def get_spectroscopy_headers(effects, **kwargs):
     """Return generator of Header objects."""
-    required_keys = ["pixel_scale", "plate_scale",
-                     "wave_min", "wave_max"]
+    required_keys = {
+        "pixel_scale",
+        "plate_scale",
+        "wave_min",
+        "wave_max",
+    }
     check_keys(kwargs, required_keys, action="error")
 
     surface_list_effects = get_all_effects(effects, (efs.SurfaceList,

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -5,9 +5,9 @@ from pathlib import Path
 import sys
 import logging
 from logging.config import dictConfig
-from collections.abc import Iterable, Generator, Set
+from collections.abc import Iterable, Generator, Set, Mapping
 from copy import deepcopy
-from typing import TextIO
+from typing import TextIO, Union
 from io import StringIO
 from importlib import metadata
 import functools
@@ -555,8 +555,40 @@ def from_rc_config(item):
     return from_currsys(item, rc.__config__)
 
 
-def check_keys(input_dict, required_keys, action="error", all_any="all"):
-    """Check to see if all/any of the required keys are present in a dict."""
+def check_keys(input_dict: Union[Mapping, Iterable],
+               required_keys: Set,
+               action: str = "error",
+               all_any: str = "all") -> bool:
+    """
+    Check to see if all/any of the required keys are present in a dict.
+
+    .. versionchanged:: v0.8.0
+        The `required_keys` parameter should now be a set.
+
+    Parameters
+    ----------
+    input_dict : Union[Mapping, Iterable]
+        The mapping to be checked.
+    required_keys : Set
+        Set containing the keys to look for.
+    action : {"error", "warn", "warning"}, optional
+        What to do in case the check does not pass. The default is "error".
+    all_any : {"all", "any"}, optional
+        Whether to check if "all" or "any" of the `required_keys` are present.
+        The default is "all".
+
+    Raises
+    ------
+    ValueError
+        Raised when an invalid parameter was passed or when `action` was set to
+        "error" (the default) and the `required_keys` were not found.
+
+    Returns
+    -------
+    keys_present : bool
+        ``True`` if check succeded, ``False`` otherwise.
+
+    """
     # Checking for Set from collections.abc instead of builtin set to allow
     # for any duck typing (e.g. dict keys view or whatever)
     if not isinstance(required_keys, Set):

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -596,15 +596,11 @@ def check_keys(input_dict: Union[Mapping, Iterable],
                        "found %s instead.", type(required_keys))
         required_keys = set(required_keys)
 
-    # First assume it's a Mapping, otherwise attempt to convert to set.
     try:
-        input_keys = input_dict.keys()
-    except AttributeError:
-        try:
-            input_keys = set(input_dict)
-        except Exception as err:
-            raise ValueError("input_dict must be mapping or iterable, but was "
-                             f"{type(input_dict)}") from err
+        input_keys = set(input_dict)
+    except Exception as err:
+        raise ValueError("input_dict must be mapping or iterable, but was "
+                         f"{type(input_dict)}") from err
 
     if all_any == "all":
         keys_present = required_keys.issubset(input_keys)

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -596,28 +596,21 @@ def check_keys(input_dict: Union[Mapping, Iterable],
                        "found %s instead.", type(required_keys))
         required_keys = set(required_keys)
 
-    try:
-        input_keys = set(input_dict)
-    except Exception as err:
-        raise ValueError("input_dict must be mapping or iterable, but was "
-                         f"{type(input_dict)}") from err
-
     if all_any == "all":
-        keys_present = required_keys.issubset(input_keys)
+        keys_present = required_keys.issubset(input_dict)
     elif all_any == "any":
-        keys_present = not required_keys.isdisjoint(input_keys)
+        keys_present = not required_keys.isdisjoint(input_dict)
     else:
         raise ValueError("all_any must be either 'all' or 'any'")
 
     if not keys_present:
+        missing = "', '".join(required_keys.difference(input_dict)) or "<none>"
         if "error" in action:
             raise ValueError(
-                f"The keys {', '.join(required_keys - input_keys) or '<none>'}"
-                " are missing from input_dict.")
+                f"The keys '{missing}' are missing from input_dict.")
         if "warn" in action:
             logger.warning(
-                "The keys '%s' are missing from input_dict.",
-                "', '".join(required_keys - input_keys) or "<none>")
+                "The keys '%s' are missing from input_dict.", missing)
 
     return keys_present
 


### PR DESCRIPTION
Harmonize the `required_keys` of all effects to be a class attribute (as it will never change across instances) and a `set` (as that makes it simpler and more efficient to compare against the supplied keys in a dict using set methods). In the future, I'll probably move this check to the `Effect` base class and run it as part of the `super().__init__()` call in each effect (i.e. `required_keys` is an empty `set` in the base class, and overridden in the effect subclasses that need it).

_Note: Yes, this is more dev wåñk. I did these changes a while ago, but never pushed and PR'd..._