### PR TITLE
Do something sensible when a trace falls outside the FoV.

### DIFF
--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -139,12 +139,12 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
                                               data=slicecube)
                 # slicefov.cube.writeto(f"slicefov_{sptid}.fits", overwrite=True)
                 slicefov.hdu = spt.map_spectra_to_focal_plane(slicefov)
-
-                sxmin = slicefov.hdu.header["XMIN"]
-                sxmax = slicefov.hdu.header["XMAX"]
-                symin = slicefov.hdu.header["YMIN"]
-                symax = slicefov.hdu.header["YMAX"]
-                fovimage[symin:symax, sxmin:sxmax] += slicefov.hdu.data
+                if slicefov.hdu is not None:
+                    sxmin = slicefov.hdu.header["XMIN"]
+                    sxmax = slicefov.hdu.header["XMAX"]
+                    symin = slicefov.hdu.header["YMIN"]
+                    symax = slicefov.hdu.header["YMAX"]
+                    fovimage[symin:symax, sxmin:sxmax] += slicefov.hdu.data
 
             obj.hdu = fits.ImageHDU(data=fovimage, header=obj.detector_header)
 

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -191,7 +191,7 @@ class SpectralTrace:
         # Check if spectral trace footprint is outside FoV
         if xmax < 0 or xmin > naxis1d or ymax < 0 or ymin > naxis2d:
             logger.info(
-                "Spectral trace %d: footprint is outside FoV", fov.trace_id)
+                "Spectral trace %s: footprint is outside FoV", fov.trace_id)
             return None
 
         # Only work on parts within the FoV
@@ -222,7 +222,7 @@ class SpectralTrace:
             xilam = XiLamImage(fov, self.dlam_per_pix)
             self._xilamimg = xilam   # ..todo: remove or make available with a debug flag?
         except ValueError:
-            logger.warning(" ---> %d gave ValueError", self.trace_id)
+            logger.warning(" ---> %s gave ValueError", self.trace_id)
 
         npix_xi, npix_lam = xilam.npix_xi, xilam.npix_lam
         xilam_wcs = xilam.wcs


### PR DESCRIPTION
Setting the METIS LM detector to 32x32 pixels will now show output like:

```
astar.scopesim.effects.spectral_trace_list_utils - Mapping Slice 4
astar.scopesim.effects.spectral_trace_list_utils - Spectral trace Slice 4: footprint is outside FoV 
astar.scopesim.effects.spectral_trace_list_utils - Mapping Slice 5
astar.scopesim.effects.spectral_trace_list_utils - Spectral trace Slice 5: footprint is outside FoV 
astar.scopesim.effects.spectral_trace_list_utils - Mapping Slice 6
astar.scopesim.effects.spectral_trace_list_utils - Spectral trace Slice 6: footprint is outside FoV astar.scopesim.effects.spectral_trace_list_utils - Mapping Slice 7
astar.scopesim.effects.spectral_trace_list_utils - Mapping Slice 8
astar.scopesim.effects.spectral_trace_list_utils - Mapping Slice 9
astar.scopesim.effects.spectral_trace_list_utils - Mapping Slice 10
astar.scopesim.effects.spectral_trace_list_utils - Mapping Slice 11
```

I don't know how to properly test this in ScopeSim itself, because it is pretty METIS-specific. However, I plan to add a feature to METIS_Simulations that creates all the simulations with 32x32 pixel detectors and let that setting be tested on the github CI (because creating all simulations in full takes too long and too much space). I'll also add METIS_Simulations to ScopeSim_Data with the 32x32 pixel detector setting, so we will have at least some coverage indirectly.