### PR TITLE
Test all cases of DIT & NDIT vs. exptime and AutoExposure

### DIFF
--- a/scopesim/tests/mocks/basic_instrument/YAML_telescope.yaml
+++ b/scopesim/tests/mocks/basic_instrument/YAML_telescope.yaml
@@ -5,6 +5,7 @@ name : basic_telescope
 description : The telescope properties and effects
 
 properties :
+  telescope : Basic Telescope
   temperature : 0   # [deg C]
 
 effects :
@@ -26,4 +27,3 @@ effects :
     outer_unit : m
     inner : 0
     inner_unit : m
-

--- a/scopesim/tests/mocks/basic_instrument/default.yaml
+++ b/scopesim/tests/mocks/basic_instrument/default.yaml
@@ -14,6 +14,7 @@ yamls :
   - YAML_detector.yaml           # electronic and detector effects and properties
 
 properties :
+  instrument: "basic_instrument"
   psf_fwhm: 1.5             # [arcsec]
   modes : ["imaging"]       # default mode name
   dit: 60

--- a/scopesim/tests/test_basic_instrument/test_basic_instrument.py
+++ b/scopesim/tests/test_basic_instrument/test_basic_instrument.py
@@ -8,7 +8,7 @@ from astropy import units as u
 
 import scopesim as sim
 from scopesim.source import source_templates as st
-from scopesim.effects import AutoExposure
+from scopesim.effects import AutoExposure, Quantization
 
 
 PLOTS = False
@@ -211,6 +211,25 @@ def basic_opt_observed():
     return opt, default
 
 
