### PR TITLE
Update example notebook to properly show the same observation

### DIFF
--- a/docs/source/examples/2_multiple_telescopes.ipynb
+++ b/docs/source/examples/2_multiple_telescopes.ipynb
@@ -108,7 +108,7 @@
    "source": [
     "cluster = sim_tp.stellar.clusters.cluster(mass=10000,        # Msun\n",
     "                                          distance=50000,    # parsec\n",
-    "                                          core_radius=2,     # parsec\n",
+    "                                          core_radius=2.1,   # parsec\n",
     "                                          seed=9001)         # random seed"
    ]
   },
@@ -133,7 +133,8 @@
     "lfoa.observe(cluster,\n",
     "             properties={\"!OBS.ndit\": 10, \"!OBS.ndit\": 360},\n",
     "             update=True)\n",
-    "hdus_lfoa = lfoa.readout()"
+    "hdus_lfoa = lfoa.readout()\n",
+    "data_lfoa = hdus_lfoa[0][1].data"
    ]
   },
   {
@@ -154,12 +155,38 @@
    "outputs": [],
    "source": [
     "micado = sim.OpticalTrain(\"MICADO\")\n",
+    "# Use the central detector of the full MICADO array\n",
+    "micado[\"detector_window\"].include = False\n",
+    "micado[\"full_detector_array\"].include = True\n",
+    "micado[\"full_detector_array\"].meta[\"active_detectors\"] = [5]\n",
     "micado.cmds[\"!OBS.dit\"] = 10\n",
     "micado.cmds[\"!OBS.ndit\"] = 360\n",
     "micado.update()\n",
     "\n",
     "micado.observe(cluster)\n",
-    "hdus_micado = micado.readout()"
+    "hdus_micado = micado.readout()\n",
+    "data_micado = hdus_micado[0][1].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d959ea6d-60e4-485e-a7ed-e542e03f4399",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_micado = hdus_micado[0][1].data\n",
+    "data_lfoa = hdus_lfoa[0][1].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbdd9702-6803-4ac6-a8ea-8e078ca17ddf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_lfoa.shape"
    ]
   },
   {
@@ -167,7 +194,9 @@
    "id": "infrared-angola",
    "metadata": {},
    "source": [
-    "Plot up the results"
+    "# Plot up the results\n",
+    "\n",
+    "LFOA has a larger field of view and a lower resolution than MICADO, so while LFOA shows the whole cluster, MICADO only shows the center."
    ]
   },
   {
@@ -180,65 +209,69 @@
     "plt.figure(figsize=(12,5))\n",
     "\n",
     "plt.subplot(121)\n",
-    "plt.imshow(hdus_lfoa[0][1].data[345:385, 525:565], norm=LogNorm(), origin=\"lower\")\n",
+    "plt.imshow(data_lfoa, norm=LogNorm(), origin=\"lower\")\n",
     "plt.colorbar()\n",
     "plt.title(\"1.5m LFOA\")\n",
     "\n",
     "plt.subplot(122)\n",
-    "plt.imshow(hdus_micado[0][1].data, norm=LogNorm(vmax=1E6, vmin=1e5), origin=\"lower\")\n",
+    "plt.imshow(data_micado, norm=LogNorm(vmax=1E6, vmin=1e5), origin=\"lower\")\n",
     "plt.colorbar()\n",
     "plt.title(\"39m ELT\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ea56edb2",
+   "id": "8ecd9a63-95b1-4b3b-8264-633b5b8bd09e",
    "metadata": {},
    "source": [
-    "## Complete script\n",
+    "# Zoom in the LFOA observation\n",
     "\n",
-    "Included below is the complete script for convenience, including the downloads, but not including the plotting."
+    "We can use the pixel scale of LFOA and MICADO to cut out the exact piece of the LFOA observation that corresponds to the MICADO one."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38429fa5",
+   "id": "43e63b25-f661-49c8-9f71-2a70ed34114b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import scopesim as sim\n",
-    "import scopesim_templates as sim_tp\n",
+    "pixel_scale_lfoa = lfoa.cmds[\"!INST.pixel_scale\"]\n",
+    "pixel_scale_micado = micado.cmds[\"!INST.pixel_scale\"]\n",
+    "scale_factor = pixel_scale_lfoa / pixel_scale_micado\n",
     "\n",
-    "# sim.download_packages([\"Armazones\", \"ELT\", \"MICADO\", \"MORFEO\", \"LFOA\"])\n",
+    "size_lfoa_x = data_micado.shape[0] / scale_factor /2\n",
+    "size_lfoa_y = data_micado.shape[1] / scale_factor /2\n",
     "\n",
-    "cluster = sim_tp.stellar.clusters.cluster(mass=10000,        # Msun\n",
-    "                                          distance=50000,    # parsec\n",
-    "                                          core_radius=2,     # parsec\n",
-    "                                          seed=9001)         # random seed\n",
+    "xcen_lfoa = data_lfoa.shape[0] / 2\n",
+    "ycen_lfoa = data_lfoa.shape[1] / 2\n",
     "\n",
-    "lfoa = sim.OpticalTrain(\"LFOA\")\n",
-    "lfoa.observe(cluster,\n",
-    "             properties={\"!OBS.ndit\": 10, \"!OBS.ndit\": 360},\n",
-    "             update=True)\n",
-    "hdus_lfoa = lfoa.readout()\n",
-    "\n",
-    "micado = sim.OpticalTrain(\"MICADO\")\n",
-    "micado.cmds[\"!OBS.dit\"] = 10\n",
-    "micado.cmds[\"!OBS.ndit\"] = 360\n",
-    "micado.update()\n",
-    "\n",
-    "micado.observe(cluster)\n",
-    "hdus_micado = micado.readout()\n"
+    "x_low = round(xcen_lfoa - size_lfoa_x / 2)\n",
+    "x_high = round(xcen_lfoa + size_lfoa_x / 2)\n",
+    "y_low = round(ycen_lfoa - size_lfoa_y / 2)\n",
+    "y_high = round(ycen_lfoa + size_lfoa_y / 2)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bright-stations",
+   "id": "b5abba5a-6740-42d4-8a59-c457d2ed2dde",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "plt.figure(figsize=(12,5))\n",
+    "\n",
+    "plt.subplot(121)\n",
+    "plt.imshow(hdus_lfoa[0][1].data[x_low:x_high, y_low:y_high], norm=LogNorm(), origin=\"lower\")\n",
+    "plt.colorbar()\n",
+    "plt.title(\"1.5m LFOA\")\n",
+    "\n",
+    "plt.subplot(122)\n",
+    "plt.imshow(hdus_micado[0][1].data, norm=LogNorm(vmax=1E6, vmin=1e5), origin=\"lower\")\n",
+    "plt.colorbar()\n",
+    "plt.title(\"39m ELT\")\n",
+    "plt.savefig(\"withfullarray.png\")"
+   ]
   }
  ],
  "metadata": {
@@ -257,7 +290,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.12.2"
   },
   "nbsphinx": {
    "execute": "auto"


### PR DESCRIPTION
This should ensure that the comparison of the LFOA and ELT observation is actually meaningful. The final image looks like

![withfullarray](https://github.com/user-attachments/assets/e8919dc6-8811-4fa2-a839-e09309e66719)

I've removed the summary at the end for simplicity, as it is easy enough to reconstruct.

Also, currently https://scopesim.readthedocs.io/en/latest/examples/2_multiple_telescopes.html is broken. It ends with a `KeyboardInterrupt`?? Let's see whether this fixes that too.