### PR TITLE
Fix master -> main aftermath

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - main
-      - master
-      - dev_master
   pull_request:
     branches:
       - main
-      - master
-      - dev_master
 
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,12 +3,10 @@ name: Tests
 on:
   push:
     branches:
-      - master
-      - dev_master
+      - main
   pull_request:
     branches:
-      - master
-      - dev_master
+      - main
   schedule:
     - # Run every day at 5:00 UTC
     - cron: "0 5 * * *"


### PR DESCRIPTION
Replace branch names in workflow files.

Also: That's a fitting PR number. Branch not found 😛 