### PR TITLE
Replace NaNs in images, log warning

### DIFF
--- a/scopesim/defaults.yaml
+++ b/scopesim/defaults.yaml
@@ -31,6 +31,7 @@ properties :
     flux_accuracy : !!float 1E-3
     preload_field_of_views : False
     bg_cell_width: 60         # arcsec
+    nan_fill_value: 0.
 
   file :
     local_packages_path : "./inst_pkgs/"

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -136,8 +136,16 @@ class FieldOfView(FieldOfViewBase):
 
             elif isinstance(fld, fits.ImageHDU):
                 if fld.header["NAXIS"] in (2, 3):
-                    fields_in_fov[ifld] = fu.extract_area_from_imagehdu(fld,
-                                                                        volume)
+                    extracted = fu.extract_area_from_imagehdu(fld, volume)
+                    fill_value = self.cmds["!SIM.computing.nan_fill_value"]
+                    if np.ma.fix_invalid(extracted.data, copy=False,
+                                         fill_value=fill_value).mask.any():
+                        logger.warning("Source contained NaN values, which "
+                                       "were replaced by %f.", fill_value)
+                        logger.info(
+                            "The replacement value for NaNs in sources can be "
+                            "set in '!SIM.computing.nan_fill_value'.")
+                    fields_in_fov[ifld] = extracted
                 if fld.header["NAXIS"] == 2 or fld.header.get("BG_SRC"):
                     ref = fld.header.get("SPEC_REF")
                     if ref is not None:

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -137,7 +137,11 @@ class FieldOfView(FieldOfViewBase):
             elif isinstance(fld, fits.ImageHDU):
                 if fld.header["NAXIS"] in (2, 3):
                     extracted = fu.extract_area_from_imagehdu(fld, volume)
-                    fill_value = self.cmds["!SIM.computing.nan_fill_value"]
+                    try:
+                        fill_value = self.cmds["!SIM.computing.nan_fill_value"]
+                    except TypeError:
+                        # This occurs in testing, not sure why
+                        fill_value = 0.
                     if np.ma.fix_invalid(extracted.data, copy=False,
                                          fill_value=fill_value).mask.any():
                         logger.warning("Source contained NaN values, which "

--- a/scopesim/tests/tests_optics/test_FieldOfView.py
+++ b/scopesim/tests/tests_optics/test_FieldOfView.py
@@ -145,6 +145,16 @@ class TestExtractFrom:
             assert the_fov.fields[1].header["NAXIS"] == 3
             assert isinstance(the_fov.fields[2], Table)
 
+    def test_handles_nans(self):
+        src = so._image_source()
+        src.fields[0].data[20:30, 20:30] = np.nan
+        assert np.isnan(src.fields[0].data).any()
+
+        fov = _fov_190_210_um()
+        fov.extract_from(src)
+
+        assert not np.isnan(fov.fields[0].data).any()
+
 
 # @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
 class TestMakeCube:


### PR DESCRIPTION
Closes #419 

Simple example to illustrate:
```python
import numpy as np
from matplotlib import pyplot as plt
import scopesim as sim
import scopesim_templates as sim_tp

src=sim_tp.galaxy("brown/NGC5866")
src.fields[0].data[70:80, 70:80] = np.nan
np.isnan(src.fields[0].data).sum()

sim.download_packages(["ELT", "Armazones", "MICADO"])
cmds=sim.UserCommands(use_instrument="MICADO")
opt=sim.OpticalTrain(cmds)

opt.observe(src)
plt.imshow(opt.readout()[0][1].data)
```

shows:

![hole](https://github.com/user-attachments/assets/79a8c0d7-adfc-4a12-9fd9-5199d6acb286)

and prints:

```
astar.scopesim.optics.fov - WARNING: Source contained NaN values, which were replaced by 0.000000.
astar.scopesim.optics.fov - The replacement value for NaNs in sources can be set in '!SIM.computing.nan_fill_value'.
```

The resulting image has a clear hole in the middle where the NaNs were, but still has some noise in there, as would be expected when setting the pixel values in the source to zero.

Setting the fill value to something intentionally ridiculously high: `cmds["!SIM.computing.nan_fill_value"] = 1e20` results in:

![brighthole](https://github.com/user-attachments/assets/500641ec-e912-49b9-a736-2a344374b8a4)

Also added a test with a similar setup to at least run that new code and make sure no NaNs remain.

I picked this particular place ScopeSim to put this because that's where the actually used part of the image is created. Any NaNs outside the FOV can be ignored anyway as they don't affect the final result. Note that this now applies only to ImageHDU-type source fields, so Tables are not checked. However, one would have to be particularly dense to create a source table with NaNs, I guess. Most of the NaN cases will come from users loading mythical FITS files from God-knows-where...