### PR TITLE
Workaround for #491 metadata.requires can return None

### DIFF
--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -136,6 +136,9 @@ def deriv_polynomial2d(poly):
 
 def _get_required_packages():
     reqs = metadata.requires(__package__)
+    # metadata.requires can return None if the package metadata cannot be found
+    if reqs is None:
+        return []
     for req in reqs:
         # Only include non-extra packages
         if "extra" in req:


### PR DESCRIPTION
Closes #491 . Or well, ensures that `bug_report()` does not crash. We could perhaps do something smarter like log an error or so, maybe we can do that if the problem appears more often.