### PR TITLE
Remove skycalc_cli from dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3351,21 +3351,6 @@ objc = ["pyobjc-framework-Cocoa"]
 win32 = ["pywin32"]
 
 [[package]]
-name = "setuptools"
-version = "70.0.0"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "setuptools-70.0.0-py3-none-any.whl", hash = "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"},
-    {file = "setuptools-70.0.0.tar.gz", hash = "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -3375,21 +3360,6 @@ files = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
-
-[[package]]
-name = "skycalc-cli"
-version = "1.4"
-description = "ESO SkyCalc Command Line Interface"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
-files = [
-    {file = "skycalc_cli-1.4-py2.py3-none-any.whl", hash = "sha256:7c62d044f44ea3009e023389ea047bb84d1b8f7b4505321a58bb20b11bb4c7bb"},
-    {file = "skycalc_cli-1.4.tar.gz", hash = "sha256:44ca70bd3559f40979cd6b46eacb3ea4e0af5dde7740a4190967031338e0ca03"},
-]
-
-[package.dependencies]
-requests = "*"
-setuptools = "*"
 
 [[package]]
 name = "skycalc-ipy"
@@ -4041,4 +4011,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d9909c7e08ea55d183c13bb77e14817a53090c6d322e21c8e49b3cf9d4816296"
+content-hash = "e03eb87cf50033b5ed00440c4a863d6a8d1b2be0163af26d618526d1ccc0f163"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,6 @@ ipykernel = "^6.24.0"
 pytest = "^7.4.3"
 pytest-cov = "^4.1.0"
 scopesim_templates = ">=0.5.1"
-# Just so that readthedocs doesn't include the tests module - yes it's hacky
-skycalc_cli = "*"
 ipykernel = "^6.24.0"
 
 [tool.poetry.group.docs]


### PR DESCRIPTION
I don't think this was used anywhere, that's what we have skycalc_ipy for!

Removing this also finally gets rid of setuptools as an indirect dependency.