### PR TITLE
Fix some exposure things

### DIFF
--- a/scopesim/detector/detector.py
+++ b/scopesim/detector/detector.py
@@ -34,7 +34,9 @@ class Detector(DetectorBase):
 
     def reset(self):
         """Reset internal HDU data to all-zeros-array."""
-        self._hdu.data = np.zeros_like(self._hdu.data)
+        # The detector might have been converted to integers by the
+        # Quantization effect, so it is not possible to use zeros_like.
+        self._hdu.data = np.zeros(self._hdu.data.shape)
 
     @property
     def hdu(self):

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -370,6 +370,15 @@ class OpticalTrain:
         - Apply detector plane (0D, 2D) effects - z_order = 500..599
 
         """
+
+        # Hack to make sure AutoExposure and Quantization work properly.
+        # Should probably be removed once #428 is fixed properly.
+        if kwargs.get('exptime', None) is not None:
+            if "!OBS.dit" in self.cmds:
+                self.cmds.pop("!OBS.dit")
+            if "!OBS.ndit" in self.cmds:
+                self.cmds.pop("!OBS.ndit")
+
         hduls = []
         for i, detector_array in enumerate(self.detector_managers):
             array_effects = self.optics_manager.detector_array_effects

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -374,10 +374,8 @@ class OpticalTrain:
         # Hack to make sure AutoExposure and Quantization work properly.
         # Should probably be removed once #428 is fixed properly.
         if kwargs.get('exptime', None) is not None:
-            if "!OBS.dit" in self.cmds:
-                self.cmds.pop("!OBS.dit")
-            if "!OBS.ndit" in self.cmds:
-                self.cmds.pop("!OBS.ndit")
+            self.cmds.pop("!OBS.dit", None)
+            self.cmds.pop("!OBS.ndit", None)
 
         hduls = []
         for i, detector_array in enumerate(self.detector_managers):

--- a/scopesim/tests/test_basic_instrument/test_basic_instrument.py
+++ b/scopesim/tests/test_basic_instrument/test_basic_instrument.py
@@ -295,7 +295,7 @@ class TestDitNdit:
         assert int(kwarged / default) == factor
 
     @pytest.mark.parametrize(("exptime", "factor", "quant"),
-                             [pytest.param(30, 3, False, marks=pytest.mark.xfail(reason="dit, ndit in !OBS overrides kwargs exptime.")),
+                             [(30, 3, False),
                               (None, 1, True)])
     def test_autoexp_overrides_obs_dict(self, obs_aeq, exptime, factor, quant):
         """This should prioritize kwargs and use dit, ndit when None."""
@@ -342,7 +342,6 @@ class TestDitNdit:
         opt.cmds["!OBS.dit"] = o_dit
         opt.cmds["!OBS.ndit"] = o_ndit
 
-    @pytest.mark.xfail(reason="Currently doesn't raise anything, b/c dit, ndit from !OBS is prioitized.")
     def test_throws_for_no_ditndit_no_autoexp_kwargs(self, obs):
         """This should use exptime from kwargs, but fail w/o AutoExp."""
         opt, default, quanteff = obs


### PR DESCRIPTION
Fixes #438 

* Remove `!OBS.dit`  and `!OBS.ndit`  if `exptime` is given as argument to `readout()`.
* Properly reset the detector; undoing any Quantization.

