### PR TITLE
Enlarge initial Field of View to suppord wide-field imagers

### DIFF
--- a/scopesim/optics/fov_manager.py
+++ b/scopesim/optics/fov_manager.py
@@ -225,10 +225,17 @@ class FovVolumeList(FOVSetupBase, MutableSequence):
         self.volumes = [{
             "wave_min": 0.3,
             "wave_max": 30,
-            "x_min": -1800,
-            "x_max": 1800,
-            "y_min": -1800,
-            "y_max": 1800,
+            # 100 square degree should be enough for everyone!
+            # Survey telescopes can have a large Field of View though:
+            # - OmegaCAM / KiDS: 1 sq. degree
+            # - DES: 4 sq. degree
+            # - Pan-STARRS 7 sq. degree
+            # - DREAMS: 6 sq. degree
+            # TODO: Why not put the entire sky here?
+            "x_min": -1800 * 10,
+            "x_max": 1800 * 10,
+            "y_min": -1800 * 10,
+            "y_max": 1800 * 10,
             "meta": {
                 "area": 0 * u.um**2,
                 "aperture_id": 0,

--- a/scopesim/tests/tests_optics/test_FOVManager.py
+++ b/scopesim/tests/tests_optics/test_FOVManager.py
@@ -1,8 +1,10 @@
 import pytest
 from pytest import approx
+import numpy as np
 
 from scopesim.optics.fov_manager import FOVManager
 from scopesim.tests.mocks.py_objects import effects_objects as eo
+from scopesim.utils import from_currsys
 
 
 class TestInit:
@@ -19,8 +21,16 @@ class TestInit:
 class TestGenerateFovList:
     def test_returns_default_single_entry_fov_list_for_no_effects(self):
         fov_man = FOVManager(pixel_scale=1, plate_scale=1)
+        assert len(fov_man.volumes_list) == 1, "volumes_list should have only 1 element initially."
+        fov_vol_org = fov_man.volumes_list[0]
+
+        chunk_size = from_currsys(fov_man.meta["chunk_size"], fov_man.cmds)
+        n_vol_x = len(np.arange(fov_vol_org["x_min"], fov_vol_org["x_max"], chunk_size))
+        n_vol_y = len(np.arange(fov_vol_org["y_min"], fov_vol_org["y_max"], chunk_size))
         fovs = list(fov_man.generate_fovs_list())
-        assert len(fovs) == 1
+
+        assert len(fovs) == n_vol_x * n_vol_y, (f"Expected {n_vol_x} * {n_vol_y} = {n_vol_x * n_vol_y} volumes, "
+                                                f"but got {len(fovs)} volumes")
 
     def test_returns_single_fov_for_mvs_system(self):
         effects = eo._mvs_effects_list()

--- a/scopesim/tests/tests_optics/test_FovVolumeList.py
+++ b/scopesim/tests/tests_optics/test_FovVolumeList.py
@@ -102,12 +102,13 @@ class TestShrink:
 
     def test_shrink_along_two_axes(self):
         fvl = FovVolumeList()
+        y_min_org = fvl[0]["y_min"]
         fvl.shrink(["x", "y"], ([0.1, None], [None, 5]))
         print(fvl)
 
         assert fvl[0]["x_min"] == 0.1
         assert fvl[0]["y_max"] == 5
-        assert fvl[0]["y_min"] == -1800
+        assert fvl[0]["y_min"] == y_min_org
 
     def test_removes_volumes_no_longer_inside_volume_limits(self):
         fvl = FovVolumeList()


### PR DESCRIPTION
100 square degree should be enough for everyone!
Survey telescopes can have a large Field of View though:

- OmegaCAM / KiDS: 1 sq. degree
- DES: 4 sq. degree
- Pan-STARRS 7 sq. degree
- DREAMS: 6 sq. degree

There should be no negative effects for having a large initial field of view, because it is immediately reduced to the actual field of view of the instrument upon initialization of the OpticalTrain.