+@pytest.fixture(scope="function", name="obs_aeq")
+def basic_opt_with_autoexp_and_quant_observed():
+    src = st.star(flux=15)
+    cmd = sim.UserCommands(use_instrument="basic_instrument",
+                           ignore_effects=SWITCHOFF,
+                           properties={"!OBS.dit": 10, "!OBS.ndit": 1})
+    opt = sim.OpticalTrain(cmd)
+    opt.observe(src)
+    default = int(opt.readout()[0][1].data.sum())
+
+    autoexp = AutoExposure(cmds=opt.cmds, mindit=1,
+                           full_well=100, fill_frac=0.8)
+    quanteff = Quantization(cmds=opt.cmds)
+    opt.optics_manager["basic_detector"].effects.insert(2, autoexp)
+    opt.optics_manager["basic_detector"].effects.append(quanteff)
+    opt.cmds["!OBS.exptime"] = 60
+    return opt, default, quanteff
+
+
 @pytest.mark.usefixtures("protect_currsys", "patch_all_mock_paths")
 class TestDitNdit:
     @pytest.mark.parametrize(("dit", "ndit", "factor"),
@@ -237,37 +256,70 @@ class TestDitNdit:
         kwarged = int(opt.readout(dit=dit, ndit=ndit)[0][1].data.sum())
         assert int(kwarged / default) == factor
 
+    @pytest.mark.parametrize(("dit", "ndit", "factor", "quant"),
+                             [pytest.param(20, 1, 2, True, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs without A.E..")),
+                              pytest.param(10, 3, 3, False, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs without A.E..")),
+                              pytest.param(None, None, 1, True, marks=pytest.mark.xfail(reason="A.E. dosen't use dit, ndit from !OBS if those are None in kwargs."))])
+    def test_kwargs_override_obs_dict_also_with_autoexp(
+            self, obs_aeq, dit, ndit, factor, quant):
+        """This should prioritize dit, ndit from kwargs.
+
+        Lacking those, dit and ndit from !OBS should be used over exptime.
+        """
+        opt, default, quanteff = obs_aeq
+        kwarged = int(opt.readout(dit=dit, ndit=ndit)[0][1].data.sum())
+        assert int(kwarged / default) == factor
+        assert quanteff._should_apply() == quant
+
     @pytest.mark.parametrize(("exptime", "factor"),
                              [(20, 2), (30, 3),
                               pytest.param(None, 6, marks=pytest.mark.xfail(reason="A.E. doesn't understand None yet."))])
-    def test_autoexp(self, obs, exptime, factor):
+    def test_autoexp(self, obs_aeq, exptime, factor):
         """This should prioritize kwargs and fallback to !OBS."""
-        opt, default = obs
-        autoexp = AutoExposure(cmds=opt.cmds, mindit=1,
-                               full_well=100, fill_frac=0.8)
-        opt.optics_manager["basic_detector"].effects.insert(2, autoexp)
-        opt.cmds["!OBS.exptime"] = 60
+        opt, default, quanteff = obs_aeq
         # This should work with patch.dict, but doesn't :(
         o_dit, o_ndit = opt.cmds["!OBS.dit"], opt.cmds["!OBS.ndit"]
         opt.cmds["!OBS.dit"] = None
         opt.cmds["!OBS.ndit"] = None
         kwarged = int(opt.readout(exptime=exptime)[0][1].data.sum())
+        assert not quanteff._should_apply()
         opt.cmds["!OBS.dit"] = o_dit
         opt.cmds["!OBS.ndit"] = o_ndit
         assert int(kwarged / default) == factor
 
-    @pytest.mark.parametrize(("exptime", "factor"),
-                             [pytest.param(30, 3, marks=pytest.mark.xfail(reason="dit, ndit in !OBS overrides kwargs exptime.")),
-                              (None, 1)])
-    def test_autoexp_overrides_obs_dict(self, obs, exptime, factor):
+    @pytest.mark.parametrize(("exptime", "factor", "quant"),
+                             [pytest.param(30, 3, False, marks=pytest.mark.xfail(reason="dit, ndit in !OBS overrides kwargs exptime.")),
+                              (None, 1, True)])
+    def test_autoexp_overrides_obs_dict(self, obs_aeq, exptime, factor, quant):
         """This should prioritize kwargs and use dit, ndit when None."""
-        opt, default = obs
-        autoexp = AutoExposure(cmds=opt.cmds, mindit=1,
-                               full_well=100, fill_frac=0.8)
-        opt.optics_manager["basic_detector"].effects.insert(2, autoexp)
-        opt.cmds["!OBS.exptime"] = 60
+        opt, default, quanteff = obs_aeq
         kwarged = int(opt.readout(exptime=exptime)[0][1].data.sum())
+        assert quanteff._should_apply() == quant
+        # Quantization results in ~4% loss, which is fine:
+        assert pytest.approx(kwarged / default, rel=.05) == factor
+
+    @pytest.mark.parametrize(("dit", "ndit", "factor", "quant"),
+                             [pytest.param(90, 1, 90, True, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs.")),
+                              pytest.param(2, 90, 180, False, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs."))])
+    def test_ditndit_in_kwargs_while_also_having_autoexp(
+            self, obs_aeq, dit, ndit, factor, quant):
+        """This should prioritize dit, ndit from kwargs."""
+        opt, default, quanteff = obs_aeq
+        kwarged = int(opt.readout(dit=dit, ndit=ndit)[0][1].data.sum())
         assert int(kwarged / default) == factor
+        assert quanteff._should_apply() == quant
+
+    @pytest.mark.parametrize(("dit", "ndit", "exptime", "factor", "quant"),
+                             [pytest.param(90, 1, None, 90, True, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs.")),
+                              pytest.param(2, 90, 20, 180, False, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs."))])
+    def test_ditndit_in_kwargs_while_also_having_autoexp_and_exptime(
+            self, obs_aeq, dit, ndit, exptime, factor, quant):
+        """This should prioritize dit, ndit from kwargs and ignore exptime."""
+        opt, default, quanteff = obs_aeq
+        kwarged = int(opt.readout(exptime=exptime,
+                                  dit=dit, ndit=ndit)[0][1].data.sum())
+        assert int(kwarged / default) == factor
+        assert quanteff._should_apply() == quant
 
     @pytest.mark.xfail(reason="Currently raises TypeError, but should be ValueError.")
     def test_throws_for_no_anything(self, obs):


### PR DESCRIPTION
Even after some recent improvements to AutoExposure (#424, #396), there are still some inconsistencies, which are also preventing #426 from moving forward.

To solve this systematically, I came up with the following tree of possible combinations:

```mermaid
flowchart TD
  ditkw{{"dit & ndit in kwargs"}} -- yes --> done1["Just use those"]
  expkw{{"exptime in kwargs"}}
  ae1{{"AutoExposure in
           optical train?"}} -- yes --> ae1b["`Get dit & ndit form AutoExposure using exptime from kwargs`"]
  ditobs{{"dit & ndit in !OBS"}} -- yes --> done2["Use dit & ndit
                                                                              form !OBS"]
  expobs{{"exptime in !OBS"}} -- no  --> ValueError
  ae2{{"AutoExposure in
           optical train?"}} -- no --> ValueError
  ae2b["`Get dit & ndit form AutoExposure using exptime from !OBS`"]
  ditkw  -- no  --> expkw
  expkw  -- yes --> ae1
  expkw  -- no  --> ditobs
  ditobs -- no  --> expobs
  expobs -- yes --> ae2
  ae2 -- yes --> ae2b
  ae1 -- no --> ValueError
```
_(using [bestagons](https://www.youtube.com/watch?v=thOifuHs6eY) for decisions instead of diamonds to limit vertical extent of the chart...)_

I created `TestDitNdit` in `test_basic_instrument` to (hopefully) cover all of this. I'm open to discussion about the location of this test class, but since it's imo more of an integration test (simulating the full optical train rather than an individual effect), I decided to put it here. It might also be worth considering to put the `AutoExposure` effect in the basic instrument test package, maybe in a separate mode (e.g. `autoimg`) instead of hacking it in as is done currently. Oh and (as commented), all the `["!OBS.xy"]` meddling should really be done with context managers using `unittest.mock.patch.dict`, but for some (nested mapping) reason, I couldn't get that to work 🙄 

Anyway, some of these tests currently xfail, which is expected. I'll put the actual solution(s) in a separate PR, this is just so we at least know what's working and what isn't...