### PR TITLE
Fix configure_logging by using function scope.

### DIFF
--- a/scopesim/tests/conftest.py
+++ b/scopesim/tests/conftest.py
@@ -16,8 +16,14 @@ MOCK_DIR = Path(__file__).parent / "mocks"
 sim.rc.__currsys__["!SIM.file.error_on_missing_file"] = True
 
 
-@pytest.fixture(scope="package", autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def configure_logging():
+    """This disables the handlers so the logs reach pytests' caplog.
+
+    This fixture should be on the function level, because some functions
+    might call `update_logging()` and therefore undo this fixture for
+    subsequent tests. E.g. test_log_to_file() does this.
+    """
     base_logger = logging.getLogger("astar")
     handlers = base_logger.handlers
     # Disable handlers


### PR DESCRIPTION
This is necessary for pytest 8. Pytest 7 apparently ran the fixture for any sub-package, but pytest 8 only runs the fixture once for the entire tests package.

test_log_to_file() reset the handlers, so test_Quantization failed.

Closes #421