### PR TITLE
Fix METIS IFU mode

### DIFF
--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -584,6 +584,13 @@ class MetisLMSEfficiency(TERCurve):
 
         lam, efficiency = self.make_ter_curve(wcal, wavelen)
 
+        # HACK: Somehow we end up with duplicate keywords here. This hack
+        #       should not be necessary at all! Investigate what's really
+        #       going on...
+        self.meta.pop("wavelength", None)
+        self.meta.pop("transmission", None)
+        self.meta.pop("emissivity", None)
+
         super().__init__(wavelength=lam,
                          transmission=efficiency,
                          emissivity=np.zeros_like(lam),

--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -315,8 +315,7 @@ class MetisLMSSpectralTrace(SpectralTrace):
         y_min = aperture["bottom"]
         y_max = aperture["top"]
 
-        filename_det_layout = from_currsys("!DET.layout.file_name", cmds=self.cmds)
-        layout = ioascii.read(find_file(filename_det_layout))
+        layout = ioascii.read(find_file(self.cmds["!DET.layout.filename"]))
         det_lims = {}
         xhw = layout["pixel_size"] * layout["x_size"] / 2
         yhw = layout["pixel_size"] * layout["y_size"] / 2
@@ -570,13 +569,10 @@ class MetisLMSEfficiency(TERCurve):
     }
 
     def __init__(self, **kwargs):
-        # TODO: Refactor these _class_params?
-        self.meta = copy.copy(self._class_params)
-        assert "grat_spacing" in self.meta, "grat_spacing is missing from self.meta 1"
-        super().__init__(**kwargs)
-        assert "grat_spacing" in self.meta, "grat_spacing is missing from self.meta 2"
+        self.meta = self._class_params
+        self.meta.update(kwargs)
 
-        filename = find_file(self.meta["filename"])
+        filename = find_file(from_currsys(self.meta["filename"], kwargs.get("cmds")))
         wcal = fits.getdata(filename, extname="WCAL")
         if "wavelen" in kwargs:
             wavelen = from_currsys(kwargs["wavelen"], kwargs.get("cmds"))

--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -1,5 +1,5 @@
 """SpectralTraceList and SpectralTrace for the METIS LM spectrograph."""
-import copy
+
 import warnings
 
 import numpy as np
@@ -163,11 +163,12 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
         self.meta["angle"] = tempres["Angle"]
 
         spec_traces = {}
-        for sli in np.arange(self.meta["nslice"]):
-            slicename = "Slice " + str(sli + 1)
+        for sli in range(self.meta["nslice"]):
+            slicename = f"Slice {sli + 1}"
             spec_traces[slicename] = MetisLMSSpectralTrace(
                 self._file,
-                spslice=sli, params=self.meta)
+                spslice=sli,
+                params=self.meta)
 
         self.spectral_traces = spec_traces
 
@@ -287,7 +288,7 @@ class MetisLMSSpectralTrace(SpectralTrace):
         super().__init__(polyhdu, **params)
 
         self._file = hdulist
-        self.meta["description"] = "Slice " + str(spslice + 1)
+        self.meta["description"] = f"Slice {spslice + 1}"
         self.meta["trace_id"] = f"Slice {spslice + 1}"
         self.meta.update(params)
         # Provisional:

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -144,8 +144,9 @@ class FieldOfView(FieldOfViewBase):
                         spec_refs.add(ref)
 
         waves = volume["waves"] * u.Unit(volume["wave_unit"])
-        spectra = {ref: fu.extract_range_from_spectrum(src.spectra[ref], waves)
-                   for ref in spec_refs}
+        spectra = {ref: fu.extract_range_from_spectrum(
+            src.spectra[int(ref)], waves)
+            for ref in spec_refs}
 
         self.fields = fields_in_fov
         self.spectra = spectra


### PR DESCRIPTION
Got a few errors when attempting to run the new `laser_spectrum` and `pinhole_mask` through the `lms` (aka IFU?) mode. This, together with the IRDB counterpart, makes it work and the output looks promising.

**Short explanation on those new exceptions:**
When I initially ran the simulation, I got weird errors which I ultimately traced down to a less-than-optimal handling of "Spectral trace outside FOV". Now the trace being outside the FOV was a symptom of something else (wrong detector layout), but that shouldn't have stopped the simulation as a whole (the erroneous layout basically mimicked a `DetecorWindow`, and that's supposed to work...). However the function `map_spectra_to_focal_plane()` just logged a warning/info and then `return None` (instead of a HDU), while the calling function had no way of handling this (unexpected but not impossible) `None` value, so it subsequently failed attempting to access the supposed HDU's attributes. Since I figured it would be fine to just "skip" a trace if it's outside the final FOV anyway, I added the new exceptions as a way for the calling function to deal with unexpected (but not catastrophic) behavior of the lower level. This also has the benefits of a) `map_spectra_to_focal_plane()` always returns a HDU or raises an exception, but never silently returns `None`; b) allows different treatment of different fail conditions if required (currently just handles the base exception).

All of this might also just be another symptom of the split between "normal" spectral traces and the "special" METIS classes.