### PR TITLE
Bump two dependencies, use tqdm.auto

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -160,13 +160,13 @@ test = ["dateparser (==1.*)", "pre-commit", "pytest", "pytest-cov", "pytest-mock
 
 [[package]]
 name = "astar-utils"
-version = "0.3.0"
+version = "0.3.1"
 description = "Contains commonly-used utilities for AstarVienna's projects."
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "astar_utils-0.3.0-py3-none-any.whl", hash = "sha256:473d056c4c873fbf077fcc2249f8c3d5bfd37083d9289b13dc2fde7fb6eed872"},
-    {file = "astar_utils-0.3.0.tar.gz", hash = "sha256:c7102b4347c7e4463927e0d3066f03bc6a0d784af8252599e18277c0313a8912"},
+    {file = "astar_utils-0.3.1-py3-none-any.whl", hash = "sha256:6cb6cac868ec4642130183ad3f9519cd60cf37b7326ff0bf38a19caee90d5638"},
+    {file = "astar_utils-0.3.1.tar.gz", hash = "sha256:eae7108aa508b5c6364aac7c4e6160ea13ff5d5887550477a477eb62db4c5270"},
 ]
 
 [package.dependencies]
@@ -3992,4 +3992,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7abe7e30fa4267e7f4bc05ca2935dc6c310e1522540e7612005722d68baaf0ea"
+content-hash = "dc3458bfcb77774f3eaf9cbcd9a5af12e47892de2c96abef59b7b9304eb1ab3a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3821,13 +3821,13 @@ files = [
 
 [[package]]
 name = "tqdm"
-version = "4.66.3"
+version = "4.66.5"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tqdm-4.66.3-py3-none-any.whl", hash = "sha256:4f41d54107ff9a223dca80b53efe4fb654c67efaba7f47bada3ee9d50e05bd53"},
-    {file = "tqdm-4.66.3.tar.gz", hash = "sha256:23097a41eba115ba99ecae40d06444c15d1c0c698d527a01c6c8bd1c5d0647e5"},
+    {file = "tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd"},
+    {file = "tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad"},
 ]
 
 [package.dependencies]
@@ -3992,4 +3992,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "dc3458bfcb77774f3eaf9cbcd9a5af12e47892de2c96abef59b7b9304eb1ab3a"
+content-hash = "e776197bcf95e19add41cdf5b2e0168bdf564b016df2881e6b9a792208b229f2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ beautifulsoup4 = "^4.12.1"
 lxml = "^4.9.3"
 pyyaml = "^6.0.1"
 more-itertools = "^10.1.0"
-tqdm = "^4.66.1"
+tqdm = "^4.66.5"
 
 synphot = "^1.4.0"
 skycalc-ipy = ">=0.5.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ tqdm = "^4.66.1"
 synphot = "^1.4.0"
 skycalc-ipy = ">=0.5.1"
 anisocado = ">=0.3.0"
-astar-utils = ">=0.3.0"
+astar-utils = ">=0.3.1"
 
 [tool.poetry.group.dev]
 optional = true

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -7,7 +7,7 @@ The Effect is called `SpectralTraceList`, it applies a list of
 
 from itertools import cycle
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from astropy.io import fits
 from astropy.table import Table

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -9,7 +9,7 @@ from scipy.interpolate import interp1d
 from astropy import units as u
 from astropy.wcs import WCS
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from synphot import SourceSpectrum, Empirical1D
 from synphot.units import PHOTLAM
@@ -234,7 +234,8 @@ class OpticalTrain:
         else:
 
             fovs = self.fov_manager.fovs
-            for fov in tqdm(fovs, desc=" FOVs", position=0):
+            nobar = len(fovs) <= 1
+            for fov in tqdm(fovs, desc=" FOVs", position=0, disable=nobar):
                 # print("FOV", fov_i+1, "of", n_fovs, flush=True)
                 # .. todo: possible bug with bg flux not using plate_scale
                 #          see fov_utils.combine_imagehdu_fields
@@ -242,8 +243,10 @@ class OpticalTrain:
 
                 hdu_type = "cube" if self.fov_manager.is_spectroscope else "image"
                 fov.view(hdu_type)
-                for effect in tqdm(self.optics_manager.fov_effects,
-                                   desc=" FOV effects", position=1, leave=False):
+                foveffs = self.optics_manager.fov_effects
+                nobar = len(foveffs) <= 1
+                for effect in tqdm(foveffs, disable=nobar,
+                                   desc=" FOV effects", position=1):#, leave=False):
                     fov = effect.apply_to(fov)
 
                 fov.flatten()
@@ -253,7 +256,9 @@ class OpticalTrain:
         # END OF MULTIPROCESSING
 
         # [2D - Vibration, flat fielding, chopping+nodding]
-        for effect in tqdm(self.optics_manager.image_plane_effects,
+        impeffs = self.optics_manager.image_plane_effects
+        nobar = len(impeffs) <= 1
+        for effect in tqdm(impeffs, disable=nobar,
                            desc=" Image Plane effects"):
             for ii, image_plane in enumerate(self.image_planes):
                 self.image_planes[ii] = effect.apply_to(image_plane)

--- a/scopesim/server/download_utils.py
+++ b/scopesim/server/download_utils.py
@@ -12,7 +12,7 @@ from shutil import get_terminal_size
 import httpx
 import bs4
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 # from tqdm.contrib.logging import logging_redirect_tqdm
 # put with logging_redirect_tqdm(loggers=all_loggers): around tqdm
 # Note: seems to work without that so far...


### PR DESCRIPTION
- astar-utils 0.3.1 is needed for other changes here
- Recent version of tqdm includes some useful fixes
- `tqdm.auto` seems to look nicer in notebooks
- Showing a progress bar for a loop with a single item isn't exactly useful