### PR TITLE
Add `SourceField` and subclasses, rework `Source`

### DIFF
--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -9,6 +9,7 @@ from astropy import units as u
 from astropy.table import Table
 
 from . import Effect
+from ..source.source_fields import HDUSourceField, TableSourceField
 from ..utils import from_currsys, find_file
 
 
@@ -530,19 +531,23 @@ class SourceDescriptionFitsKeywords(ExtraFitsKeywords):
         if (src := opt_train._last_source) is not None:
             prefix = self.meta["keyword_prefix"]
             for i, field in enumerate(src.fields):
-                src_class = field.__class__.__name__
+                src_class = field.field.__class__.__name__
                 src_dic = deepcopy(src._meta_dicts[i])
-                if isinstance(field, fits.ImageHDU):
+                print(src)
+                print(src.meta)
+                print(src_dic)
+                print(src.fields[0].meta)
+                if isinstance(field, HDUSourceField):
                     hdr = field.header
                     for key in hdr:
                         src_dic = {key: [hdr[key], hdr.comments[key]]}
 
-                elif isinstance(field, Table):
+                elif isinstance(field, TableSourceField):
                     src_dic.update(field.meta)
                     src_dic["length"] = len(field)
-                    for j, name in enumerate(field.colnames):
+                    for j, name in enumerate(field.field.colnames):
                         src_dic[f"col{j}_name"] = name
