### PR TITLE
Add a new top level to CMDS nested mapping to store current simulation run settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ build-backend = "poetry.core.masonry.api"
 addopts = "--strict-markers"
 markers = [
     "webtest: marks tests as requiring network (deselect with '-m \"not webtest\"')",
+    "slow: marks tests that take a while (deselect with '-m \"not slow\"')",
 ]
 filterwarnings = [
     "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ScopeSim"
-version = "0.9.0b0"
+version = "0.9.0b1"
 description = "Generalised telescope observation simulator"
 license = "GPL-3.0-or-later"
 authors = ["Kieran Leschinski <kieran.leschinski@unive.ac.at>"]

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -157,7 +157,11 @@ class UserCommands(NestedChainMap):
     def __init__(self, *maps, **kwargs):
         if not maps:
             maps = [rc.__config__]
-        super().__init__(RecursiveNestedMapping(title="CurrSys"), *maps)
+        if not any(getattr(_map, "title", "") == "CurrSys" for _map in maps):
+            # Don't add another layer when .new_child() is called.
+            maps = [RecursiveNestedMapping(title="CurrSys"), *maps]
+
+        super().__init__(*maps)
 
         self.yaml_dicts = []
         # HACK: the deepcopy is necessary because otherwise some subdicts

--- a/scopesim/effects/electronic/exposure.py
+++ b/scopesim/effects/electronic/exposure.py
@@ -202,6 +202,7 @@ class SummedExposure(Effect):
 
         dit = from_currsys(self.meta["dit"], self.cmds)
         ndit = from_currsys(self.meta["ndit"], self.cmds)
+        logger.debug("S.E.: DIT = %s s, NDIT = %s", dit, ndit)
         # TODO: Remove this silly try-except once currsys works properly...
         # TODO: Check the following case: dit, ndit None in kwargs, but
         #       exptime set and AutoExp sets dit, ndit in !OBS (but not kwargs)

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -8,6 +8,8 @@ from astropy.io import fits
 from astropy import units as u
 from astropy.table import Table
 
+from astar_utils.nested_mapping import recursive_update
+
 from . import Effect
 from ..source.source_fields import HDUSourceField, TableSourceField
 from ..utils import from_currsys, find_file
@@ -616,7 +618,7 @@ class SimulationConfigFitsKeywords(ExtraFitsKeywords):
             # TODO: Improve this at some point.....
             cmds = deepcopy(opt_train.cmds.maps[-1].dic)
             for m in opt_train.cmds.maps[-2::-1]:
-                cmds |= deepcopy(m.dic)
+                cmds = recursive_update(cmds, m.dic)
 
             sim_prefix = self.meta["keyword_prefix"]
             resolve_prefix = "unresolved_" if not self.meta["resolve"] else ""

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -451,8 +451,8 @@ class OpticalTrain:
         for i, detector_array in enumerate(self.detector_managers):
             array_effects = self.optics_manager.detector_array_effects
             dtcr_effects = self.optics_manager.detector_effects
-            hdul = detector_array.readout(self.image_planes, array_effects,
-                                         dtcr_effects, **kwargs)
+            hdul = detector_array.readout(
+                self.image_planes, array_effects, dtcr_effects)
 
             fits_effects = self.optics_manager.get_all(ExtraFitsKeywords)
             if len(fits_effects) > 0:

--- a/scopesim/tests/test_basic_instrument/test_basic_instrument.py
+++ b/scopesim/tests/test_basic_instrument/test_basic_instrument.py
@@ -42,6 +42,7 @@ class TestLoadsOpticalTrain:
         assert opt["#slit_wheel.current_slit!"] == "narrow"
 
 
+@pytest.mark.slow
 @pytest.mark.usefixtures("protect_currsys", "patch_all_mock_paths")
 class TestObserveImagingMode:
     def test_runs(self):
@@ -65,6 +66,7 @@ class TestObserveImagingMode:
         assert det_im[505:520, 505:520].sum() > 3e6
 
 
+@pytest.mark.slow
 @pytest.mark.usefixtures("protect_currsys", "patch_all_mock_paths")
 class TestObserveSpectroscopyMode:
     """
@@ -115,6 +117,7 @@ class TestObserveSpectroscopyMode:
             assert round(trace_flux / spot_flux) == n
 
 
+@pytest.mark.slow
 @pytest.mark.usefixtures("protect_currsys", "patch_all_mock_paths")
 class TestObserveIfuMode:
     def test_runs(self):

--- a/scopesim/tests/test_basic_instrument/test_basic_instrument.py
+++ b/scopesim/tests/test_basic_instrument/test_basic_instrument.py
@@ -247,7 +247,7 @@ class TestDitNdit:
         o_dit, o_ndit = opt.cmds["!OBS.dit"], opt.cmds["!OBS.ndit"]
         opt.cmds["!OBS.dit"] = dit
         opt.cmds["!OBS.ndit"] = ndit
-        kwarged = int(opt.readout()[0][1].data.sum())
+        kwarged = int(opt.readout(reset=False)[0][1].data.sum())
         assert quanteff._should_apply() == quant
         opt.cmds["!OBS.dit"] = o_dit
         opt.cmds["!OBS.ndit"] = o_ndit
@@ -255,8 +255,8 @@ class TestDitNdit:
         assert pytest.approx(kwarged / default, rel=.05) == factor
 
     @pytest.mark.parametrize(("dit", "ndit", "factor", "quant"),
-                             [pytest.param(20, 1, 2, True, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs without A.E..")),
-                              pytest.param(10, 3, 3, False, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs without A.E..")),
+                             [(20, 1, 2, True),
+                              (10, 3, 3, False),
                               (None, None, 1, True)])
     def test_kwargs_override_obs_dict(self, obs, dit, ndit, factor, quant):
         """This should prioritize kwargs and fallback to !OBS."""
@@ -267,9 +267,9 @@ class TestDitNdit:
         assert pytest.approx(kwarged / default, rel=.05) == factor
 
     @pytest.mark.parametrize(("dit", "ndit", "factor", "quant"),
-                             [pytest.param(20, 1, 2, True, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs without A.E..")),
-                              pytest.param(10, 3, 3, False, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs without A.E..")),
-                              pytest.param(None, None, 1, True, marks=pytest.mark.xfail(reason="A.E. dosen't use dit, ndit from !OBS if those are None in kwargs."))])
+                             [(20, 1, 2, True),
+                              (10, 3, 3, False),
+                              (None, None, 1, True)])
     def test_kwargs_override_obs_dict_also_with_autoexp(
             self, obs_aeq, dit, ndit, factor, quant):
         """This should prioritize dit, ndit from kwargs.
@@ -277,13 +277,13 @@ class TestDitNdit:
         Lacking those, dit and ndit from !OBS should be used over exptime.
         """
         opt, default, quanteff = obs_aeq
-        kwarged = int(opt.readout(dit=dit, ndit=ndit)[0][1].data.sum())
-        assert int(kwarged / default) == factor
+        kwarged = int(opt.readout(dit=dit, ndit=ndit, reset=False)[0][1].data.sum())
         assert quanteff._should_apply() == quant
+        # Quantization results in ~4% loss, which is fine:
+        assert pytest.approx(kwarged / default, rel=.05) == factor
 
     @pytest.mark.parametrize(("exptime", "factor"),
-                             [(20, 2), (30, 3),
-                              pytest.param(None, 6, marks=pytest.mark.xfail(reason="A.E. doesn't understand None yet."))])
+                             [(20, 2), (30, 3), (None, 6)])
     def test_autoexp(self, obs_aeq, exptime, factor):
         """This should prioritize kwargs and fallback to !OBS."""
         opt, default, quanteff = obs_aeq
@@ -291,45 +291,47 @@ class TestDitNdit:
         o_dit, o_ndit = opt.cmds["!OBS.dit"], opt.cmds["!OBS.ndit"]
         opt.cmds["!OBS.dit"] = None
         opt.cmds["!OBS.ndit"] = None
-        kwarged = int(opt.readout(exptime=exptime)[0][1].data.sum())
+        kwarged = int(opt.readout(exptime=exptime, reset=False)[0][1].data.sum())
         assert not quanteff._should_apply()
         opt.cmds["!OBS.dit"] = o_dit
         opt.cmds["!OBS.ndit"] = o_ndit
-        assert int(kwarged / default) == factor
+        # Quantization results in ~4% loss, which is fine:
+        assert pytest.approx(kwarged / default, rel=.05) == factor
 
     @pytest.mark.parametrize(("exptime", "factor", "quant"),
-                             [(30, 3, False),
-                              (None, 1, True)])
+                             [(30, 3, False), (None, 1, True)])
     def test_autoexp_overrides_obs_dict(self, obs_aeq, exptime, factor, quant):
         """This should prioritize kwargs and use dit, ndit when None."""
         opt, default, quanteff = obs_aeq
-        kwarged = int(opt.readout(exptime=exptime)[0][1].data.sum())
+        kwarged = int(opt.readout(exptime=exptime, reset=False)[0][1].data.sum())
         assert quanteff._should_apply() == quant
         # Quantization results in ~4% loss, which is fine:
         assert pytest.approx(kwarged / default, rel=.05) == factor
 
     @pytest.mark.parametrize(("dit", "ndit", "factor", "quant"),
-                             [pytest.param(90, 1, 90, True, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs.")),
-                              pytest.param(2, 90, 180, False, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs."))])
+                             [(90, 1, 9, True), (2, 90, 18, False)])
     def test_ditndit_in_kwargs_while_also_having_autoexp(
             self, obs_aeq, dit, ndit, factor, quant):
         """This should prioritize dit, ndit from kwargs."""
         opt, default, quanteff = obs_aeq
-        kwarged = int(opt.readout(dit=dit, ndit=ndit)[0][1].data.sum())
-        assert int(kwarged / default) == factor
+        kwarged = int(opt.readout(dit=dit, ndit=ndit, reset=False)[0][1].data.sum())
         assert quanteff._should_apply() == quant
+        # Quantization results in ~4% loss, which is fine:
+        assert pytest.approx(kwarged / default, rel=.05) == factor
 
     @pytest.mark.parametrize(("dit", "ndit", "exptime", "factor", "quant"),
-                             [pytest.param(90, 1, None, 90, True, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs.")),
-                              pytest.param(2, 90, 20, 180, False, marks=pytest.mark.xfail(reason="S.E. doesn't get kwargs."))])
+                             [(90, 1, None, 9, True),
+                              (2, 90, 20, 18, False)])
     def test_ditndit_in_kwargs_while_also_having_autoexp_and_exptime(
             self, obs_aeq, dit, ndit, exptime, factor, quant):
         """This should prioritize dit, ndit from kwargs and ignore exptime."""
         opt, default, quanteff = obs_aeq
         kwarged = int(opt.readout(exptime=exptime,
-                                  dit=dit, ndit=ndit)[0][1].data.sum())
-        assert int(kwarged / default) == factor
+                                  dit=dit, ndit=ndit,
+                                  reset=False)[0][1].data.sum())
         assert quanteff._should_apply() == quant
+        # Quantization results in ~4% loss, which is fine:
+        assert pytest.approx(kwarged / default, rel=.05) == factor
 
     def test_throws_for_no_anything(self, obs):
         """No specification whatsoever, so throw error."""
@@ -340,7 +342,7 @@ class TestDitNdit:
         opt.cmds["!OBS.dit"] = None
         opt.cmds["!OBS.ndit"] = None
         with pytest.raises(ValueError):
-            opt.readout()
+            opt.readout(reset=False)
         opt.cmds["!OBS.dit"] = o_dit
         opt.cmds["!OBS.ndit"] = o_ndit
 
@@ -349,7 +351,7 @@ class TestDitNdit:
         opt, default, quanteff = obs
         opt.cmds["!OBS.exptime"] = None
         with pytest.raises(ValueError):
-            opt.readout(exptime=60)
+            opt.readout(exptime=60, reset=False)
 
     def test_throws_for_no_ditndit_no_autoexp_obs(self, obs):
         """This should fallback to !OBS.exptime, but fail w/o AutoExp."""
@@ -360,6 +362,6 @@ class TestDitNdit:
         opt.cmds["!OBS.dit"] = None
         opt.cmds["!OBS.ndit"] = None
         with pytest.raises(ValueError):
-            opt.readout()
+            opt.readout(reset=False)
         opt.cmds["!OBS.dit"] = o_dit
         opt.cmds["!OBS.ndit"] = o_ndit


### PR DESCRIPTION
This allows the effects to "talk to each other", without polluting the CurrSys settings for another readout run, making it possible to run multiple readouts from the same simulation without having to hack DIT/NDIT etc.

Edit: IRDB notebooks run without issues from this branch.