### PR TITLE
Rename `DetectorArray` ➡️ `DetectorManager` plus Docstrings and Refactoring

### DIFF
--- a/scopesim/detector/__init__.py
+++ b/scopesim/detector/__init__.py
@@ -1,2 +1,2 @@
 from .detector import Detector
-from .detector_array import DetectorArray
+from .detector_manager import DetectorManager

--- a/scopesim/detector/detector.py
+++ b/scopesim/detector/detector.py
@@ -65,5 +65,5 @@ class Detector(DetectorBase):
 
     @property
     def image(self):
-        """Return header from internal HDU."""
+        """Return data from internal HDU."""
         return self.data

--- a/scopesim/detector/detector.py
+++ b/scopesim/detector/detector.py
@@ -1,11 +1,12 @@
 import numpy as np
 
-from ..base_classes import ImagePlaneBase, DetectorBase
-from ..optics import image_plane_utils as imp_utils
-from ..utils import get_logger, from_currsys, stringify_dict
-
-from astropy.io import fits
+from astropy.io.fits import ImageHDU
 from astropy.wcs import WCS
+
+from ..base_classes import ImagePlaneBase, DetectorBase
+from ..optics.image_plane_utils import (add_imagehdu_to_imagehdu,
+                                        sky_wcs_from_det_wcs)
+from ..utils import get_logger, from_currsys, stringify_dict
 
 
 logger = get_logger(__name__)
@@ -14,28 +15,30 @@ logger = get_logger(__name__)
 class Detector(DetectorBase):
     def __init__(self, header, cmds=None, **kwargs):
         image = np.zeros((header["NAXIS2"], header["NAXIS1"]))
-        self._hdu = fits.ImageHDU(header=header, data=image)
+        self._hdu = ImageHDU(header=header, data=image)
         self.meta = {}
         self.meta.update(header)
         self.meta.update(kwargs)
         self.cmds = cmds
 
     def extract_from(self, image_plane, spline_order=1, reset=True):
+        """Extract HDU from ImagePlane object and add to internal HDU."""
         if reset:
             self.reset()
         if not isinstance(image_plane, ImagePlaneBase):
-            raise ValueError("image_plane must be an ImagePlane object, but is: "
-                             f"{type(image_plane)}")
+            raise ValueError("image_plane must be an ImagePlane object, "
+                             f"but is: {type(image_plane)}")
 
-        self._hdu = imp_utils.add_imagehdu_to_imagehdu(image_plane.hdu,
-                                                       self.hdu, spline_order,
-                                                       wcs_suffix="D")
+        self._hdu = add_imagehdu_to_imagehdu(
+            image_plane.hdu, self.hdu, spline_order, wcs_suffix="D")
 
     def reset(self):
+        """Reset internal HDU data to all-zeros-array."""
         self._hdu.data = np.zeros_like(self._hdu.data)
 
     @property
     def hdu(self):
+        """Return internal HDU."""
         new_meta = stringify_dict(self.meta)
         self._hdu.header.update(new_meta)
 
@@ -44,7 +47,7 @@ class Detector(DetectorBase):
         if pixel_scale == 0 or plate_scale == 0:
             logger.warning("Could not create sky WCS.")
         else:
-            sky_wcs, _ = imp_utils.sky_wcs_from_det_wcs(
+            sky_wcs, _ = sky_wcs_from_det_wcs(
                 WCS(self._hdu.header, key="D"), pixel_scale, plate_scale)
             self._hdu.header.update(sky_wcs.to_header())
 
@@ -52,12 +55,15 @@ class Detector(DetectorBase):
 
     @property
     def header(self):
+        """Return header from internal HDU."""
         return self._hdu.header
 
     @property
     def data(self):
+        """Return data from internal HDU."""
         return self._hdu.data
 
     @property
     def image(self):
+        """Return header from internal HDU."""
         return self.data

--- a/scopesim/detector/detector_manager.py
+++ b/scopesim/detector/detector_manager.py
@@ -30,6 +30,13 @@ class DetectorManager(Sequence):
         self._array_effects: list[Effect] = []
         self._dtcr_effects: list[Effect] = []
         self._detectors: list[Detector] = []
+        if self._detector_list is not None:
+            self._detectors = [
+                Detector(hdr, cmds=self.cmds, **self.meta)
+                for hdr in self._detector_list.detector_headers()]
+        else:
+            logger.warning("No detector effect was passed, cannot fully "
+                           "initialize detector manager.")
 
         self._latest_exposure: HDUList | None = None
 
@@ -83,11 +90,7 @@ class DetectorManager(Sequence):
         for effect in self._array_effects:
             image_plane = effect.apply_to(image_plane, **self.meta)
 
-        # 3. make a series of Detectors for each row in a DetectorList object
-        self._detectors = [Detector(hdr, cmds=self.cmds, **self.meta)
-                           for hdr in self._detector_list.detector_headers()]
-
-        # 4. iterate through all Detectors, extract image from image_plane
+        # 3. iterate through all Detectors, extract image from image_plane
         logger.info("Extracting from %d detectors...", len(self))
         for detector in self:
             detector.extract_from(image_plane)

--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -1,4 +1,12 @@
-"""TBA."""
+"""
+Module contains the actual "Detector" effects.
+
+As opposed to the Detector class and the DetectorManager (ex DetectorArray),
+which are kept in the scopesim.detector subpackage. The effects here are used
+to define the detector geometry and help creating the other classes mentioned
+above. The effects here (or one of them) are what ScopeSim "actually needs" to
+have defined in order to run.
+"""
 
 import warnings
 
@@ -183,6 +191,8 @@ class DetectorList(Effect):
 
     @property
     def image_plane_header(self):
+        """Create and return the Image Plane Header."""
+        # FIXME: Heavy property.....
         tbl = self.active_table
         pixel_size = np.min(quantity_from_table("pixel_size", tbl, u.mm))
         x_unit = unit_from_table("x_size", tbl, u.mm)
@@ -215,6 +225,8 @@ class DetectorList(Effect):
 
     @property
     def active_table(self):
+        """Create and return the active table."""
+        # FIXME: Heavy property.....
         if self.meta["active_detectors"] == "all":
             tbl = self.table
         elif isinstance(self.meta["active_detectors"], (list, tuple)):
@@ -229,6 +241,7 @@ class DetectorList(Effect):
         return tbl
 
     def detector_headers(self, ids=None):
+        """Create detector headers from active detectors or given IDs."""
         if ids is not None and all(isinstance(ii, int) for ii in ids):
             self.meta["active_detectors"] = list(ids)
 
@@ -268,6 +281,7 @@ class DetectorList(Effect):
         return hdrs
 
     def plot(self, axes=None):
+        """Plot the detector layout."""
         if axes is None:
             _, axes = figure_factory()
 

--- a/scopesim/optics/fov_manager_utils.py
+++ b/scopesim/optics/fov_manager_utils.py
@@ -184,17 +184,17 @@ def get_imaging_headers(effects, **kwargs):
                                                  efs.SlitWheel,
                                                  efs.ApertureList))
     if not aperture_effects:
-        detector_arrays = get_all_effects(effects, efs.DetectorList)
-        if not detector_arrays:
+        detector_managers = get_all_effects(effects, efs.DetectorList)
+        if not detector_managers:
             raise ValueError("No ApertureMask or DetectorList was provided. "
                              "At least one must be passed to make an "
                              f"ImagePlane: {effects}.")
         aperture_effects.extend(
             detarr.fov_grid(which="edges", pixel_scale=pixel_scale)
-            for detarr in detector_arrays)
+            for detarr in detector_managers)
 
     # FIXME: all of this is a bit inconsistent; fov_grid(which="edges" is
-    #        called afterwards, but when looking in detector_arrays, the same
+    #        called afterwards, but when looking in detector_managers, the same
     #        is called immediately; does that even work? is this all tested??
     # get aperture headers from fov_grid()
     # - for-loop catches mutliple headers from ApertureList.fov_grid()

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -17,7 +17,7 @@ from .optics_manager import OpticsManager
 from .fov_manager import FOVManager
 from .image_plane import ImagePlane
 from ..commands.user_commands import UserCommands
-from ..detector import DetectorArray
+from ..detector import DetectorManager
 from ..effects import ExtraFitsKeywords
 from ..utils import from_currsys, top_level_catch, get_logger
 from .. import rc, __version__
@@ -106,7 +106,7 @@ class OpticalTrain:
         self.optics_manager = None
         self.fov_manager = None
         self.image_planes = []
-        self.detector_arrays = []
+        self.detector_managers = []
         self.yaml_dicts = None
         self._last_source = None
 