-                        src_dic[f"col{j}_unit"] = str(field[name].unit)
+                        src_dic[f"col{j}_unit"] = str(field.field[name].unit)
 
                 self.dict_list = [{"ext_number": self.meta["ext_number"],
                                    "keywords": {

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -532,7 +532,7 @@ class SourceDescriptionFitsKeywords(ExtraFitsKeywords):
             prefix = self.meta["keyword_prefix"]
             for i, field in enumerate(src.fields):
                 src_class = field.field.__class__.__name__
-                src_dic = deepcopy(src._meta_dicts[i])
+                src_dic = deepcopy(field.meta)
                 if isinstance(field, HDUSourceField):
                     hdr = field.header
                     for key in hdr:

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -532,7 +532,7 @@ class SourceDescriptionFitsKeywords(ExtraFitsKeywords):
             prefix = self.meta["keyword_prefix"]
             for i, field in enumerate(src.fields):
                 src_class = field.field.__class__.__name__
-                src_dic = deepcopy(field.meta)
+                src_dic = deepcopy(src.meta)
                 if isinstance(field, HDUSourceField):
                     hdr = field.header
                     for key in hdr:

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -533,10 +533,6 @@ class SourceDescriptionFitsKeywords(ExtraFitsKeywords):
             for i, field in enumerate(src.fields):
                 src_class = field.field.__class__.__name__
                 src_dic = deepcopy(src._meta_dicts[i])
-                print(src)
-                print(src.meta)
-                print(src_dic)
-                print(src.fields[0].meta)
                 if isinstance(field, HDUSourceField):
                     hdr = field.header
                     for key in hdr:

--- a/scopesim/effects/spectral_efficiency.py
+++ b/scopesim/effects/spectral_efficiency.py
@@ -106,10 +106,10 @@ class SpectralEfficiency(Effect):
             logger.warning("No grating efficiency for trace %s", trace_id)
             return obj
 
-        wcs = WCS(obj.hdu.header).spectral
-        wave_cube = wcs.all_pix2world(np.arange(obj.hdu.data.shape[0]), 0)[0]
-        wave_cube = (wave_cube * u.Unit(wcs.wcs.cunit[0])).to(u.AA)
-        obj.hdu = apply_throughput_to_cube(obj.hdu, effic.throughput)
+        swcs = WCS(obj.hdu.header).spectral
+        with u.set_enabled_equivalencies(u.spectral()):
+            wave = swcs.pixel_to_world(np.arange(swcs.pixel_shape[0])) << u.um
+        obj.hdu = apply_throughput_to_cube(obj.hdu, effic.throughput, wave)
         return obj
 
     def plot(self):

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -116,7 +116,8 @@ class TERCurve(Effect):
             # apply transmission to source spectra
             for fld in obj.fields:
                 if isinstance(fld, CubeSourceField):
-                    fld.field = apply_throughput_to_cube(fld.field, thru)
+                    fld.field = apply_throughput_to_cube(fld.field, thru,
+                                                         fld.wave)
                     continue
 
                 for isp, spec in fld.spectra.items():

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -113,7 +113,7 @@ class TERCurve(Effect):
             thru = self.throughput
 
             # apply transmission to source spectra
-            for isp, spec in enumerate(obj.spectra):
+            for isp, spec in obj.spectra.items():
                 obj.spectra[isp] = combine_two_spectra(spec, thru, "multiply",
                                                        wave_min, wave_max)
 

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -121,7 +121,7 @@ class FieldOfView(FieldOfViewBase):
         if not isinstance(src, SourceBase):
             raise ValueError(f"source must be a Source object: {type(src)}")
 
-        fields_in_fov = [field for field in src.fields
+        fields_in_fov = [field.field for field in src.fields
                          if fu.is_field_in_fov(self.header, field)]
         if not fields_in_fov:
             logger.warning("No fields in FOV.")

--- a/scopesim/optics/fov_utils.py
+++ b/scopesim/optics/fov_utils.py
@@ -22,8 +22,9 @@ def is_field_in_fov(fov_header, field, wcs_suffix=""):
     ----------
     fov_header : fits.Header
         Header from a FieldOfView object
-    field : [astropy.Table, astropy.ImageHDU]
-        Field object from a Source object
+    field : [SourceField, astropy.Table, astropy.ImageHDU]
+        Field object from a Source object. Should now be SourceField, but bare
+        Table and ImageHDU still supported.
     wcs_suffix : str
         ["S", "D"] Coordinate system: Sky or Detector
 
@@ -34,6 +35,8 @@ def is_field_in_fov(fov_header, field, wcs_suffix=""):
     """
     if isinstance(field, SourceField):
         field = field.field
+    # TODO: Check if this can always get a SourceField, if yes then just do
+    #       that and remove this.
 
     if isinstance(field, fits.ImageHDU) and \
             field.header.get("BG_SRC") is not None:

--- a/scopesim/optics/fov_utils.py
+++ b/scopesim/optics/fov_utils.py
@@ -7,6 +7,7 @@ from astropy.wcs import WCS
 from synphot import SourceSpectrum, Empirical1D
 
 from . import image_plane_utils as imp_utils
+from ..source.source_fields import SourceField
 from ..utils import from_currsys, quantify, quantity_from_table, get_logger
 
 
@@ -31,6 +32,9 @@ def is_field_in_fov(fov_header, field, wcs_suffix=""):
     is_inside_fov : bool
 
     """
+    if isinstance(field, SourceField):
+        field = field.field
+
     if isinstance(field, fits.ImageHDU) and \
             field.header.get("BG_SRC") is not None:
         is_inside_fov = True

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -52,7 +52,7 @@ def get_canvas_header(hdu_or_table_list, pixel_scale=1 * u.arcsec):
             else:
                 raise TypeError(
                     "hdu_or_table_list may only contain fits.ImageHDU, Table "
-                    "or fits.Header, found {type(hdu_or_table)}.")
+                    f"or fits.Header, found {type(hdu_or_table)}.")
         if tables:
             yield _make_bounding_header_for_tables(*tables,
                                                    pixel_scale=pixel_scale)

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import numpy as np
 from scipy.interpolate import interp1d
 from astropy import units as u
+from astropy.wcs import WCS
 
 from tqdm import tqdm
 
@@ -20,7 +21,7 @@ from ..commands.user_commands import UserCommands
 from ..detector import DetectorManager
 from ..effects import ExtraFitsKeywords
 from ..utils import from_currsys, top_level_catch, get_logger
-from .. import rc, __version__
+from .. import __version__
 
 
 logger = get_logger(__name__)
@@ -275,7 +276,8 @@ class OpticalTrain:
         ImageHDU.
         """
         # Convert to PHOTLAM per arcsec2
-        # ..todo: this is not sufficiently general
+        # TODO: this is not sufficiently general
+        # TODO: Maybe move this to source_fields??
 
         for ispec, spec in source.spectra.items():
             # Put on fov wavegrid
@@ -347,6 +349,8 @@ class OpticalTrain:
             cube.header["CRVAL3"] = wave_min.value
             cube.header["CDELT3"] = dwave
             cube.header["CUNIT3"] = wave_unit.name
+
+            cube.wcs = WCS(cube.field)
 
         return source
 

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -277,7 +277,7 @@ class OpticalTrain:
         # Convert to PHOTLAM per arcsec2
         # ..todo: this is not sufficiently general
 
-        for ispec, spec in enumerate(source.spectra):
+        for ispec, spec in source.spectra.items():
             # Put on fov wavegrid
             wave_min = min(fov.meta["wave_min"] for fov in self.fov_manager.fovs)
             wave_max = max(fov.meta["wave_max"] for fov in self.fov_manager.fovs)

--- a/scopesim/rc.py
+++ b/scopesim/rc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Global configurations for ScopeSim."""
+"""Global configurations for ScopeSim (rc ... runtime configuration)."""
 
 from pathlib import Path
 import yaml

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -558,13 +558,15 @@ class Source(SourceBase):
         new_source._meta = deepcopy(self.meta)
         # new_source.spectra = deepcopy(self.spectra)
         for field in self.fields:
-            new_source.fields.append(deepcopy(field))
+            # new_source.fields.append(deepcopy(field))
             # TODO: The code below refers to DataContainer??
-            # if isinstance(field, (fits.ImageHDU, fits.PrimaryHDU)) \
-            #         and field._file is not None:  # and field._data_loaded is False:
-            #     new_source.fields.append(field)
-            # else:
-            #     new_source.fields.append(deepcopy(field))
+            # FIXME: Omitting this causes "TypeError: cannot pickle '_io.BufferedReader' object"
+            #        for fields loaded from FITS files. Should be properly fixed!!
+            if (isinstance(field.field, (fits.ImageHDU, fits.PrimaryHDU))
+                    and field.field._file is not None):  # and field._data_loaded is False:
+                new_source.fields.append(field)
+            else:
+                new_source.fields.append(deepcopy(field))
 
         return new_source
 

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -412,15 +412,6 @@ class Source(SourceBase):
         self.fields[0].meta = value
 
     @property
-    def _meta_dicts(self):
-        return [fld.meta for fld in self.fields]
-
-    @_meta_dicts.setter
-    def _meta_dicts(self, value):
-        logger.debug("_meta_dicts setting is deprecated")
-        pass
-
-    @property
     def bandpass(self):
         return self._bandpass
 
@@ -568,7 +559,6 @@ class Source(SourceBase):
     def make_copy(self):
         new_source = Source()
         new_source.meta = deepcopy(self.meta)
-        # new_source._meta_dicts = deepcopy(self._meta_dicts)
         # new_source.spectra = deepcopy(self.spectra)
         for field in self.fields:
             new_source.fields.append(deepcopy(field))
@@ -586,13 +576,6 @@ class Source(SourceBase):
             raise ValueError(f"Cannot add {type(source_to_add)} object to Source object")
 
         new_source = source_to_add.make_copy()
-        # If there is no field yet, then self._meta_dicts contains a
-        # reference to self.meta, which is empty. This ensures that both are
-        # updated at the same time. However, it is important that the fields
-        # and _meta_dicts match when appending sources.
-        if len(self.fields) == 0:
-            assert self._meta_dicts == [{}] or self._meta_dicts == []
-            self._meta_dicts = []
 
         specrefoffset = max(self.spectra.keys()) + 1 if self.spectra else 0
         for field in new_source.fields:
@@ -608,7 +591,6 @@ class Source(SourceBase):
 
             field.spectra = {k + specrefoffset: v for k, v in
                              new_source.spectra.items()}
-            self._meta_dicts += source_to_add._meta_dicts
 
     def __add__(self, new_source):
         self_copy = self.make_copy()

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -574,6 +574,11 @@ class Source(SourceBase):
 
         new_source = source_to_add.make_copy()
 
+        # FIXME: This offset should not be required, now that spectra for each
+        #        field are stored in that field. However, there is some code
+        #        that loops over the combined Source.spectra dict and that
+        #        fails if the keys in the field's spectra contain duplicates.
+        #        This need to be fixed ASAP!
         specrefoffset = max(self.spectra.keys()) + 1 if self.spectra else 0
         for field in new_source.fields:
             if isinstance(field, TableSourceField):

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -368,17 +368,17 @@ class Source(SourceBase):
 
     @property
     def table_fields(self):
-        """Return list of fields that are defined through tables."""
+        """List of fields that are defined through tables."""
         return list(self._get_fields(TableSourceField))
 
     @property
     def image_fields(self):
-        """Return list of fields that are defined through 2D images."""
+        """List of fields that are defined through 2D images."""
         return list(self._get_fields(ImageSourceField))
 
     @property
     def cube_fields(self):
-        """Return list of fields that are defined through 3D datacubes."""
+        """List of fields that are defined through 3D datacubes."""
         return list(self._get_fields(CubeSourceField))
 
     @property

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -4,7 +4,7 @@ Contains ``SourceField`` and its subclasses.
 
 While the ``Source`` object serves as the high-level interface between target
 descriptions and the ScopeSim optical train, the actual information about the
-observed objects is stored in the ``SourceField`` classes, which constitut the
+observed objects is stored in the ``SourceField`` classes, which constitute the
 members of ``Source.fields`` collection. Any target to be understood by
 ScopeSim can be characterized by either a ``Table`` of point sources, a
 two-dimensional image (``ImageHDU``) plus a separate (averaged) spectrum, or a
@@ -23,7 +23,7 @@ are now stored in the ``.field`` attribute of each source field. This new
 distinction of the different cases allows much clearer separation of the logic
 required to handle various operations on those objects, such as plotting and
 shifting the source, which previously had to incorporate a number of case
-differentiations that made the ``Source`` class rather oberloaded with logic.
+differentiations that made the ``Source`` class rather overloaded with logic.
 This now also allows for well-structured validation logic of the individual
 source field data upon creation of each ``SourceField`` subclass instance.
 
@@ -33,7 +33,7 @@ these classes directly, except for debugging. They serve more as an internal
 abstraction layer to handle the different cases of target object descriptions,
 as described above.
 
-The following class diagramm illustrates the relationship between the
+The following class diagram illustrates the relationship between the
 ``SourceField`` subclasses:
 
 ```mmd

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -274,9 +274,11 @@ class ImageSourceField(SpectrumSourceField, HDUSourceField):
 class CubeSourceField(HDUSourceField):
     """Source field with 3D data cube."""
 
+    from_hdul: bool = False
+
     def __post_init__(self):
         """Validate input."""
-        if self.wcs is None and not self.meta.get("from_hdul", False):
+        if self.wcs is None and not self.from_hdul:
             self.wcs = WCS(self.field)
 
         try:
@@ -295,7 +297,7 @@ class CubeSourceField(HDUSourceField):
         """Load source cube from HDUL."""
         cube = fits.ImageHDU(header=hdulist[ext].header.copy(),
                              data=deepcopy(hdulist[ext].data))
-        new_csf = cls(field=cube, meta=kwargs | {"from_hdul": True})
+        new_csf = cls(field=cube, meta=kwargs, from_hdul=True)
         new_csf.wcs = WCS(hdulist[ext], fobj=hdulist)
         return new_csf
 

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -198,7 +198,7 @@ class HDUSourceField(SourceField):
     """Base class for source fields with HDU."""
 
     field: fits.ImageHDU
-    wcs: WCS = dataclass_field(default_factory=WCS, init=False)
+    wcs: WCS | None = dataclass_field(default=None, init=False)
 
     def __new__(cls, *args, **kwargs):
         """Override creation to create subclasses."""

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -203,7 +203,7 @@ class HDUSourceField(SourceField):
     def __new__(cls, *args, **kwargs):
         """Override creation to create subclasses."""
         if issubclass(cls, (CubeSourceField, ImageSourceField)):
-            # Allow for dirct subclass access
+            # Allow for direct subclass access
             return super().__new__(cls)
 
         field = kwargs.get("field", args[0])

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+"""."""
+
+from copy import deepcopy
+from pathlib import Path
+from typing import TextIO, Any
+from dataclasses import dataclass, KW_ONLY, field as dataclass_field
+# rename it dataclass_field to avoid confusion with source field
+
+import numpy as np
+
+from astropy.table import Table, Column
+from astropy.io.registry import IORegistryError
+from astropy.io import fits
+from astropy import units as u
+from astropy.wcs import WCS, SingularMatrixError, FITSFixedWarning
+
+from synphot import SourceSpectrum
+
+
+from ..optics import image_plane_utils as imp_utils
+from ..utils import (quantify, quantity_from_table, close_loop, get_logger,
+                     convert_table_comments_to_dict)
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class SourceField:
+    """Base class for source fields, not meant to be instantiated."""
+
+    field: Any
+    _: KW_ONLY
+    meta: dict = dataclass_field(default_factory=dict, repr=False)
+
+    def _write_stream(self, stream: TextIO) -> None:
+        raise NotImplementedError("Subclasses should implement this.")
+
+    def __getitem__(self, key):
+        # For backwards-combatibility to allow direct access of
+        # Source.fields[x][y] if possible. Maybe in the long run get rid of
+        # this and force the use of .field...
+        # warn("Direct item access for source fields may become deprecated "
+        #      "in the future. Use the .field attribute instead.",
+        #      PendingDeprecationWarning, stacklevel=2)
+        return self.field.__getitem__(key)
+
+    def __setitem__(self, key, value):
+        # For backwards-combatibility to allow direct access of
+        # Source.fields[x][y] if possible. Maybe in the long run get rid of
+        # this and force the use of .field...
+        # warn("Direct item assignment for source fields may become deprecated "
+        #      "in the future. Use the .field attribute instead.",
+        #      PendingDeprecationWarning, stacklevel=2)
+        self.field.__setitem__(key, value)
+
+    @property
+    def name(self) -> str:
+        """Name of the object (if set)."""
+        return self.meta.get("object", "<unknown>")
+
+
+@dataclass
+class SpectrumSourceField(SourceField):
+    """Base class for source fields with separate spectra (no cube)."""
+
+    spectra: dict
+
+
+@dataclass
+class TableSourceField(SpectrumSourceField):
+    """Source field with table of point source(s)."""
+
+    field: Table
+
+    @classmethod
+    def from_file(cls, filename: Path | str,
+                  spectra: dict[int, SourceSpectrum],
+                  **kwargs):
+        """Load source table from file."""
+        try:
+            tbl = Table.read(filename)
+            # There used to be a header combining functionality here...
+            # hdr1 = fits.getheader(filename, 1)
+            # hdr.update(hdr1)
+            # tbl = Table(data, meta=dict(hdr))
+            # tbl.meta.update(convert_table_comments_to_dict(tbl))
+        except IORegistryError:
+            logger.debug("Table format guessing failed, retry with ascii.")
+            tbl = Table.read(filename, format="ascii")
+
+        tbl.meta.update(convert_table_comments_to_dict(tbl))
+        return cls(tbl, spectra=spectra, meta=kwargs)
+
+    @classmethod
+    def from_arrays(cls, x, y, ref, weight,
+                    spectra: dict[int, SourceSpectrum],
+                    **kwargs):
+        """Construct source table from arrays for each column."""
+        if weight is None:
+            weight = np.ones(len(x))
+
+        x = quantify(x, u.arcsec)
+        y = quantify(y, u.arcsec)
+        tbl = Table(names=["x", "y", "ref", "weight"],
+                    data=[x, y, ref, weight])
+        tbl.meta["x_unit"] = "arcsec"
+        tbl.meta["y_unit"] = "arcsec"
+        return cls(tbl, spectra=spectra, meta=kwargs)
+
+    def __post_init__(self):
+        """Validate input."""
+        assert self.spectra, "Spectra must be non-empty for table source."
+        if "weight" not in self.field.colnames:
+            self.field.add_column(
+                Column(name="weight", data=np.ones(len(self.field)))
+            )
+        self.meta.update(self.field.meta)
+
+    def __len__(self) -> int:
+        """Return len(self)."""
+        return len(self.field)
+
+    def _write_stream(self, stream: TextIO) -> None:
+        stream.write(f"Table with {len(self)} rows, referencing "
+                     f"spectra {set(self.spectra)}")
+
+    def plot(self, axes, color) -> None:
+        """Plot source."""
+        axes.plot(self.field["x"], self.field["y"], color+".", label=self.name)
+
+    def shift(self, dx, dy) -> None:
+        """Shift source by dx, dy."""
+        x = quantity_from_table("x", self.field, u.arcsec)
+        x += quantify(dx, u.arcsec)
+        self.field["x"] = x
+
+        y = quantity_from_table("y", self.field, u.arcsec)
+        y += quantify(dy, u.arcsec)
+        self.field["y"] = y
+
+
+@dataclass
+class HDUSourceField(SourceField):
+    """Base class for source fields with HDU."""
+
+    field: fits.ImageHDU
+    wcs: WCS = dataclass_field(default_factory=WCS, init=False)
+
+    def __new__(cls, *args, **kwargs):
+        """Override creation to create subclasses."""
+        if issubclass(cls, (CubeSourceField, ImageSourceField)):
+            # Allow for dirct subclass access
+            return super().__new__(cls)
+
+        field = kwargs.get("field", args[0])
+        if field.header["NAXIS"] == 3:
+            return super().__new__(CubeSourceField)
+        if field.header["NAXIS"] == 2:
+            return super().__new__(ImageSourceField)
+
+        # If we get here, something went wrong
+        raise TypeError(f"{field.header['NAXIS'] = } must be 2 or 3.")
+
+    @property
+    def header(self) -> fits.Header:
+        """Shortcut for `field.header`."""
+        return self.field.header
+
+    @property
+    def data(self) -> np.ndarray:
+        """Shortcut for `field.data`."""
+        return self.field.data
+
+    @data.setter
+    def data(self, value):
+        self.field.data = value
+
+    @property
+    def img_size(self) -> str:
+        """Shortcut for `field.data.shape`."""
+        if self.data is None:
+            return "<empty>"
+        return str(self.data.shape)
+
+    def _write_stream(self, stream: TextIO) -> None:
+        stream.write(f"ImageHDU with size {self.img_size}, referencing "
+                     f"spectrum {self.field.header.get('SPEC_REF', '-')}")
+
+    def plot(self, axes, color) -> None:
+        """Plot source."""
+        xypts = imp_utils.calc_footprint(self.header)
+        convf = u.Unit(self.header["CUNIT1"]).to(u.arcsec)
+        outline = np.array(list(close_loop(xypts))) * convf
+        axes.plot(*outline.T, color, label=self.name)
+
+    def shift(self, dx, dy) -> None:
+        """Shift source by dx, dy."""
+        dx = dx << u.arcsec << self.wcs.wcs.cunit[0]
+        dy = dy << u.arcsec << self.wcs.wcs.cunit[1]
+        self.header["CRVAL1"] += dx.value
+        self.header["CRVAL2"] += dy.value
+
+
+@dataclass
+class ImageSourceField(SpectrumSourceField, HDUSourceField):
+    """Source field with 2D image and a single (average) spectrum."""
+
+    def __post_init__(self):
+        """Validate input."""
+        assert self.spectra, "Spectra must be non-empty for 2D image source."
+        try:
+            self.wcs = WCS(self.field)
+        except (SingularMatrixError, FITSFixedWarning):
+            # This occurs for BG SRC
+            logger.debug("Couldn't create source field WCS.")
+            self.wcs = None
+
+
+@dataclass
+class CubeSourceField(HDUSourceField):
+    """Source field with 3D data cube."""
+
+    def __post_init__(self):
+        """Validate input."""
+        if self.wcs is None and not self.meta.get("from_hdul", False):
+            self.wcs = WCS(self.field)
+
+        try:
+            bunit = u.Unit(self.header["BUNIT"])
+        except KeyError:
+            bunit = u.erg / u.s / u.cm**2 / u.arcsec**2
+            logger.warning(
+                "Keyword \"BUNIT\" not found, setting to %s by default", bunit)
+        except ValueError as error:
+            logger.error("\"BUNIT\" keyword is malformed: %s", error)
+            raise
+        self.field.header["BUNIT"] = str(bunit)
+
+    @classmethod
+    def from_hdulist(cls, hdulist: fits.HDUList, ext: int = 0, **kwargs):
+        """Load source cube from HDUL."""
+        cube = fits.ImageHDU(header=hdulist[ext].header.copy(),
+                             data=deepcopy(hdulist[ext].data))
+        new_csf = cls(field=cube, meta=kwargs | {"from_hdul": True})
+        new_csf.wcs = WCS(hdulist[ext], fobj=hdulist)
+        return new_csf
+
+    def shift(self, dx, dy) -> None:
+        """Shift source by dx, dy."""
+        logger.warning(
+            "Source shift for cubes assumes first two axes are celestial.")
+        super().shift(dx, dy)
+
+    @property
+    def wave(self) -> u.Quantity:
+        """Construct wavelength axis for cube in um."""
+        swcs = self.wcs.spectral
+        with u.set_enabled_equivalencies(u.spectral()):
+            wave = swcs.pixel_to_world(np.arange(swcs.pixel_shape[0])) << u.um
+        return wave

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -253,6 +253,7 @@ class HDUSourceField(SourceField):
         dy = dy << u.arcsec << self.wcs.wcs.cunit[1]
         self.header["CRVAL1"] += dx.value
         self.header["CRVAL2"] += dy.value
+        # TODO: self.wcs should be updated here!
 
 
 @dataclass

--- a/scopesim/source/source_utils.py
+++ b/scopesim/source/source_utils.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from typing import Optional, Union
 from collections.abc import Iterable
 
 import numpy as np
@@ -6,143 +8,187 @@ from astropy.io import fits
 from astropy.table import Table
 from synphot import SourceSpectrum, Empirical1D, SpectralElement
 
-from ..utils import find_file, quantify, get_logger
+from ..utils import find_file, get_logger
 
 
 logger = get_logger(__name__)
 
 
-def validate_source_input(**kwargs):
-    if "filename" in kwargs and kwargs["filename"] is not None:
-        filename = kwargs["filename"]
-        if find_file(filename) is None:
-            logger.warning("filename was not found: %s", filename)
-
-    if "image" in kwargs and kwargs["image"] is not None:
-        image_hdu = kwargs["image"]
-        if not isinstance(image_hdu, (fits.PrimaryHDU, fits.ImageHDU)):
-            raise ValueError("image must be fits.HDU object with a WCS."
-                             f"{type(image_hdu) = }")
-
-        if len(wcs.find_all_wcs(image_hdu.header)) == 0:
-            logger.warning("image does not contain valid WCS. %s",
-                            wcs.WCS(image_hdu))
-
-    if "table" in kwargs and kwargs["table"] is not None:
-        tbl = kwargs["table"]
-        if not isinstance(tbl, Table):
-            raise ValueError("table must be an astropy.Table object:"
-                             f"{type(tbl) = }")
-
-        if not np.all([col in tbl.colnames for col in ["x", "y", "ref"]]):
-            raise ValueError("table must contain at least column names: "
-                             f"'x, y, ref': {tbl.colnames}")
-
-    return True
-
-
-def convert_to_list_of_spectra(spectra, lam):
-    spectra_list = []
-    if isinstance(spectra, SourceSpectrum):
-        spectra_list += [spectra]
-
-    elif lam is None and\
-            isinstance(spectra, (tuple, list)) and \
-            isinstance(spectra[0], SourceSpectrum):
-        spectra_list += spectra
-
-    elif lam is not None and len(spectra.shape) == 1 and \
-            isinstance(spectra, np.ndarray) and \
-            isinstance(lam, np.ndarray):
-        spec = SourceSpectrum(Empirical1D, points=lam, lookup_table=spectra)
-        spectra_list += [spec]
-
-    elif ((isinstance(spectra, np.ndarray) and
-           len(spectra.shape) == 2) or
-          (isinstance(spectra, (list, tuple)) and
-           isinstance(spectra[0], np.ndarray))) and \
-            isinstance(lam, np.ndarray):
-
-        for sp in spectra:
-            spec = SourceSpectrum(Empirical1D, points=lam, lookup_table=sp)
-            spectra_list += [spec]
-
-    return spectra_list
-
-
-def photons_in_range(spectra, wave_min, wave_max, area=None, bandpass=None):
+def validate_source_input(**kwargs) -> None:
     """
+    Check validity of kwargs passed to ``Source`` object.
+
+    Currently checks for "filename", "image" and "table", raising the
+    exceptions listed below. Additionally logs a warning if no WCS is found in
+    an image, or if a given filename cannot be found.
 
     Parameters
     ----------
-    spectra
-    wave_min
-        [um]
-    wave_max
-        [um]
-    area : Quantity
-        [m2]
-    bandpass : SpectralElement
+    **kwargs : TYPE
+        DESCRIPTION.
 
+    Raises
+    ------
+    TypeError
+        Raised if an image isn't a FITS HDU or a table isn't an astropy Table.
+    ValueError
+        Raised if a table does not contain the minimum required columns.
 
     Returns
     -------
-    counts : u.Quantity array
+    None
 
     """
+    if (filename := kwargs.get("filename")) is not None:
+        if find_file(filename) is None:
+            logger.warning("filename was not found: %s", filename)
 
-    if isinstance(wave_min, u.Quantity):
-        wave_min = wave_min.to(u.Angstrom).value
-    else:
-        wave_min *= 1E4
+    if (image_hdu := kwargs.get("image")) is not None:
+        if not isinstance(image_hdu, (fits.PrimaryHDU, fits.ImageHDU)):
+            raise TypeError(
+                f"Image must be fits.HDU object: {type(image_hdu) = }")
 
-    if isinstance(wave_max, u.Quantity):
-        wave_max = wave_max.to(u.Angstrom).value
-    else:
-        wave_max *= 1E4
+        if not wcs.find_all_wcs(image_hdu.header):
+            logger.warning(
+                "Image does not contain valid WCS. %s", wcs.WCS(image_hdu))
+
+    if (tbl := kwargs.get("table")) is not None:
+        tbl = kwargs["table"]
+        if not isinstance(tbl, Table):
+            raise TypeError(
+                f"Table must be astropy.Table object: {type(tbl) = }")
+
+        if not {"x", "y", "ref"}.issubset(tbl.colnames):
+            raise ValueError(
+                "Table must contain at least the following column names: 'x', "
+                f"""'y', 'ref'; found only: '{"', '".join(tbl.colnames)}'""")
+            # TODO py312: The triple quotes will become redundant in 3.12 !
+
+
+def convert_to_list_of_spectra(spectra, lam) -> list[SourceSpectrum]:
+    """Produce SourceSpectrum instances or pass them through."""
+    def _synphotify(spec):
+        if not isinstance(lam, np.ndarray):
+            raise TypeError("If spectra is/are given as array(s), lam must be "
+                            "an array as well.")
+        return SourceSpectrum(Empirical1D, points=lam, lookup_table=spec)
+
+    def _from_arrays(specarrays):
+        for spec in specarrays:
+            yield _synphotify(spec)
+
+    def _get_list():
+        if isinstance(spectra, SourceSpectrum):
+            yield spectra
+            return
+
+        if (isinstance(spectra, Iterable) and
+                not isinstance(spectra, np.ndarray)):
+            if all(isinstance(spec, SourceSpectrum) for spec in spectra):
+                yield from spectra
+            elif all(isinstance(spec, np.ndarray) for spec in spectra):
+                yield from _from_arrays(spectra)
+            else:
+                raise ValueError(
+                    "If given as an iterable, spectra must consist of all "
+                    "synphot spectra or all arrays")
+            return
+
+        if isinstance(spectra, np.ndarray):
+            if spectra.ndim == 1:
+                yield _synphotify(spectra)
+            elif spectra.ndim == 2:
+                yield from _from_arrays(spectra)
+            else:
+                raise ValueError(
+                    "If given as an array, spectra must have either 1 (single "
+                    "flux list) or 2 (flux of multiple spectra) dimensions, "
+                    f"but {spectra.ndim} were found.")
+            return
+
+    return list(_get_list())
+
+
+# FIXME: typing: This should work with the more general (and true, since
+#        conversion is done anyway) Quantity["length"] (or "area" resp.), but
+#        doing so currently causes a NameError. Not sure what's going on.
+def photons_in_range(
+        spectra: SourceSpectrum,
+        wave_min: Union[u.Quantity[u.um], float],
+        wave_max: Union[u.Quantity[u.um], float],
+        area: Optional[Union[u.Quantity[u.m**2], float]] = None,
+        bandpass: Optional[SpectralElement] = None,
+) -> Union[u.Quantity[u.ph * u.s**-1 * u.m**-2], u.Quantity[u.ph * u.s**-1]]:
+    """
+    Integrate photons from spectrum in given wavelength range.
+
+    Parameters
+    ----------
+    spectra : SourceSpectrum
+        Input spectrum.
+    wave_min : Union[u.Quantity["length"], float]
+        Minimum wavelength. If float, assumes um.
+    wave_max : Union[u.Quantity["length"], float]
+        Maximum wavelength. If float, assumes um.
+    area : Optional[Union[u.Quantity["area"], float]], optional
+        Area to multiply with. If float, assumes m**2. The default is None.
+    bandpass : Optional[SpectralElement], optional
+        Filter to take into account, if any. The default is None.
+
+    Returns
+    -------
+    counts : astropy.units.Quantity
+        Either in ph/s/m**2 or just ph/s (if area was given).
+
+    """
+    # Note: Assuming um if given as float.
+    wave_min = (wave_min << u.um).to(u.Angstrom).value
+    wave_max = (wave_max << u.um).to(u.Angstrom).value
+    # Note: There appear to be some float shenanigans going on here, but
+    # rounding produces an error in the spectrum evaluation. Not sure what's
+    # going on, maybe it's fine as-is.
 
     counts = []
     for spec in spectra:
         waveset = spec.waveset.value
         mask = (waveset > wave_min) * (waveset < wave_max)
-        x = waveset[mask]
-        x = np.append(np.append(wave_min, x), wave_max)
-        y = spec(x).value
+        wave = np.array([wave_min, *waveset[mask], wave_max])
+        flux = spec(wave).value
 
-        # flux [ph s-1 cm-2] == y [ph s-1 cm-2 AA-1] * x [AA]
+        # flux [ph s-1 cm-2] == flux [ph s-1 cm-2 AA-1] * wave [AA]
         if isinstance(bandpass, SpectralElement):
-            bp = bandpass(x)
             bandpass.model.bounds_error = True
-            counts += [np.trapz(bp * y, x)]
+            counts.append(np.trapz(bandpass(wave).value * flux, wave))
         else:
-            counts += [np.trapz(y, x)]
+            counts.append(np.trapz(flux, wave))
 
     # counts = flux [ph s-1 cm-2]
-    counts = 1E4 * np.array(counts)    # to get from cm-2 to m-2
-    counts *= u.ph * u.s**-1 * u.m**-2
+    counts = (counts * u.ph * u.s**-1 * u.cm**-2).to(u.ph * u.s**-1 * u.m**-2)
     if area is not None:
-        counts *= quantify(area, u.m ** 2)
+        counts *= (area << u.m**2)
 
     return counts
 
 
 def scale_imagehdu(imagehdu, waverange, area=None):
-    # ..todo: implement this
-    # For the moment, all imagehdu must be accompanied by a spectrum in PHOTLAM
-    #
-    # Future functionality will include scaling here of:
-    # ph s-1
-    # ph s-1 m-2
-    # ph s-1 m-2
-    # ph s-1 m-2 um-1
-    # ph s-1 m-2 um-1 arcsec-2
-    # J s-1 m-2 Hz-1
-    # J s-1 m-2 Hz-1 arcsec-2
-    # ABMAG
-    # ABMAG arcsec-2
-    # VEGAMAG
-    # VEGAMAG arcsec-2
+    """
+    ..todo: implement this
 
+    For the moment, all imagehdu must be accompanied by a spectrum in PHOTLAM
+
+    Future functionality will include scaling here of:
+    ph s-1
+    ph s-1 m-2
+    ph s-1 m-2
+    ph s-1 m-2 um-1
+    ph s-1 m-2 um-1 arcsec-2
+    J s-1 m-2 Hz-1
+    J s-1 m-2 Hz-1 arcsec-2
+    ABMAG
+    ABMAG arcsec-2
+    VEGAMAG
+    VEGAMAG arcsec-2
+    """
     if "SPEC_REF" not in imagehdu.header:
         raise ValueError("For this version, an ImageHDU must be associated "
                          "with a spectrum. This will change in the future.")
@@ -150,14 +196,24 @@ def scale_imagehdu(imagehdu, waverange, area=None):
     return imagehdu
 
 
-def make_img_wcs_header(pixel_scale, image_size):
+def make_img_wcs_header(
+    pixel_scale: float,
+    image_size: tuple[int, int],
+) -> fits.Header:
     """
-    Create a WCS header for an image
+    Create a WCS header for an image.
 
+    Parameters
+    ----------
     pixel_scale : float
-        arcsecs
-    image_size : tuple
-        x, y where x, y are integers
+        Pixel scale in arcsecs.
+    image_size : tuple[int, int]
+        Image size (x, y).
+
+    Returns
+    -------
+    TYPE
+        DESCRIPTION.
 
     """
     ra, dec = 0, 0
@@ -167,7 +223,7 @@ def make_img_wcs_header(pixel_scale, image_size):
     imgwcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
     imgwcs.wcs.cunit = [u.deg, u.deg]
     imgwcs.wcs.crpix = [(x + 1) / 2, (y + 1) / 2]
-    imgwcs.wcs.cdelt = np.array([-pixel_scale / 3600, pixel_scale / 3600])
+    imgwcs.wcs.cdelt = np.array([-pixel_scale, pixel_scale]) / 3600
     imgwcs.wcs.crval = [ra, dec]
     imgwcs.wcs.cunit = [u.deg, u.deg]
 

--- a/scopesim/source/source_utils.py
+++ b/scopesim/source/source_utils.py
@@ -84,10 +84,11 @@ def convert_to_list_of_spectra(spectra, lam) -> list[SourceSpectrum]:
 
         if (isinstance(spectra, Iterable) and
                 not isinstance(spectra, np.ndarray)):
-            if all(isinstance(spec, SourceSpectrum) for spec in spectra):
-                yield from spectra
-            elif all(isinstance(spec, np.ndarray) for spec in spectra):
-                yield from _from_arrays(spectra)
+            _spectra = list(spectra)  # avoid eating iterators in all()
+            if all(isinstance(spec, SourceSpectrum) for spec in _spectra):
+                yield from _spectra
+            elif all(isinstance(spec, np.ndarray) for spec in _spectra):
+                yield from _from_arrays(_spectra)
             else:
                 raise ValueError(
                     "If given as an iterable, spectra must consist of all "

--- a/scopesim/tests/mocks/py_objects/source_objects.py
+++ b/scopesim/tests/mocks/py_objects/source_objects.py
@@ -55,6 +55,28 @@ def _table_source_overlapping():
     return tbl_source
 
 
+def _basic_img_hdu(weight):
+    n = 51
+    im_wcs = wcs.WCS(naxis=2)
+    im_wcs.wcs.cunit = [u.arcsec, u.arcsec]
+    im_wcs.wcs.cdelt = [0.2, 0.2]
+    im_wcs.wcs.crval = [0, 0]
+    im_wcs.wcs.crpix = [(n + 1) / 2, (n + 1) / 2]
+    # im_wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    im_wcs.wcs.ctype = ["LINEAR", "LINEAR"]
+
+    im = np.random.random(size=(n, n)) * 1e-9 * weight
+    im[n-1, 1] += 5 * weight
+    im[1, 1] += 5 * weight
+    im[n // 2, n // 2] += 10 * weight
+    im[n // 2, n-1] += 5 * weight
+
+    im_hdu = fits.ImageHDU(data=im, header=im_wcs.to_header())
+    im_hdu.header["SPEC_REF"] = 0
+
+    return im_hdu
+
+
 def _image_source(dx=0, dy=0, angle=0, weight=1):
     """
     Produce a source with 3 point sources on a random BG.
@@ -77,23 +99,7 @@ def _image_source(dx=0, dy=0, angle=0, weight=1):
     specs = [SourceSpectrum(Empirical1D, points=wave,
                             lookup_table=np.linspace(0, 4, n) * unit)]
 
-    n = 51
-    im_wcs = wcs.WCS(naxis=2)
-    im_wcs.wcs.cunit = [u.arcsec, u.arcsec]
-    im_wcs.wcs.cdelt = [0.2, 0.2]
-    im_wcs.wcs.crval = [0, 0]
-    im_wcs.wcs.crpix = [(n + 1) / 2, (n + 1) / 2]
-    # im_wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
-    im_wcs.wcs.ctype = ["LINEAR", "LINEAR"]
-
-    im = np.random.random(size=(n, n)) * 1e-9 * weight
-    im[n-1, 1] += 5 * weight
-    im[1, 1] += 5 * weight
-    im[n // 2, n // 2] += 10 * weight
-    im[n // 2, n-1] += 5 * weight
-
-    im_hdu = fits.ImageHDU(data=im, header=im_wcs.to_header())
-    im_hdu.header["SPEC_REF"] = 0
+    im_hdu = _basic_img_hdu(weight)
     im_source = Source(image_hdu=im_hdu, spectra=specs)
 
     angle = angle * np.pi / 180
@@ -137,12 +143,33 @@ def _cube_source(**kwargs):
     source
     """
     n = 101
-    im_src = _image_source(**kwargs)
-    data = im_src.fields[0].data
+    im_hdu = _basic_img_hdu(kwargs.get("weight", 1))
+    # im_src = _image_source(**kwargs)
+    # data = im_src.fields[0].data
+    data = im_hdu.data
+
+    # taken from Source
+    for i in [1, 2]:
+        unit = u.Unit(im_hdu.header[f"CUNIT{i}"].lower())
+        val = float(im_hdu.header[f"CDELT{i}"])
+        im_hdu.header[f"CUNIT{i}"] = "deg"
+        im_hdu.header[f"CDELT{i}"] = val * unit.to(u.deg)
+
+    dx = kwargs.get("dx", 0)
+    dy = kwargs.get("dy", 0)
+    angle = kwargs.get("angle", 0)
+
+    angle = angle * np.pi / 180
+    im_hdu.header["CRVAL1"] += dx / 3600
+    im_hdu.header["CRVAL2"] += dy / 3600
+    im_hdu.header["PC1_1"] = np.cos(angle)
+    im_hdu.header["PC1_2"] = np.sin(angle)
+    im_hdu.header["PC2_1"] = -np.sin(angle)
+    im_hdu.header["PC2_2"] = np.cos(angle)
 
     # Broadcast the array onto a 3rd dimension and scale along the new axis
-    im_src.fields[0].data = data[None, :, :] * np.linspace(0, 4, n)[:, None, None]
-    im_src.spectra = {}
+    im_hdu.data = data[None, :, :] * np.linspace(0, 4, n)[:, None, None]
+    # im_src.spectra = {}
 
     # FIXME: CRPIX might be wrong here, aka off-by-one!!
     # But all other code assumes it like this, so I'm keeping it for now.
@@ -151,7 +178,8 @@ def _cube_source(**kwargs):
                      "CRVAL3": 1.5, "CRPIX3": 50, "SPEC_REF": None,
                      "BUNIT": "ph s-1 m-2 um-1"}
 
-    im_src.fields[0].header.update(cube_hdr_dict)
+    im_hdu.header.update(cube_hdr_dict)
+    im_src = Source(cube=im_hdu)
 
     return im_src
 

--- a/scopesim/tests/mocks/py_objects/source_objects.py
+++ b/scopesim/tests/mocks/py_objects/source_objects.py
@@ -142,7 +142,7 @@ def _cube_source(**kwargs):
 
     # Broadcast the array onto a 3rd dimension and scale along the new axis
     im_src.fields[0].data = data[None, :, :] * np.linspace(0, 4, n)[:, None, None]
-    im_src.spectra = []
+    im_src.spectra = {}
 
     # FIXME: CRPIX might be wrong here, aka off-by-one!!
     # But all other code assumes it like this, so I'm keeping it for now.

--- a/scopesim/tests/tests_optics/test_FieldOfView.py
+++ b/scopesim/tests/tests_optics/test_FieldOfView.py
@@ -393,7 +393,7 @@ class TestMakeSpectrum:
         spec = fov.make_spectrum()
 
         in_sum = np.sum([n * spec(fov.waveset).value
-                        for n, spec in zip([3, 1, 1], src_table.spectra)])      # sum of weights [3,1,1]
+                        for n, spec in zip([3, 1, 1], src_table.spectra.values())])      # sum of weights [3,1,1]
         out_sum = np.sum(spec(fov.waveset).value)
 
         assert in_sum == approx(out_sum)
@@ -435,7 +435,7 @@ class TestMakeSpectrum:
         spec = fov.make_spectrum()
 
         table_sum = np.sum([n * spec(fov.waveset).value
-                            for n, spec in zip([3, 1, 1], src_table.spectra)])  # sum of weights [3,1,1]
+                            for n, spec in zip([3, 1, 1], src_table.spectra.values())])  # sum of weights [3,1,1]
         image_sum = np.sum(src_image.fields[0].data) * \
                     np.sum(src_image.spectra[0](fov.waveset).value)
         cube_sum = np.sum(src_cube.fields[0].data[70:81, :, :]) * 1e-8

--- a/scopesim/tests/tests_source/test_source_Source.py
+++ b/scopesim/tests/tests_source/test_source_Source.py
@@ -16,6 +16,7 @@ from synphot.units import PHOTLAM
 
 from scopesim.source import source_utils
 from scopesim.source.source import Source
+from scopesim.source.source_fields import CubeSourceField
 
 from scopesim.optics.image_plane import ImagePlane
 from scopesim.utils import convert_table_comments_to_dict
@@ -424,6 +425,26 @@ class TestSpectraListConverter:
                 [np.array([0, 1, 1, 0]), [0, 1, 1, 0]],
                 [np.array([1, 2, 3, 4]), [1, 2, 3, 4]])
 
+
+def test_cube_source_field():
+    size = 5
+    hdu = fits.ImageHDU(data=np.arange(size**3).reshape(3*(size,)))
+
+    hdu.header["CUNIT1"] = "arcsec"
+    hdu.header["CUNIT2"] = "arcsec"
+    hdu.header["CUNIT3"] = "um"
+    hdu.header["CTYPE3"] = "WAVE"
+    hdu.header["CRVAL1"] = 0
+    hdu.header["CRVAL2"] = 0
+    csf = CubeSourceField(hdu)
+
+    np.testing.assert_equal(csf.wave.value, np.arange(1, 6))
+    csf.shift(2, 3)
+    assert csf.header["CRVAL1"] == 2
+    assert csf.header["CRVAL2"] == 3
+
+    _, ax = plt.subplots()
+    csf.plot(ax, "red")
 
 #
 # class TestScaleImageHDU:

--- a/scopesim/tests/tests_source/test_source_Source.py
+++ b/scopesim/tests/tests_source/test_source_Source.py
@@ -209,7 +209,7 @@ class TestSourceAddition:
         image_source.append(table_source)
         comb_refs = image_source.fields[1]["ref"]
         tbl_refs = table_source.fields[0]["ref"]
-        assert np.all(tbl_refs.data + 1 == comb_refs.data)
+        assert all(tbl_refs.data + 1 == comb_refs.data)
         assert image_source.fields[0].header["SPEC_REF"] == 0
         assert len(image_source.fields) == len(image_source._meta_dicts)
         image_source.shift(0.1, 0.2)
@@ -218,7 +218,7 @@ class TestSourceAddition:
         new_source = table_source + image_source
         comb_refs = new_source.fields[0]["ref"]
         tbl_refs = table_source.fields[0]["ref"]
-        assert np.all(tbl_refs.data == comb_refs.data)
+        assert all(tbl_refs.data == comb_refs.data)
         assert new_source.fields[1].header["SPEC_REF"] == 3
         assert len(new_source.fields) == len(new_source._meta_dicts)
         new_source.shift(0.1, 0.2)
@@ -245,7 +245,7 @@ class TestSourceAddition:
         assert len(img_fits_src.fields) == len(img_fits_src._meta_dicts)
         assert len(fits_img_src.fields) == 2
         assert len(img_fits_src.fields) == len(img_fits_src._meta_dicts)
-        assert np.all(fits_img_src.fields[0].data == fits_src.fields[0].data)
+        assert (fits_img_src.fields[0].data == fits_src.fields[0].data).all()
         assert img_fits_src.fields[0] is not img_src.fields[0]
 
     def test_meta_data_is_passed_on_when_added(self, table_source, image_source):
@@ -309,11 +309,11 @@ class TestSourceImageInRange:
 class TestSourcePhotonsInRange:
     def test_correct_photons_are_returned_for_table_source(self, table_source):
         ph = table_source.photons_in_range(1, 2)
-        assert np.all(np.isclose(ph.value, [4., 2., 2.]))
+        assert np.allclose(ph.value, [4., 2., 2.])
 
     def test_correct_photons_are_returned_for_image_source(self, image_source):
         ph = image_source.photons_in_range(1, 2)
-        assert np.all(np.isclose(ph.value, [2.]))
+        assert np.allclose(ph.value, [2.])
 
     def test_correct_photons_are_returned_for_no_spectra(self, image_source):
         image_source.spectra = []
@@ -328,7 +328,7 @@ class TestSourcePhotonsInRange:
     def test_photons_returned_only_for_indexes(self, table_source):
         ph = table_source.photons_in_range(1, 2, indexes=[0, 2])
         assert len(ph) == 2
-        assert np.all(np.isclose(ph.value, [4, 2]))
+        assert np.allclose(ph.value, [4, 2])
 
 
 class TestSourceShift:
@@ -387,7 +387,7 @@ class TestPhotonsInRange:
                               (np.linspace(0, 1, 11)**0.5, 100,  34.931988)])
     def test_with_bandpass_and_area_returns_correct_value(self, flux, area,
                                                           expected):
-        flux = flux * u.Unit("ph s-1 m-2 um-1")
+        flux *= u.Unit("ph s-1 m-2 um-1")
         spec = SourceSpectrum(Empirical1D,
                               points=np.linspace(0.5, 2.5, 11) * u.um,
                               lookup_table=flux)

--- a/scopesim/tests/tests_source/test_source_Source.py
+++ b/scopesim/tests/tests_source/test_source_Source.py
@@ -211,7 +211,6 @@ class TestSourceAddition:
         tbl_refs = table_source.fields[0]["ref"]
         assert all(tbl_refs.data + 1 == comb_refs.data)
         assert image_source.fields[0].header["SPEC_REF"] == 0
-        assert len(image_source.fields) == len(image_source._meta_dicts)
         image_source.shift(0.1, 0.2)
 
     def test_same_as_above_but_reversed(self, table_source, image_source):
@@ -220,7 +219,6 @@ class TestSourceAddition:
         tbl_refs = table_source.fields[0]["ref"]
         assert all(tbl_refs.data == comb_refs.data)
         assert new_source.fields[1].header["SPEC_REF"] == 3
-        assert len(new_source.fields) == len(new_source._meta_dicts)
         new_source.shift(0.1, 0.2)
 
     def test_imagehdu_with_empty_spec_ref_is_handled(self, table_source,
@@ -228,7 +226,6 @@ class TestSourceAddition:
         image_source.fields[0].header["SPEC_REF"] = ""
         new_source = table_source + image_source
         assert new_source.fields[1].header["SPEC_REF"] == ""
-        assert len(new_source.fields) == len(new_source._meta_dicts)
 
     def test_fits_image_and_array_image_are_added_correctly(self):
         img_src = so._image_source()
@@ -238,16 +235,13 @@ class TestSourceAddition:
         fits_img_src = fits_src + img_src
 
         assert len(img_src.fields) == 1
-        assert len(img_src.fields) == len(img_src._meta_dicts)
         assert len(fits_src.fields) == 1
-        assert len(fits_src.fields) == len(fits_src._meta_dicts)
         assert len(img_fits_src.fields) == 2
-        assert len(img_fits_src.fields) == len(img_fits_src._meta_dicts)
         assert len(fits_img_src.fields) == 2
-        assert len(img_fits_src.fields) == len(img_fits_src._meta_dicts)
         assert (fits_img_src.fields[0].data == fits_src.fields[0].data).all()
         assert img_fits_src.fields[0] is not img_src.fields[0]
 
+    @pytest.mark.skip(reason="_meta_dicts was removed, find a better way to perform the same check...")
     def test_meta_data_is_passed_on_when_added(self, table_source, image_source):
         table_source.fields[0].meta["hello"] = "world"
         image_source.fields[0].meta["servus"] = "oida"
@@ -257,6 +251,7 @@ class TestSourceAddition:
         assert new_source._meta_dicts[0]["hello"] == "world"
         assert new_source._meta_dicts[1]["servus"] == "oida"
 
+    @pytest.mark.skip(reason="_meta_dicts was removed, find a better way to perform the same check...")
     def test_empty_source_is_the_additive_identity(self, image_source):
         new_source_1 = Source() + image_source
         assert len(new_source_1.fields) == len(new_source_1._meta_dicts)

--- a/scopesim/tests/tests_source/test_source_Source.py
+++ b/scopesim/tests/tests_source/test_source_Source.py
@@ -137,7 +137,7 @@ class TestSourceInit:
         src = Source(table=table, spectra=input_spectra)
         assert isinstance(src, Source)
         assert isinstance(src.spectra[0], SourceSpectrum)
-        assert isinstance(src.fields[0], Table)
+        assert isinstance(src.fields[0].field, Table)
         src.shift(0.1, 0.2)
 
     def test_initialises_with_image_and_1_spectrum(self, input_hdulist,
@@ -145,14 +145,14 @@ class TestSourceInit:
         src = Source(image_hdu=input_hdulist[0], spectra=input_spectra[0])
         assert isinstance(src, Source)
         assert isinstance(src.spectra[0], SourceSpectrum)
-        assert isinstance(src.fields[0], fits.ImageHDU)
+        assert isinstance(src.fields[0].field, fits.ImageHDU)
         src.shift(0.1, 0.2)
 
     def test_initialises_with_image_and_flux(self, input_hdulist):
         src = Source(image_hdu=input_hdulist[0], flux=20*u.ABmag)
         assert isinstance(src, Source)
         assert isinstance(src.spectra[0], SourceSpectrum)
-        assert isinstance(src.fields[0], fits.ImageHDU)
+        assert isinstance(src.fields[0].field, fits.ImageHDU)
         src.shift(0.1, 0.2)
 
     def test_initialises_with_only_image(self, input_hdulist):
@@ -175,7 +175,7 @@ class TestSourceInit:
 
         assert isinstance(src, Source)
         assert isinstance(src.spectra[0], SourceSpectrum)
-        assert isinstance(src.fields[0], fits.ImageHDU)
+        assert isinstance(src.fields[0].field, fits.ImageHDU)
         src.shift(0.1, 0.2)
 
     @pytest.mark.parametrize("ii, dtype",
@@ -188,7 +188,7 @@ class TestSourceInit:
         src = Source(filename=fname, spectra=input_spectra[0])
         assert isinstance(src, Source)
         assert isinstance(src.spectra[0], SourceSpectrum)
-        assert isinstance(src.fields[0], dtype)
+        assert isinstance(src.fields[0].field, dtype)
         src.shift(0.1, 0.2)
 
     def test_initialised_with_old_style_arrays(self):
@@ -199,7 +199,7 @@ class TestSourceInit:
         src = Source(x=x, y=y, ref=ref, weight=weight, lam=lam, spectra=spectra)
         assert isinstance(src, Source)
         assert isinstance(src.spectra[0], SourceSpectrum)
-        assert isinstance(src.fields[0], Table)
+        assert isinstance(src.fields[0].field, Table)
         src.shift(0.1, 0.2)
 
 
@@ -249,8 +249,8 @@ class TestSourceAddition:
         assert img_fits_src.fields[0] is not img_src.fields[0]
 
     def test_meta_data_is_passed_on_when_added(self, table_source, image_source):
-        table_source.meta["hello"] = "world"
-        image_source.meta["servus"] = "oida"
+        table_source.fields[0].meta["hello"] = "world"
+        image_source.fields[0].meta["servus"] = "oida"
         new_source = table_source + image_source
 
         assert len(new_source.fields) == len(new_source._meta_dicts)
@@ -316,7 +316,7 @@ class TestSourcePhotonsInRange:
         assert np.allclose(ph.value, [2.])
 
     def test_correct_photons_are_returned_for_no_spectra(self, image_source):
-        image_source.spectra = {}
+        image_source.fields[0].spectra = {}
         ph = image_source.photons_in_range(1, 2)
         assert len(ph) == 0
 
@@ -325,8 +325,8 @@ class TestSourcePhotonsInRange:
         ph = image_source.photons_in_range(1, 2, area=area)
         assert ph[0].value == approx(expected)
 
-    def test_photons_returned_only_for_indexes(self, table_source):
-        ph = table_source.photons_in_range(1, 2, indexes=[0, 2])
+    def test_photons_returned_only_for_indices(self, table_source):
+        ph = table_source.photons_in_range(1, 2, indices=[0, 2])
         assert len(ph) == 2
         assert np.allclose(ph.value, [4, 2])
 

--- a/scopesim/tests/tests_source/test_source_templates.py
+++ b/scopesim/tests/tests_source/test_source_templates.py
@@ -1,13 +1,11 @@
 import pytest
 from pytest import approx
-from unittest.mock import patch
 
 from matplotlib import pyplot as plt
 
 from astropy import units as u
 from astropy.table import Table
 
-from scopesim import rc
 from scopesim import load_example_optical_train
 from scopesim.source import source_templates as src_ts
 from scopesim.source.source import Source
@@ -35,7 +33,7 @@ class TestStarField:
 
     def test_star_fields_data(self):
         src = src_ts.star_field(100, 15, 25, 60)
-        assert isinstance(src.fields[0], Table)
+        assert isinstance(src.fields[0].field, Table)
         assert all(src.fields[0]["weight"] == 10**(-0.4 * src.fields[0]["mag"]))
         src.shift(0.1, 0.2)
 


### PR DESCRIPTION
Some ~minor~ major refactoring in vague preparation of scopesim-targets...

## Main changes

- Introduce `SourceField` and subclasses: As discussed in the Waidhofen hackathon, this family of classes will now hold the source fields as part of the `Source` class. Different subclasses exist for different kinds of fields (table, image, cube). This produced a bit of a rat-tail of changes elsewhere, but should ultimately move us forward.
- Make `Source.spectra` (now just a collection of all `field.spectra`) a `dict`. This was a rather minimal change with limited need to adapt elsewhere, but is a lot more explicit on which spectra are referenced where, instead of hoping the the indices of the previous `list` don't get mixed up when changing stuff in the source.

## Other changes

- Added the SED table parser convenience function for use in the METIS notebooks.
- Some other refactoring, mostly in the `Source` class.

## Further notes

Ignore all the force pushes, which resulted from rebasing...

~This needs 3.10, so waiting for that...~
