### PR TITLE
Do not ignore PytestRemovedIn8Warning.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,6 @@ filterwarnings = [
     "ignore:The py23*:DeprecationWarning",
     "ignore:datetime.datetime.utcfromtimestamp()*:DeprecationWarning",
     # Pytest Notebook stuff
-    "ignore:The*:pytest.PytestRemovedIn8Warning",
     "ignore:Proactor*:RuntimeWarning",
 ]
 


### PR DESCRIPTION
The main point of treating warnings as errors in the tests is to detect deprecation warningns early, so we have time to fix them before they become errors.

We should only ignore deprecation warnings in very specific cases where we have ensured that doing so is save and will not cause problems.

At the very least, every ignored deprecation warning should come with an issue that describes what is required to fix the problem.