@@ -164,7 +164,7 @@ class OpticalTrain:
                                       **kwargs)
         self.image_planes = [ImagePlane(hdr, self.cmds, **kwargs)
                              for hdr in opt_man.image_plane_headers]
-        self.detector_arrays = [DetectorArray(det_list, cmds=self.cmds, **kwargs)
+        self.detector_managers = [DetectorManager(det_list, cmds=self.cmds, **kwargs)
                                 for det_list in opt_man.detector_setup_effects]
 
     @top_level_catch
@@ -371,7 +371,7 @@ class OpticalTrain:
 
         """
         hduls = []
-        for i, detector_array in enumerate(self.detector_arrays):
+        for i, detector_array in enumerate(self.detector_managers):
             array_effects = self.optics_manager.detector_array_effects
             dtcr_effects = self.optics_manager.detector_effects
             hdul = detector_array.readout(self.image_planes, array_effects,
@@ -391,7 +391,7 @@ class OpticalTrain:
 
             if filename is not None and isinstance(filename, str):
                 fname = filename
-                if len(self.detector_arrays) > 1:
+                if len(self.detector_managers) > 1:
                     fname = f"{i}_{filename}"
                 hdul.writeto(fname, overwrite=True)
 
@@ -535,9 +535,9 @@ class OpticalTrain:
                     p.breakable()
                     p.pretty(item)
             p.breakable()
-            p.text("DetectorArrays:")
+            p.text("DetectorManagers:")
             with p.indent(2):
-                for item in self.detector_arrays:
+                for item in self.detector_managers:
                     p.breakable()
                     p.pretty(item)
             p.breakable()

--- a/scopesim/tests/tests_detector/test_detector_manager.py
+++ b/scopesim/tests/tests_detector/test_detector_manager.py
@@ -4,7 +4,7 @@ import numpy as np
 from astropy.io import fits
 
 from scopesim.optics.image_plane import ImagePlane
-from scopesim.detector import DetectorArray
+from scopesim.detector import DetectorManager
 from scopesim.tests.mocks.py_objects import effects_objects as efs_objs
 
 
@@ -24,24 +24,24 @@ def image_plane():
 
 class TestInit:
     def test_initialises_with_nothing(self):
-        assert isinstance(DetectorArray(), DetectorArray)
+        assert isinstance(DetectorManager(), DetectorManager)
 
     def test_initialisation_parameters_stored_in_meta(self):
-        dtcr_arr = DetectorArray(random_parameter=42)
+        dtcr_arr = DetectorManager(random_parameter=42)
         assert dtcr_arr.meta["random_parameter"] == 42
 
 
 class TestReadout:
     def test_returns_hdu_for_empty_effects_list(self, image_plane,
                                                 detector_list_effect):
-        dtcr_arr = DetectorArray(detector_list_effect)
+        dtcr_arr = DetectorManager(detector_list_effect)
         hdu = dtcr_arr.readout([image_plane])
 
         assert isinstance(hdu, fits.HDUList)
 
     def test_hdu_data_is_lots_of_zeros_for_empty_input(self, image_plane,
                                                        detector_list_effect):
-        dtcr_arr = DetectorArray(detector_list_effect)
+        dtcr_arr = DetectorManager(detector_list_effect)
         hdu = dtcr_arr.readout([image_plane])
 
         assert np.all(hdu[1].data == 0)


### PR DESCRIPTION
Rename class `DetectorArray` ➡️ `DetectorManager` and all corresponding file names.
Also rename variable names like `detector_arrays` ➡️ `detector_managers` and react to changes in test modules.

## Rationale

I always found the existence of both `DetectorList` and `DetectorArray` quite confusing. The now-renamed class acts in a somewhat comparable way to the `FOVManager` and `OpticsManager` classes, thus I found it fitting to apply this naming convention also to this class.

This was done after brief discussion with @astronomyk a few weeks ago, now rebased and finalized.

## Consequences

There are two occurrences in IRDB package tests where this change will need to be incorporated to avoid breaking those tests. Other than that, the things changed here are rather internal, so unlikely to break any existing scripts.

## Other Changes along the Way

- Some refactoring while already here.
- Added some more documentation along the way, clarifying which "detector" class does what.
- Make functions and attribute private that are not currently used outside the class anyway.

## Version Change?

This (and other things coming soon) might be considered worth of a minor version bump (aka v0.9.0).