### PR TITLE
METIS WCU effects

### DIFF
--- a/scopesim/effects/__init__.py
+++ b/scopesim/effects/__init__.py
@@ -20,4 +20,6 @@ from .fits_headers import *
 
 from .rotation import *
 
+from .metis_wcu import *
+
 # from . import effects_utils

--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -115,6 +115,7 @@ class ApertureMask(Effect):
     def apply_to(self, obj, **kwargs):
         """See parent docstring."""
         if isinstance(obj, FOVSetupBase):
+            logger.debug("Executing %s, FoV setup", self.meta['name'])
             x = quantity_from_table("x", self.table,
                                     u.arcsec).to(u.arcsec).value
             y = quantity_from_table("y", self.table,
@@ -295,6 +296,7 @@ class ApertureList(Effect):
     def apply_to(self, obj, **kwargs):
         """See parent docstring."""
         if isinstance(obj, FOVSetupBase):
+            logger.debug("Executing %s, FoV setup", self.meta['name'])
             new_vols = []
             for row in self.table:
                 vols = obj.extract(["x", "y"], ([row["left"], row["right"]],

--- a/scopesim/effects/metis_wcu/__init__.py
+++ b/scopesim/effects/metis_wcu/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""
+Effects for METIS Warm Calibration Unit
+
+Classes:
+-
+-
+"""
+
+from ...utils import get_logger
+
+logger = get_logger(__name__)
+
+from .metis_wcu import BlackBodySource

--- a/scopesim/effects/metis_wcu/__init__.py
+++ b/scopesim/effects/metis_wcu/__init__.py
@@ -12,3 +12,4 @@ from ...utils import get_logger
 logger = get_logger(__name__)
 
 from .metis_wcu import WCUSource
+from .fpmask import FPMask

--- a/scopesim/effects/metis_wcu/__init__.py
+++ b/scopesim/effects/metis_wcu/__init__.py
@@ -11,4 +11,4 @@ from ...utils import get_logger
 
 logger = get_logger(__name__)
 
-from .metis_wcu import BlackBodySource
+from .metis_wcu import WCUSource

--- a/scopesim/effects/metis_wcu/fpmask.py
+++ b/scopesim/effects/metis_wcu/fpmask.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 import numpy as np
 from astropy.io import fits
+from astropy import units as u
 from ..data_container import DataContainer
 
 class FPMask:
@@ -35,25 +36,21 @@ class FPMask:
                "BUNIT": "PHOTLAM arcsec-2",
                "SOLIDANG": "arcsec-2"}
 
-        self.hdu = self.make_hdu(header=hdr)
+        self.pixarea = (hdr['CDELT1'] * u.Unit(hdr['CUNIT1'])
+                        * hdr['CDELT2'] * u.Unit(hdr['CUNIT2']))
+
+        self.holehdu = self.make_holehdu(header=hdr)
+        self.opaquehdu = self.make_opaquehdu(header=hdr)
 
 
-    def make_hdu(self, header) -> fits.ImageHDU:
+    def make_holehdu(self, header) -> fits.ImageHDU:
+        """Create an hdu for the holes in fpmask
+
+        The holes are assumed to be unresolved. They therefore cover one pixel and have
+        a value corresponding to the actual solid angle covered by the hole.
+        """
+
         hdu = fits.ImageHDU()
-        header = {"BG_SRC": True,    ## TODO this is a test
-                  "BG_SURF": "WCU focal plane mask",   # TODO more specific?
-                  "CTYPE1": "LINEAR",
-                  "CTYPE2": "LINEAR",
-                  "CRPIX1": 1024.,
-                  "CRPIX2": 1024.,
-                  "CRVAL1": 0.,
-                  "CRVAL2": 0.,
-                  "CUNIT1": "arcsec",
-                  "CUNIT2": "arcsec",
-                  "CDELT1": 0.00547,
-                  "CDELT2": 0.00547,
-                  "BUNIT": "PHOTLAM arcsec-2",
-                  "SOLIDANG": "arcsec-2"}
         hdu.header.update(header)
         hdu.data = np.zeros((2047, 2047))  # TODO test - do we need to go back to 2048?
         tab = self.data_container.table
@@ -61,4 +58,24 @@ class FPMask:
         ypix = (tab['y'] - header['CRVAL2']) / header['CDELT2'] + header['CRPIX2'] - 1
         holearea = (tab['diam']/2)**2 * np.pi
         hdu.data[ypix.astype(int), xpix.astype(int)] = holearea
+        return hdu
+
+    def make_opaquehdu(self, header) -> fits.ImageHDU:
+        """Create an hdu for the opaque area of the mask
+
+        When spectrum is intensity (../arcsec2), the image must contain the pixel
+        area (arcsec2). For a true backgroud field, this is taken care of by
+        fov._calc_area_factor, but this is not applied to image data, so we
+        have to do it here.
+
+        The holes are assumed to be unresolved. They therefore cover one pixel and have
+        value zero, i.e. no background emission.
+        """
+        hdu = fits.ImageHDU()
+        hdu.header.update(header)
+        hdu.data = np.ones((2047, 2047)) * self.pixarea.value # TODO test - do we need to go back to 2048?
+        tab = self.data_container.table
+        xpix = (tab['x'] - header['CRVAL1']) / header['CDELT1'] + header['CRPIX1'] - 1
+        ypix = (tab['y'] - header['CRVAL2']) / header['CDELT2'] + header['CRPIX2'] - 1
+        hdu.data[ypix.astype(int), xpix.astype(int)] = 0
         return hdu

--- a/scopesim/effects/metis_wcu/fpmask.py
+++ b/scopesim/effects/metis_wcu/fpmask.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 import numpy as np
-from matplotlib import pyplot as plt
 from astropy.io import fits
 from astropy import units as u
 from ..data_container import DataContainer

--- a/scopesim/effects/metis_wcu/fpmask.py
+++ b/scopesim/effects/metis_wcu/fpmask.py
@@ -6,7 +6,7 @@ from matplotlib import pyplot as plt
 from astropy.io import fits
 from astropy import units as u
 from ..data_container import DataContainer
-from ...utils import find_file, from_currsys, get_logger
+from ...utils import find_file, from_currsys, get_logger, figure_factory
 from ...optics.image_plane_utils import sub_pixel_fractions
 
 logger = get_logger(__name__)
@@ -113,11 +113,13 @@ class FPMask:
 
     def plot(self):
         """Plot the location of the holes"""
-        plt.plot(self.xpix, self.ypix, 'o')
-        plt.xlim(0, 2048)
-        plt.ylim(0, 2048)
-        plt.gca().set_aspect('equal')
-        plt.show()
+        _, axes = figure_factory()
+        axes.plot(self.xpix, self.ypix, 'o')
+        axes.set_xlim(0, 2048)
+        axes.set_ylim(0, 2048)
+        axes.set_aspect('equal')
+
+        return axes
 
     def __str__(self) -> str:
         return f"""{self.__class__.__name__}: "{self.name}"

--- a/scopesim/effects/metis_wcu/fpmask.py
+++ b/scopesim/effects/metis_wcu/fpmask.py
@@ -5,6 +5,9 @@ import numpy as np
 from astropy.io import fits
 from astropy import units as u
 from ..data_container import DataContainer
+from ...utils import find_file, from_currsys, get_logger
+
+logger = get_logger(__name__)
 
 class FPMask:
     """Focal-plane mask for the METIS WCU
@@ -16,11 +19,19 @@ class FPMask:
     """
 
     def __init__(self,
-                 filename: Path | str | None = None,
+                 maskname: Path | str | None = None,
+                 fpmask_filename_format: str | None = None,
                  **kwargs
                  ):
-        self.filename = filename
-        self.data_container = DataContainer(filename=filename, **kwargs)
+        logger.debug("Initialising FPMask with ", maskname)
+        # Try to find the file as a path
+        if find_file(maskname, silent=True) is None:
+            file_format = from_currsys(fpmask_filename_format)
+            self.filename = file_format.format(maskname)
+        else:
+            self.filename = maskname
+
+        self.data_container = DataContainer(filename=self.filename, **kwargs)
         hdr = {"BG_SRC": True,
                "BG_SURF": "WCU focal plane mask",   # TODO more specific?
                "CTYPE1": "LINEAR",

--- a/scopesim/effects/metis_wcu/fpmask.py
+++ b/scopesim/effects/metis_wcu/fpmask.py
@@ -1,0 +1,64 @@
+"""A class for the METIS WCU focal-plane mask"""
+
+from pathlib import Path
+import numpy as np
+from astropy.io import fits
+from ..data_container import DataContainer
+
+class FPMask:
+    """Focal-plane mask for the METIS WCU
+
+    Parameters
+    ----------
+    See :class:`DataContainer` for input parameters
+
+    """
+
+    def __init__(self,
+                 filename: Path | str | None = None,
+                 **kwargs
+                 ):
+        self.filename = filename
+        self.data_container = DataContainer(filename=filename, **kwargs)
+        hdr = {"BG_SRC": True,
+               "BG_SURF": "WCU focal plane mask",   # TODO more specific?
+               "CTYPE1": "LINEAR",
+               "CTYPE2": "LINEAR",
+               "CRPIX1": 1024.5,
+               "CRPIX2": 1024.5,
+               "CRVAL1": 0.,
+               "CRVAL2": 0.,
+               "CUNIT1": "arcsec",
+               "CUNIT2": "arcsec",
+               "CDELT1": 0.00547,
+               "CDELT2": 0.00547,
+               "BUNIT": "PHOTLAM arcsec-2",
+               "SOLIDANG": "arcsec-2"}
+
+        self.hdu = self.make_hdu(header=hdr)
+
+
+    def make_hdu(self, header) -> fits.ImageHDU:
+        hdu = fits.ImageHDU()
+        header = {"BG_SRC": True,    ## TODO this is a test
+                  "BG_SURF": "WCU focal plane mask",   # TODO more specific?
+                  "CTYPE1": "LINEAR",
+                  "CTYPE2": "LINEAR",
+                  "CRPIX1": 1024.,
+                  "CRPIX2": 1024.,
+                  "CRVAL1": 0.,
+                  "CRVAL2": 0.,
+                  "CUNIT1": "arcsec",
+                  "CUNIT2": "arcsec",
+                  "CDELT1": 0.00547,
+                  "CDELT2": 0.00547,
+                  "BUNIT": "PHOTLAM arcsec-2",
+                  "SOLIDANG": "arcsec-2"}
+        hdu.header.update(header)
+        hdu.data = np.zeros((2047, 2047))  # TODO test - do we need to go back to 2048?
+        tab = self.data_container.table
+        xpix = (tab['x'] - header['CRVAL1']) / header['CDELT1'] + header['CRPIX1'] - 1
+        ypix = (tab['y'] - header['CRVAL2']) / header['CDELT2'] + header['CRPIX2'] - 1
+        holearea = (tab['diam']/2)**2 * np.pi
+        hdu.data[ypix.astype(int), xpix.astype(int)] = holearea
+        return hdu

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -113,7 +113,8 @@ class WCUSource(TERCurve):
             self._background_source.append(Source(image_hdu=bg_hdu, spectra=bb_flux))
 
         else:   # TODO: properly define masks
-            fpmask = FPMask(self.meta['current_mask'])   # Need a path
+            fpmask = FPMask(maskname=self.meta['current_mask'],
+                            fpmask_filename_format=self.meta['fpmask_filename_format'])
 
             self._background_source.append(Source(image_hdu=fpmask.holehdu, spectra=bb_flux))
             self._background_source.append(Source(image_hdu=fpmask.opaquehdu, spectra=mask_flux))

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -24,14 +24,56 @@ class BlackBodySource(TERCurve):
         super().__init__(**kwargs)
         params = {
             "z_order": [113, 513],
-            "action": "emission",
+            "action": "emissivity",
             "position": 0,  # position in surface table
         }
         self.meta.update(params)
         self.meta.update(kwargs)
+        self._background_source = None
 
         self.compute_emission()
 
+    @property
+    def emission(self):
+        return self.surface.emission
+
+    def set_temperature(self, bb_temp: [float | u.Quantity]=None,
+                        wcu_temp: [float | u.Quantity]=None):
+        """Change the black-body temperature
+
+        Parameters
+        ----------
+        bb_temp, wcu_temp : float, Quantity
+            new temperatures for the BB source and the ambient WCU, respectively.
+            If float, the unit is assumed to be Kelvin.
+        """
+        if isinstance(bb_temp, float):
+            bb_temp = bb_temp << u.K
+            self.meta["bb_temp"] = bb_temp
+        elif isinstance(bb_temp, u.Quantity):
+            try:
+                bb_temp = bb_temp.to(u.K, equivalencies=u.temperature())
+                self.meta["bb_temp"] = bb_temp
+            except u.UnitConversionError:
+                logger.warning(
+                    "UnitConversionError: Parameter bb_temp cannot be converted to Kelvin")
+                return None
+
+        if isinstance(wcu_temp, float):
+            wcu_temp = wcu_temp << u.K
+            self.meta["wcu_temp"] = wcu_temp
+        elif isinstance(wcu_temp, u.Quantity):
+            try:
+                wcu_temp = wcu_temp.to(u.K, equivalencies=u.temperature())
+                self.meta["wcu_temp"] = wcu_temp
+            except u.UnitConversionError:
+                logger.warning(
+                    "UnitConversionError: Parameter wcu_temp cannot be converted to Kelvin")
+                return None
+
+        self.compute_emission()
+
+        return None
 
     def compute_emission(self):
         """Compute the emission at the exit of the integrating sphere"""
@@ -44,10 +86,15 @@ class BlackBodySource(TERCurve):
                   BlackBody(wcu_temp, scale=bb_scale))
         flux = bb_lam(lam)
         tbl.add_column(lam, name="wavelength")
-        tbl.add_column(np.zeros_like(lam).value, name="transmission")
+        tbl.add_column(np.ones_like(lam).value, name="transmission")
         tbl.add_column(flux, name="emission")
         tbl.meta["wavelength_unit"] = tbl["wavelength"].unit
         tbl.meta["emission_unit"] = tbl["emission"].unit
 
         self.surface.table = tbl
         self.surface.meta.update(tbl.meta)
+
+    def __str__(self) -> str:
+        return f"""{self.__class__.__name__}: "{self.display_name}"
+        BlackBody temperature: {self.meta['bb_temp']}
+        WCU temperature:       {self.meta['wcu_temp']}"""

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -217,9 +217,9 @@ class WCUSource(TERCurve):
         """Change the focal-plane mask"""
         # TODO: use name of current_mask to find file
         ## Shall we construct a masklist from all the files that we have?
-        masklist = self.meta['fpmasks']
-        if fpmask not in masklist:
-            raise ValueError(f"fpmask must be one of {masklist}")
+        #masklist = self.meta['fpmasks']
+        #if fpmask not in masklist:
+        #    raise ValueError(f"fpmask must be one of {masklist}")
         self.meta["current_mask"] = fpmask
 
         # Read file: x, y, rad (arcsec)

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -1,8 +1,11 @@
 """Classes for the METIS Warm Calibration Unit"""
 
 import numpy as np
+from astropy.table import Table
+from astropy.modeling.models import BlackBody
+from astropy import units as u
 from ..ter_curves import TERCurve
-from ...utils import get_logger
+from ...utils import get_logger, seq
 
 logger = get_logger(__name__)
 
@@ -20,7 +23,31 @@ class BlackBodySource(TERCurve):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         params = {
-            "z_order": [113, 513]
+            "z_order": [113, 513],
+            "action": "emission",
+            "position": 0,  # position in surface table
         }
         self.meta.update(params)
         self.meta.update(kwargs)
+
+        self.compute_emission()
+
+
+    def compute_emission(self):
+        """Compute the emission at the exit of the integrating sphere"""
+        bb_temp = self.meta["bb_temp"] << u.K
+        wcu_temp = self.meta["wcu_temp"] << u.K
+        tbl = Table()
+        lam = seq(2.2, 15, 0.01) * u.um
+        bb_scale = 1 * u.ph / (u.s * u.m**2 * u.sr * u.um)
+        bb_lam = (BlackBody(bb_temp, scale=bb_scale) +
+                  BlackBody(wcu_temp, scale=bb_scale))
+        flux = bb_lam(lam)
+        tbl.add_column(lam, name="wavelength")
+        tbl.add_column(np.zeros_like(lam).value, name="transmission")
+        tbl.add_column(flux, name="emission")
+        tbl.meta["wavelength_unit"] = tbl["wavelength"].unit
+        tbl.meta["emission_unit"] = tbl["emission"].unit
+
+        self.surface.table = tbl
+        self.surface.meta.update(tbl.meta)

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -172,10 +172,7 @@ class WCUSource(TERCurve):
 
     def get_wavelength(self):
         """Try to set the appropriate wavelength vector for the mode and filter"""
-        if self.cmds is None and "_lam1" in self.meta and "_lam2" in self.meta and "_dlam" in self.meta:
-            # This is for testing only
-            lam = seq(self.meta["_lam1"], self.meta["_lam2"], self.meta["_dlam"])
-        elif 'wcu_lms' in self.cmds['!OBS.modes']:     ## Need to provide for wcu_lms_extended
+        if 'wcu_lms' in self.cmds['!OBS.modes']:     ## Need to provide for wcu_lms_extended
             lamc = self.cmds['!OBS.wavelen']
             dlam = self.cmds['!SIM.spectral.spectral_bin_width']
             lam = seq(lamc - 3000 * dlam, lamc + 3000 * dlam, dlam) * u.um

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -190,30 +190,24 @@ class WCUSource(TERCurve):
             If float, the unit is assumed to be Kelvin.
         """
         if bb_temp is not None:
-            if isinstance(bb_temp, (int, float)):
-                bb_temp = bb_temp << u.K
-
-            bb_temp = bb_temp.to(u.K, equivalencies=u.temperature())
+            with u.set_enabled_equivalencies(u.temperature()):
+                bb_temp <<= u.K
             if bb_temp >= 0:
                 self.meta["bb_temp"] = bb_temp
             else:
                 raise ValueError("bb_temp below absolute zero, not changed")
 
         if wcu_temp is not None:
-            if isinstance(wcu_temp, (int, float)):
-                wcu_temp = wcu_temp << u.K
-
-            wcu_temp = wcu_temp.to(u.K, equivalencies=u.temperature())
+            with u.set_enabled_equivalencies(u.temperature()):
+                wcu_temp <<= u.K
             if wcu_temp >= 0:
                 self.meta["wcu_temp"] = wcu_temp
             else:
                 raise ValueError("wcu_temp below absolute zero, not changed")
 
         if is_temp is not None:
-            if isinstance(is_temp, (int, float)):
-                is_temp = is_temp << u.K
-
-            is_temp = is_temp.to(u.K, equivalencies=u.temperature())
+            with u.set_enabled_equivalencies(u.temperature()):
+                is_temp <<= u.K
             if is_temp >= 0:
                 self.meta["is_temp"] = is_temp
             else:

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -12,10 +12,9 @@ import yaml
 
 from ..ter_curves import TERCurve, FilterCurve
 from ...utils import get_logger, seq, find_file,\
-    convert_table_comments_to_dict, from_currsys
+    from_currsys
 from ...source.source import Source
 from ...optics.surface import SpectralSurface
-from ...optics.surface_utils import make_emission_from_array
 
 
 logger = get_logger(__name__)
@@ -173,7 +172,10 @@ class WCUSource(TERCurve):
 
     def get_wavelength(self):
         """Try to set the appropriate wavelength vector for the mode and filter"""
-        if 'wcu_lms' in self.cmds['!OBS.modes']:     ## Need to provide for wcu_lms_extended
+        if self.cmds is None and "_lam1" in self.meta and "_lam2" in self.meta and "_dlam" in self.meta:
+            # This is for testing only
+            lam = seq(self.meta["_lam1"], self.meta["_lam2"], self.meta["_dlam"])
+        elif 'wcu_lms' in self.cmds['!OBS.modes']:     ## Need to provide for wcu_lms_extended
             lamc = self.cmds['!OBS.wavelen']
             dlam = self.cmds['!SIM.spectral.spectral_bin_width']
             lam = seq(lamc - 3000 * dlam, lamc + 3000 * dlam, dlam) * u.um
@@ -190,10 +192,12 @@ class WCUSource(TERCurve):
 
     @property
     def lamps(self):
+        """List of available lamps"""
         return self.meta['lamps']
 
     @property
     def current_lamp(self):
+        """Name of the lamp currently in use"""
         return self.meta['current_lamp']
 
     def set_temperature(self, bb_temp: [float | u.Quantity]=None,
@@ -242,8 +246,7 @@ class WCUSource(TERCurve):
 
 
     def set_mask(self, fpmask: str):
-        """Change the focal-plane mask
-        """
+        """Change the focal-plane mask"""
         masklist = self.meta['fpmasks']
         if fpmask not in masklist:
             raise ValueError(f"fpmask must be one of {masklist}")
@@ -254,6 +257,7 @@ class WCUSource(TERCurve):
 
     @property
     def current_mask(self):
+        """Name of the mask currently in use"""
         return self.meta['current_mask']
 
 

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -116,7 +116,7 @@ class WCUSource(TERCurve):
     def background_source(self):
         """Define a source field for the FP mask"""
 
-        bb_flux = self.emission * self.bb_aperture
+        bb_flux = self.emission
         mask_flux = self.mask_emission
         self._background_source = []
 
@@ -177,14 +177,15 @@ class WCUSource(TERCurve):
         return self.meta['current_lamp']
 
     def set_temperature(self, bb_temp: [float | u.Quantity]=None,
-                        wcu_temp: [float | u.Quantity]=None,
-                        is_temp: [float | u.Quantity]=None):
+                        is_temp: [float | u.Quantity]=None,
+                        wcu_temp: [float | u.Quantity]=None):
         """Change the black-body temperature
 
         Parameters
         ----------
-        bb_temp, wcu_temp : float, Quantity
-            new temperatures for the BB source and the ambient WCU, respectively.
+        bb_temp, wcu_temp, is_temp : float, Quantity
+            new temperatures for the BB source, the integrating sphere and the
+            ambient WCU, arespectively.
             If float, the unit is assumed to be Kelvin.
         """
         if bb_temp is not None:
@@ -232,7 +233,7 @@ class WCUSource(TERCurve):
             logger.warning("bb_aperture value out of range [0, 1], clipping to {}"
                            .format(value))
         self.bb_aperture = value
-
+        self.compute_lamp_emission()
 
     def set_fpmask(self, fpmask: str):
         """Change the focal-plane mask"""
@@ -280,7 +281,7 @@ class WCUSource(TERCurve):
         # continuum black-body source
         if self.current_lamp == "bb":
             self.is_lamp = BlackBody(self.bb_temp, scale=self.bb_scale)
-            self.flux_lamp = (self.emiss_bb * self.is_lamp(lam)
+            self.flux_lamp = (self.emiss_bb * self.is_lamp(lam) * self.bb_aperture
                             * (np.pi * self.d_is_in**2 / 4) * (np.pi * u.sr))
             self.flux_lamp *= self.bb_to_is(self.rho_tube(lam))
             self.intens_lamp = self.flux_lamp / (np.pi * self.d_is**2) * mult_is / (np.pi * u.sr)

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -47,25 +47,41 @@ class BlackBodySource(TERCurve):
             new temperatures for the BB source and the ambient WCU, respectively.
             If float, the unit is assumed to be Kelvin.
         """
-        if isinstance(bb_temp, float):
+        if isinstance(bb_temp, (int, float)):
             bb_temp = bb_temp << u.K
-            self.meta["bb_temp"] = bb_temp
+            if bb_temp >= 0:
+                self.meta["bb_temp"] = bb_temp
+            else:
+                logger.warning("bb_temp below absolute zero, not changed")
+                return None
         elif isinstance(bb_temp, u.Quantity):
             try:
                 bb_temp = bb_temp.to(u.K, equivalencies=u.temperature())
-                self.meta["bb_temp"] = bb_temp
+                if bb_temp >= 0:
+                    self.meta["bb_temp"] = bb_temp
+                else:
+                    logger.warning("bb_temp below absolute zero, not changed")
+                    return None
             except u.UnitConversionError:
                 logger.warning(
                     "UnitConversionError: Parameter bb_temp cannot be converted to Kelvin")
                 return None
 
-        if isinstance(wcu_temp, float):
+        if isinstance(wcu_temp, (int, float)):
             wcu_temp = wcu_temp << u.K
-            self.meta["wcu_temp"] = wcu_temp
+            if wcu_temp >= 0:
+                self.meta["wcu_temp"] = wcu_temp
+            else:
+                logger.warning("wcu_temp below absolute zero, not changed")
+                return None
         elif isinstance(wcu_temp, u.Quantity):
             try:
                 wcu_temp = wcu_temp.to(u.K, equivalencies=u.temperature())
-                self.meta["wcu_temp"] = wcu_temp
+                if wcu_temp >= 0:
+                    self.meta["wcu_temp"] = wcu_temp
+                else:
+                    logger.warning("wcu_temp below absolute zero, not changed")
+                    return None
             except u.UnitConversionError:
                 logger.warning(
                     "UnitConversionError: Parameter wcu_temp cannot be converted to Kelvin")

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -47,49 +47,28 @@ class BlackBodySource(TERCurve):
             new temperatures for the BB source and the ambient WCU, respectively.
             If float, the unit is assumed to be Kelvin.
         """
-        if isinstance(bb_temp, (int, float)):
-            bb_temp = bb_temp << u.K
+        if bb_temp is not None:
+            if isinstance(bb_temp, (int, float)):
+                bb_temp = bb_temp << u.K
+
+            bb_temp = bb_temp.to(u.K, equivalencies=u.temperature())
             if bb_temp >= 0:
                 self.meta["bb_temp"] = bb_temp
             else:
-                logger.warning("bb_temp below absolute zero, not changed")
-                return None
-        elif isinstance(bb_temp, u.Quantity):
-            try:
-                bb_temp = bb_temp.to(u.K, equivalencies=u.temperature())
-                if bb_temp >= 0:
-                    self.meta["bb_temp"] = bb_temp
-                else:
-                    logger.warning("bb_temp below absolute zero, not changed")
-                    return None
-            except u.UnitConversionError:
-                logger.warning(
-                    "UnitConversionError: Parameter bb_temp cannot be converted to Kelvin")
-                return None
+                raise ValueError("bb_temp below absolute zero, not changed")
 
-        if isinstance(wcu_temp, (int, float)):
-            wcu_temp = wcu_temp << u.K
+        if wcu_temp is not None:
+            if isinstance(wcu_temp, (int, float)):
+                wcu_temp = wcu_temp << u.K
+
+            wcu_temp = wcu_temp.to(u.K, equivalencies=u.temperature())
             if wcu_temp >= 0:
                 self.meta["wcu_temp"] = wcu_temp
             else:
-                logger.warning("wcu_temp below absolute zero, not changed")
-                return None
-        elif isinstance(wcu_temp, u.Quantity):
-            try:
-                wcu_temp = wcu_temp.to(u.K, equivalencies=u.temperature())
-                if wcu_temp >= 0:
-                    self.meta["wcu_temp"] = wcu_temp
-                else:
-                    logger.warning("wcu_temp below absolute zero, not changed")
-                    return None
-            except u.UnitConversionError:
-                logger.warning(
-                    "UnitConversionError: Parameter wcu_temp cannot be converted to Kelvin")
-                return None
+                raise ValueError("wcu_temp below absolute zero, not changed")
 
         self.compute_emission()
 
-        return None
 
     def compute_emission(self):
         """Compute the emission at the exit of the integrating sphere"""

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -1,0 +1,26 @@
+"""Classes for the METIS Warm Calibration Unit"""
+
+import numpy as np
+from ..ter_curves import TERCurve
+from ...utils import get_logger
+
+logger = get_logger(__name__)
+
+class BlackBodySource(TERCurve):
+    """Black Body Source
+
+    This class returns a TERCurve that describes the output emission
+    from the integrating sphere of the METIS WCU. The calculations include
+    - black-body emission from the black-body source
+    - coupling into the integrating sphere
+    - integrating sphere magnification factor
+    - thermal emission from the integrating sphere
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        params = {
+            "z_order": [113, 513]
+        }
+        self.meta.update(params)
+        self.meta.update(kwargs)

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -104,15 +104,21 @@ class BlackBodySource(TERCurve):
             bg_hdu.data = np.zeros((2048, 2048))
             bg_hdu.data[1024, 1024] = 1
             bg_hdu.data[512, 512] = 1
+            # When spectrum is intensity (../arcsec2), the image must contain the pixel
+            # area (arcsec2). For a true backgroud field, this is taken care of by
+            # fov._calc_area_factor, but this is not applied to image data, so we
+            # have to do it here.
+            pixarea = (hdr['CDELT1'] * u.Unit(hdr['CUNIT1'])
+                       * hdr['CDELT2'] * u.Unit(hdr['CUNIT2']))
+            bg_hdu.data = bg_hdu.data #* pixarea  # Should actually be the size of the hole
             self._background_source.append(Source(image_hdu=bg_hdu, spectra=bb_flux))
 
-            pixarea = hdr['CDELT1'] * u.Unit(hdr['CUNIT1']) * hdr['CDELT2'] * u.Unit(hdr['CUNIT2'])
             bg2_hdu = fits.ImageHDU()
             bg2_hdu.header.update(hdr)
-            bg2_hdu.data = np.ones((2048, 2048)) * pixarea
+            bg2_hdu.data = np.ones((2048, 2048))
             bg2_hdu.data[1024, 1024] = 0
             bg2_hdu.data[512, 512] = 0
-
+            bg2_hdu.data = bg2_hdu.data * pixarea
             self._background_source.append(Source(image_hdu=bg2_hdu, spectra=mask_flux))
             #self._background_source = [Source(image_hdu=bg2_hdu, spectra=bb_flux)]  # TEST!!!
 

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -288,7 +288,6 @@ class WCUSource(TERCurve):
         self.emiss_bb = self.meta["emiss_bb"]      # <<<<<< that needs to be a function
 
         lam = self.wavelength
-        print("compute_lamp_emission: len(lam) = ", len(lam))
 
         mult_is = self.is_multiplication(lam)
 
@@ -313,8 +312,6 @@ class WCUSource(TERCurve):
         #self.intens_bg = self.flux_bg / (np.pi * self.d_is**2) * mult_is / (np.pi * u.sr)
         self.intens_bg  = self.rho_is(lam) * self.is_bg(lam)
 
-        print("intens_lamp:", len(self.intens_lamp))
-        print("intens_bg:", len(self.intens_bg))
         self.intensity = self.intens_lamp + self.intens_bg
 
         tbl = Table()
@@ -346,7 +343,6 @@ class WCUSource(TERCurve):
         self.emiss_mask = 1 - self.meta["rho_mask"]       # <<<<<< that needs to be a function
 
         lam = self.wavelength
-        print("compute_fp_emission len(lam) = ", len(lam))
 
         # continuum black-body source
         #self.bb_scale = 1 * u.ph / (u.s * u.m**2 * u.arcsec**2 * u.um)

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -1,5 +1,7 @@
 """Classes for the METIS Warm Calibration Unit"""
 
+from typing import ClassVar
+
 import numpy as np
 from astropy.table import Table
 from astropy.modeling.models import BlackBody, Gaussian1D
@@ -60,10 +62,11 @@ class WCUSource(TERCurve):
     tunable laser currently cannot be tuned.
     """
 
+    z_order: ClassVar[tuple[int, ...]] = (113, 513)
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         params = {
-            "z_order": [113, 513],
             "action": "emissivity",
             "position": 0,  # position in surface table
         }
@@ -71,7 +74,7 @@ class WCUSource(TERCurve):
         self.meta.update(kwargs)
         if 'config_file' in self.meta:
             config_file = from_currsys(self.meta['config_file'], self.cmds)
-            with open(find_file(config_file)) as fd:
+            with open(find_file(config_file), encoding="utf-8") as fd:
                 config = yaml.safe_load(fd)
                 self.meta.update(config)
 

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -231,8 +231,8 @@ class WCUSource(TERCurve):
         """
         if value > 1 or value < 0:
             value = max(0, min(value, 1))
-            logger.warning("bb_aperture value out of range [0, 1], clipping to {}"
-                           .format(value))
+            logger.warning("bb_aperture value out of range [0, 1], clipping to %f",
+                           value)
         self.bb_aperture = value
         self.compute_lamp_emission()
 

--- a/scopesim/effects/psfs/psf_base.py
+++ b/scopesim/effects/psfs/psf_base.py
@@ -8,8 +8,9 @@ from astropy import units as u
 
 from ..effects import Effect
 from ...base_classes import ImagePlaneBase, FieldOfViewBase, FOVSetupBase
-from ...utils import from_currsys, quantify, figure_factory
+from ...utils import from_currsys, quantify, figure_factory, get_logger
 
+logger = get_logger(__name__)
 
 class PoorMansFOV:
     def __init__(self, pixel_scale, spec_dict, recursion_call=False):
@@ -54,6 +55,7 @@ class PSF(Effect):
         """Apply the PSF."""
         # 1. During setup of the FieldOfViews
         if isinstance(obj, FOVSetupBase) and self._waveset is not None:
+            logger.debug("Executing %s, FoV setup", self.meta['name'])
             waveset = self._waveset
             if len(waveset) != 0:
                 waveset_edges = 0.5 * (waveset[:-1] + waveset[1:])
@@ -61,6 +63,7 @@ class PSF(Effect):
 
         # 2. During observe: convolution
         elif isinstance(obj, self.convolution_classes):
+            logger.debug("Executing %s, convolution", self.meta['name'])
             if ((hasattr(obj, "fields") and len(obj.fields) > 0) or
                     (obj.hdu is not None)):
                 kernel = self.get_kernel(obj).astype(float)

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -896,7 +896,78 @@ class PupilTransmission(TERCurve):
                          emissivity=[0., 0.], **self.params)
 
     def update_transmission(self, transmission, **kwargs):
+        """Set a new transmission value"""
         self.__init__(transmission, **kwargs)
+
+
+class PupilMaskWheel(Effect):
+    """
+    Wheel holding a selection of predefined pupil masks
+
+    Currently, changing the PupilMask only changes the relative transmission.
+    Eventually, the change should also affect the total PSF of the OpticalTrain.
+
+    Example
+    -------
+    ::
+
+       name : pupil_masks
+       class : PupilMaskWheel
+       kwargs:
+           pupil_masks: [("name1", transmission1),
+                         ("name2", transmission2)]
+           current_mask: "open"
+    """
+    required_keys = {"pupil_masks", "current_mask"}
+    z_order: ClassVar[tuple[int, ...]] = (126, 226, 526)
+    report_plot_include: ClassVar[bool] = False
+    report_table_include: ClassVar[bool] = True
+    report_table_rounding: ClassVar[int] = 4
+    _current_str = "current_mask"
+
+    def __init__(self, cmds=None, **kwargs):
+        super().__init__(cmds=cmds, **kwargs)
+        check_keys(kwargs, self.required_keys, action="error")
+
+        self.meta.update(kwargs)
+        mask_dict = from_currsys(self.meta["pupil_masks"], cmds=self.cmds)
+        names = mask_dict['names']
+        transmissions = mask_dict['transmissions']
+        self.masks = {}
+        for name, trans in zip(names, transmissions):
+            kwargs["name"] = name
+            self.masks[name] = PupilTransmission(transmission=trans,
+                                                 cmds=cmds,
+                                                 **kwargs)
+        self.table = self.get_table(mask_dict)
+
+    def apply_to(self, obj, **kwargs):
+        """Use ``apply_to`` of current pupil mask."""
+        return self.current_mask.apply_to(obj, **kwargs)
+
+    def change_mask(self, maskname=None):
+        """Change the current pupil mask."""
+        if not maskname or maskname in self.masks:
+            self.meta["current_mask"] = maskname
+            self.include = maskname
+        else:
+            raise ValueError(f"Unknown pupil mask requested: {maskname}")
+
+    @property
+    def current_mask(self):
+        """Return the currently used pupil mask."""
+        currmask = from_currsys(self.meta['current_mask'], cmds=self.cmds)
+        if not currmask:
+            return False
+        return self.masks[currmask]
+
+    def __getattr__(self, item):
+        return getattr(self.current_mask, item)
+
+    def get_table(self, maskdict):
+        """Create a table of pupil masks with throughput."""
+        tbl = Table(maskdict)
+        return tbl
 
 
 class ADCWheel(Effect):

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -134,7 +134,8 @@ class TERCurve(Effect):
 
             # add the effect background to the source background field
             if self.background_source is not None:
-                obj.append(self.background_source)
+                for bgs in self.background_source:
+                    obj.append(bgs)
 
         if isinstance(obj, FOVSetupBase):
             from ..optics.fov_manager import FovVolumeList
@@ -174,7 +175,7 @@ class TERCurve(Effect):
                                   "SOLIDANG": "arcsec-2"})
             self._background_source = Source(image_hdu=bg_hdu, spectra=flux)
 
-        return self._background_source
+        return [self._background_source]
 
     def plot(self, which="x", wavelength=None, *, axes=None, **kwargs):
         """Plot TER curves.
@@ -845,7 +846,7 @@ class SpanishVOFilterWheel(FilterWheelBase):
 
     required_keys = {"observatory", "instrument", "current_filter"}
 
-    def __init__(self, **kwargs):        
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
         params = {"include_str": None,         # passed to

--- a/scopesim/logconfig.yaml
+++ b/scopesim/logconfig.yaml
@@ -21,11 +21,11 @@ loggers:
   # The following loggers produce lots of log spam on DEBUG level, so switch
   # them to INFO by default. They can be re-enabled individually if needed.
   astar.scopesim.optics.image_plane:
-    level: INFO
+    level: DEBUG
   astar.scopesim.optics.image_plane_utils:
-    level: INFO
+    level: DEBUG
   astar.scopesim.optics.surface:
-    level: INFO
+    level: DEBUG
   astar.scopesim.commands.user_commands:
     level: INFO
 

--- a/scopesim/logconfig.yaml
+++ b/scopesim/logconfig.yaml
@@ -21,11 +21,11 @@ loggers:
   # The following loggers produce lots of log spam on DEBUG level, so switch
   # them to INFO by default. They can be re-enabled individually if needed.
   astar.scopesim.optics.image_plane:
-    level: DEBUG
+    level: INFO
   astar.scopesim.optics.image_plane_utils:
-    level: DEBUG
+    level: INFO
   astar.scopesim.optics.surface:
-    level: DEBUG
+    level: INFO
   astar.scopesim.commands.user_commands:
     level: INFO
 

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -380,18 +380,19 @@ class FieldOfView(FieldOfViewBase):
 
         """
         spline_order = from_currsys("!SIM.computing.spline_order", self.cmds)
-
         # Make waveset and canvas image
         fov_waveset = self.waveset
         bin_widths = np.diff(fov_waveset)       # u.um
         bin_widths = 0.5 * (np.r_[0, bin_widths] + np.r_[bin_widths, 0])
-        area = from_currsys(self.meta["area"], self.cmds)    # u.m2
+        area = from_currsys(self.meta["area"], self.cmds) << u.m**2   # u.m2
 
         # PHOTLAM * u.um * u.m2 --> ph / s
         specs = {ref: spec(fov_waveset) if use_photlam
                  else (spec(fov_waveset) * bin_widths * area).to(u.ph / u.s)
                  for ref, spec in self.spectra.items()}
+
         fluxes = {ref: np.sum(spec.value) for ref, spec in specs.items()}
+
         canvas_image_hdu = fits.ImageHDU(
             data=np.zeros((self.header["NAXIS2"], self.header["NAXIS1"])),
             header=self.header)

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -531,6 +531,7 @@ def rescale_imagehdu(imagehdu: fits.ImageHDU, pixel_scale: float | u.Quantity,
         if any(ctype != "LINEAR" for ctype in ww.wcs.ctype):
             logger.warning("Non-linear WCS rescaled using linear procedure.")
 
+        logger.debug("old crpix %s", ww.wcs.crpix)
         new_crpix = (zoom + 1) / 2 + (ww.wcs.crpix - 1) * zoom
         #ew_crpix = np.round(new_crpix * 2) / 2  # round to nearest half-pixel
         logger.debug("new crpix %s", new_crpix)

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -483,13 +483,10 @@ def rescale_imagehdu(imagehdu: fits.ImageHDU, pixel_scale: float | u.Quantity,
 
     """
 
-    logger.debug("Writing test_imagehdu.fits")
-    imagehdu.writeto("test_imagehdu.fits", overwrite=True)
-
     # Identify the wcs to which pixel_scale refers to and determine the zoom factor
     wcs_suffix = wcs_suffix or " "
     primary_wcs = WCS(imagehdu.header, key=wcs_suffix[0])
-    logger.debug("primary wcs: %s", primary_wcs)
+
     # make sure that units are correct and zoom factor is positive
     # The length of the zoom factor will be determined by imagehdu.data,
     # which might differ from the dimension of primary_wcs. Here, pick

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -59,12 +59,15 @@ class OpticsManager:
             raise ValueError("'!INST.pixel_scale' is missing from the current"
                              "system. Please add this to the instrument (INST)"
                              "properties dict for the system.")
-        pixel_scale = self.cmds["!INST.pixel_scale"] * u.arcsec
-        area = self.area
+        pixel_scale = self.cmds["!INST.pixel_scale"] << u.arcsec
+        if "!TEL.area" in self.cmds and self.cmds["!TEL.area"] != 0:
+            area = self.cmds["!TEL.area"] << u.m**2
+        else:
+            area = self.area
+            self.cmds["!TEL.area"] = area
         etendue = area * pixel_scale**2
         self.cmds["!TEL.etendue"] = etendue
         self.cmds["!TEL.area"] = area
-
         params = {"area": area, "pixel_scale": pixel_scale, "etendue": etendue}
         self.meta.update(params)
 

--- a/scopesim/tests/mocks/files/fp_mask_pinhole.dat
+++ b/scopesim/tests/mocks/files/fp_mask_pinhole.dat
@@ -1,0 +1,17 @@
+# description : WCU focal plane mask, pinhole
+# author : Oliver Czoske
+# source : ...
+# date_created : 2024-11-06
+# date_modified : 2024-11-06
+# status : preliminary fantasy values
+# type : aperture:aperture_mask
+# x_unit : arcsec
+# y_unit : arcsec
+# diam_unit : arcsec
+# notes : use plate scale 3.319 mm / arcsec
+# changes :
+#     - 2025-01-09 :  (OC) change format
+#
+ x   y    diam
+ 0   0    0.007532
+ 0.4 0.4  0.007532

--- a/scopesim/tests/test_utils_functions.py
+++ b/scopesim/tests/test_utils_functions.py
@@ -1,6 +1,7 @@
 """Unit tests for module scopesim.utils"""
 
 import pytest
+from pytest import approx
 from unittest.mock import patch
 
 import numpy as np
@@ -131,7 +132,7 @@ class TestDerivPolynomial2D:
 
 class TestConvertCommentsToDict:
     def test_converts_list_of_strings_to_dict_if_comments_in_table_meta(self):
-        tbl = ioascii.read("""# key1 : val 1 
+        tbl = ioascii.read("""# key1 : val 1
                               # key2 : extra long entry
                               col1    col2
                               0       1 """)
@@ -147,8 +148,8 @@ class TestConvertCommentsToDict:
 
     def test_returns_input_if_conversion_doesnt_work(self):
         tbl_str = """
-        # key1 : val 1 
-        # 
+        # key1 : val 1
+        #
         # key2
         col1    col2
         0       1 """
@@ -232,3 +233,34 @@ class TestLoadExampleOptTrain:
     #
     #     assert isinstance(opt, OpticalTrain)
     #     assert from_currsys(opt["slit_wheel"].include)
+
+
+class TestSeq:
+    @pytest.mark.parametrize("start,stop,step",
+                             [(0, 10, 1),
+                              (10, 0, -1),
+                              (-3., 17., 0.05),
+                              (-2000., 5200., 200.)])
+    def test_seq_includes_last_when_it_should(self, start, stop, step):
+        arr = utils.seq(start, stop, step)
+        assert stop == arr[-1]
+
+    @pytest.mark.parametrize("start,stop,step",
+                             [(0, 10, 3),
+                              (10, 0, -3),
+                              (-3., 17., 0.07),
+                              (-2000., 5200., 210.)])
+    def test_seq_includes_last_when_it_should_not(self, start, stop, step):
+        arr = utils.seq(start, stop, step)
+        assert arr[-1] != stop
+        assert stop not in arr
+
+
+    @pytest.mark.parametrize("start,stop,step",
+                             [(0, 10, 1),
+                              (10, 0, -1),
+                              (-3., 17., 0.17),
+                              (-2000., 5200., 312.)])
+    def test_seq_has_correct_step_size(self, start, stop, step):
+        arr = utils.seq(start, stop, step)
+        assert arr[1:] - arr[:-1] == approx(step)

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -27,3 +27,15 @@ class TestBlackBodySource:
     def test_bbsource_has_correct_emission_units(self, bbsource):
         assert (bbsource.surface.table['emission'].unit ==
                 u.ph / (u.s * u.sr * u.um * u.m**2))
+
+    def test_can_set_bb_temperature(self, bbsource):
+        old_temp = bbsource.meta['bb_temp']
+        new_temp = 1.5 * old_temp
+        bbsource.set_temperature(new_temp)
+        assert bbsource.meta['bb_temp'] == new_temp
+
+    def test_can_set_wcu_temperature(self, bbsource):
+        old_temp = bbsource.meta['wcu_temp']
+        new_temp = old_temp + 12 * u.K
+        bbsource.set_temperature(wcu_temp=new_temp)
+        assert bbsource.meta['wcu_temp'] == new_temp

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -101,3 +101,4 @@ class TestBlackBodySource:
     def test_black_body_source_fails_without_parameters(self):
         with pytest.raises(ValueError):
             bbsource = BlackBodySource()
+            assert isinstance(bbsource, BlackBodySource)

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -11,7 +11,7 @@ from scopesim import UserCommands
 from scopesim.effects.metis_wcu import WCUSource
 from scopesim.utils import seq
 
-def _patched_cmds(mode="wcu_lms", wavelen=3.9, bin_width=0.003):
+def _patched_cmds(mode="wcu_lms", wavelen=3.9, bin_width=0.0003):
     """Minimal UserCommands object to stand in for missing OpticalTrain"""
     return UserCommands(properties={"!OBS.modes": mode,
                                     "!OBS.wavelen": wavelen,
@@ -31,7 +31,7 @@ def fixture_bbsource():
                      diam_is_in=25.4,
                      diam_is_out=100.,
                      emiss_bb=0.98,
-                     _lam1=3.2*u.um, _lam2=4.2*u.um, _dlam=0.01*u.um)
+                     cmds=_patched_cmds())
 
 class TestWCUSource:
     def test_initialises_correctly(self, bbsource):
@@ -116,12 +116,10 @@ class TestWCUSource:
 
 
     def test_get_wavelength_for_lms(self, bbsource):
-        print(bbsource.wavelength)
         binw=0.0001
         lamc=3.9
         bbsource.cmds = _patched_cmds(mode="wcu_lms",  wavelen=lamc, bin_width=binw)
         bbsource.get_wavelength()
-        print(bbsource.wavelength)
         lam = 3.6 + (np.arange(6001) * binw)
         assert len(bbsource.wavelength) == len(lam)
         assert np.all(bbsource.wavelength.value == lam)

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -168,6 +168,22 @@ class TestWCUSource:
         bbsource.set_bb_aperture(13)
         assert bbsource.bb_aperture == 1
 
+    @pytest.mark.parametrize("newvalue", [1., 0.6, 0.])
+    def test_bb_aperture_changes_lamp_emission(self, bbsource, newvalue):
+        bbsource.set_bb_aperture(1.)
+        ref_lamp = bbsource.intens_lamp
+        bbsource.set_bb_aperture(newvalue)
+        assert np.allclose(bbsource.intens_lamp, newvalue * ref_lamp)
+
+    @pytest.mark.parametrize("newvalue", [1., 0.6, 0.])
+    def test_bb_aperture_does_not_change_background_emission(self, bbsource,
+                                                             newvalue):
+        bbsource.set_bb_aperture(1.)
+        ref_bg = bbsource.intens_bg
+        bbsource.set_bb_aperture(newvalue)
+        assert np.all(bbsource.intens_bg == ref_bg)
+
+
 @pytest.fixture(name="fpmask", scope="function")
 def fixture_fpmask(mock_path):
     return FPMask(maskname=str(mock_path / "fp_mask_pinhole.dat"))

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -1,5 +1,8 @@
 """Tests for METIS WCU classes"""
 
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
 import pytest
 from astropy import units as u
 
@@ -8,7 +11,16 @@ from scopesim.utils import seq
 
 @pytest.fixture(name="bbsource", scope="function")
 def fixture_bbsource():
-    return BlackBodySource(bb_temp=1000*u.K, wcu_temp=300*u.K)
+    return BlackBodySource(bb_temp=1000*u.K,
+                           is_temp=300*u.K,
+                           wcu_temp=300*u.K,
+                           bb_to_is=None,
+                           rho_tube=0.95,
+                           rho_is=0.95,
+                           diam_is=250,
+                           diam_is_in=25.4,
+                           diam_is_out=100.,
+                           emiss_bb=0.98)
 
 class TestBlackBodySource:
     def test_initialises_correctly(self, bbsource):

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -1,0 +1,13 @@
+"""Tests for METIS WCU classes"""
+
+import pytest
+
+from scopesim.effects.metis_wcu import BlackBodySource
+
+@pytest.fixture(name="bbsource", scope="function")
+def fixture_bbsource():
+    return BlackBodySource()
+
+class TestBlackBodySource:
+    def test_initialises_correctly(self, bbsource):
+        assert isinstance(bbsource, BlackBodySource)

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -4,6 +4,7 @@ import pytest
 from astropy import units as u
 
 from scopesim.effects.metis_wcu import BlackBodySource
+from scopesim.utils import seq
 
 @pytest.fixture(name="bbsource", scope="function")
 def fixture_bbsource():
@@ -44,3 +45,12 @@ class TestBlackBodySource:
         old_temp = bbsource.meta['bb_temp']
         bbsource.set_temperature(bb_temp=-1000 * u.K)
         assert bbsource.meta['bb_temp'] == old_temp
+
+    def test_emission_increases_with_temperature(self, bbsource):
+        old_temp = bbsource.meta['bb_temp']
+        new_temp = 1.2 * old_temp
+        old_emission = bbsource.surface.emission
+        bbsource.set_temperature(bb_temp=new_temp)
+        new_emission = bbsource.surface.emission
+        lam_ref = seq(2.2, 15, 0.1) * u.um
+        assert all(new_emission(lam_ref) > old_emission(lam_ref))

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -188,9 +188,28 @@ class TestWCUSource:
 def fixture_fpmask(mock_path):
     return FPMask(maskname=str(mock_path / "fp_mask_pinhole.dat"))
 
+@pytest.fixture(name="openmask", scope="function")
+def fixture_openmask():
+    return FPMask(maskname="open")
+
+@pytest.fixture(name="pinholemask", scope="function")
+def fixture_pinholemask(mock_path):
+    return FPMask(maskname="pinhole",
+                  fpmask_filename_format=str(mock_path / "fp_mask_{}.dat"))
+
 class TestFPMask:
     def test_fpmask_initialises_correctly(self, fpmask):
         assert isinstance(fpmask, FPMask)
+
+    def test_fpmask_open_has_correct_hdus(self, openmask):
+        assert openmask.holehdu.data is None
+        assert openmask.opaquehdu is None
+
+    def test_fpmask_uses_file_format(self, fpmask, pinholemask):
+        assert fpmask.data_container.meta['filename'] == \
+            pinholemask.data_container.meta['filename']
+        assert np.all(fpmask.holehdu.data == pinholemask.holehdu.data)
+        assert np.all(fpmask.opaquehdu.data == pinholemask.opaquehdu.data)
 
     def test_has_table(self, fpmask):
         assert fpmask.data_container.table is not None

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -205,6 +205,7 @@ class TestFPMask:
         assert openmask.holehdu.data is None
         assert openmask.opaquehdu is None
 
+    @pytest.mark.usefixtures("no_file_error")
     def test_fpmask_uses_file_format(self, fpmask, pinholemask):
         assert fpmask.data_container.meta['filename'] == \
             pinholemask.data_container.meta['filename']

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -161,3 +161,20 @@ class TestFPMask:
 
     def test_has_table(self, fpmask):
         assert fpmask.data_container.table is not None
+
+    def test_has_holehdu(self, fpmask):
+        assert fpmask.holehdu is not None
+
+    def test_has_opaquehdu(self, fpmask):
+        assert fpmask.opaquehdu is not None
+
+    def test_pixarea_correct(self, fpmask):
+        hdr = fpmask.holehdu.header
+        pixarea = hdr['CDELT1'] * hdr['CDELT2'] * u.arcsec**2
+        assert fpmask.pixarea == pixarea
+
+    def test_data_correct(self, fpmask):
+        assert fpmask.holehdu.data[241, 1943] == 0
+        assert fpmask.holehdu.data[1023, 1023] == np.pi * (0.007532**2) / 4
+        assert fpmask.opaquehdu.data[1023, 1023] == 0
+        assert fpmask.opaquehdu.data[748, 1308] == fpmask.pixarea.value

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -41,12 +41,44 @@ class TestBlackBodySource:
         bbsource.set_temperature(wcu_temp=new_temp)
         assert bbsource.meta['wcu_temp'] == new_temp
 
-    def test_ignore_negative_bb_temperature(self, bbsource):
+    def test_can_set_temperature_in_celsius(self, bbsource):
+        bbsource.set_temperature(bb_temp=30*u.deg_C)
+        assert bbsource.meta['bb_temp'] == 303.15 * u.K
+
+    def test_ignore_incompatible_units_bb(self, bbsource):
         old_temp = bbsource.meta['bb_temp']
-        bbsource.set_temperature(bb_temp=-1000 * u.K)
+        with pytest.raises(u.UnitConversionError):
+            bbsource.set_temperature(bb_temp=2*u.Jy)
         assert bbsource.meta['bb_temp'] == old_temp
 
+    def test_ignore_incompatible_units_wcu(self, bbsource):
+        old_temp = bbsource.meta['wcu_temp']
+        with pytest.raises(u.UnitConversionError):
+            bbsource.set_temperature(wcu_temp=2*u.Tesla)
+        assert bbsource.meta['wcu_temp'] == old_temp
+
+
+    def test_ignore_negative_bb_temperature(self, bbsource):
+        old_temp = bbsource.meta['bb_temp']
+        with pytest.raises(ValueError):
+            bbsource.set_temperature(bb_temp=-1000 * u.K)
+        assert bbsource.meta['bb_temp'] == old_temp
+
+    def test_ignore_negative_wcu_temperature(self, bbsource):
+        old_temp = bbsource.meta['wcu_temp']
+        with pytest.raises(ValueError):
+            bbsource.set_temperature(wcu_temp=-1000 * u.K)
+        assert bbsource.meta['wcu_temp'] == old_temp
+
+
     def test_emission_increases_with_temperature(self, bbsource):
+        """
+        Test that increasing the temperature leads to increasing emission.
+
+        This is not a rigorous quantitative test, but should stay correct
+        when all the wavelength-dependent corrections are made to the
+        original black-body emission.
+        """
         old_temp = bbsource.meta['bb_temp']
         new_temp = 1.2 * old_temp
         old_emission = bbsource.surface.emission

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -39,3 +39,8 @@ class TestBlackBodySource:
         new_temp = old_temp + 12 * u.K
         bbsource.set_temperature(wcu_temp=new_temp)
         assert bbsource.meta['wcu_temp'] == new_temp
+
+    def test_ignore_negative_bb_temperature(self, bbsource):
+        old_temp = bbsource.meta['bb_temp']
+        bbsource.set_temperature(bb_temp=-1000 * u.K)
+        assert bbsource.meta['bb_temp'] == old_temp

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -230,6 +230,7 @@ class TestFPMask:
 
     def test_data_correct(self, fpmask):
         assert fpmask.holehdu.data[241, 1943] == 0
-        assert fpmask.holehdu.data[1023, 1023] == np.pi * (0.007532**2) / 4
+        assert fpmask.holehdu.data[1023, 1023] < np.pi * (0.007532**2) / 4
+        assert fpmask.holehdu.data[1021:1025, 1021:1025].sum() == np.pi * (0.007532**2) / 4
         assert fpmask.opaquehdu.data[1023, 1023] == 0
         assert fpmask.opaquehdu.data[748, 1308] == fpmask.pixarea.value

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -1,13 +1,29 @@
 """Tests for METIS WCU classes"""
 
 import pytest
+from astropy import units as u
 
 from scopesim.effects.metis_wcu import BlackBodySource
 
 @pytest.fixture(name="bbsource", scope="function")
 def fixture_bbsource():
-    return BlackBodySource()
+    return BlackBodySource(bb_temp=1000*u.K, wcu_temp=300*u.K)
 
 class TestBlackBodySource:
     def test_initialises_correctly(self, bbsource):
         assert isinstance(bbsource, BlackBodySource)
+
+    def test_bbsource_has_temperatures(self, bbsource):
+        assert bbsource.meta['bb_temp'] == 1000 * u.K
+        assert bbsource.meta['wcu_temp'] == 300 * u.K
+
+    def test_bbsource_has_table(self, bbsource):
+        assert bbsource.surface.table
+
+    def test_bbsource_table_has_correct_columns(self, bbsource):
+        assert (bbsource.surface.table.colnames ==
+                ['wavelength', 'transmission', 'emission'])
+
+    def test_bbsource_has_correct_emission_units(self, bbsource):
+        assert (bbsource.surface.table['emission'].unit ==
+                u.ph / (u.s * u.sr * u.um * u.m**2))

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -38,6 +38,7 @@ def fixture_bbsource():
                      bb_temp=1000*u.K,
                      is_temp=300*u.K,
                      wcu_temp=300*u.K,
+                     bb_aperture=1.,
                      bb_to_is=None,
                      rho_tube=0.95,
                      rho_is=0.95,
@@ -46,11 +47,13 @@ def fixture_bbsource():
                      diam_is_in=25.4,
                      diam_is_out=100.,
                      emiss_bb=0.98,
+                     current_fpmask="open",
+                     fpmask_filename_format="fp_mask_{}.dat",
                      cmds=_patched_cmds())
 
 @pytest.mark.usefixtures("patch_mock_path_basic_instrument")
 class TestWCUSource:
-    def test_initialises_correctly(self, bbsource):
+    def test_wcu_initialises_correctly(self, bbsource):
         assert isinstance(bbsource, WCUSource)
 
     def test_bbsource_has_temperatures(self, bbsource):
@@ -150,13 +153,27 @@ class TestWCUSource:
         lam = seq(1.15, 1.37, 0.002)
         assert np.all(bbsource.wavelength.value == lam)
 
+    def test_bb_aperture_initialises_correctly(self, bbsource):
+        assert bbsource.bb_aperture == 1.
+
+    def test_bb_aperture_set_good_value(self, bbsource):
+        bbsource.set_bb_aperture(0.3)
+        assert bbsource.bb_aperture == 0.3
+
+    def test_bb_aperture_set_clip_negative_value(self, bbsource):
+        bbsource.set_bb_aperture(-3)
+        assert bbsource.bb_aperture == 0
+
+    def test_bb_aperture_set_clip_large_value(self, bbsource):
+        bbsource.set_bb_aperture(13)
+        assert bbsource.bb_aperture == 1
 
 @pytest.fixture(name="fpmask", scope="function")
 def fixture_fpmask(mock_path):
-    return FPMask(filename=str(mock_path / "fp_mask_pinhole.dat"))
+    return FPMask(maskname=str(mock_path / "fp_mask_pinhole.dat"))
 
 class TestFPMask:
-    def test_initialises_correctly(self, fpmask):
+    def test_fpmask_initialises_correctly(self, fpmask):
         assert isinstance(fpmask, FPMask)
 
     def test_has_table(self, fpmask):

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -69,7 +69,6 @@ class TestBlackBodySource:
             bbsource.set_temperature(wcu_temp=2*u.Tesla)
         assert bbsource.meta['wcu_temp'] == old_temp
 
-
     def test_ignore_negative_bb_temperature(self, bbsource):
         old_temp = bbsource.meta['bb_temp']
         with pytest.raises(ValueError):
@@ -81,7 +80,6 @@ class TestBlackBodySource:
         with pytest.raises(ValueError):
             bbsource.set_temperature(wcu_temp=-1000 * u.K)
         assert bbsource.meta['wcu_temp'] == old_temp
-
 
     def test_emission_increases_with_temperature(self, bbsource):
         """
@@ -98,3 +96,8 @@ class TestBlackBodySource:
         new_emission = bbsource.surface.emission
         lam_ref = seq(2.2, 15, 0.1) * u.um
         assert all(new_emission(lam_ref) > old_emission(lam_ref))
+
+
+    def test_black_body_source_fails_without_parameters(self):
+        with pytest.raises(ValueError):
+            bbsource = BlackBodySource()

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -48,6 +48,8 @@ def fixture_bbsource():
                      diam_is_out=100.,
                      emiss_bb=0.98,
                      current_fpmask="open",
+                     fpmask_angle=0,
+                     fpmask_shift=(0, 0),
                      fpmask_filename_format="fp_mask_{}.dat",
                      cmds=_patched_cmds())
 

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -10,7 +10,7 @@ import numpy as np
 from astropy import units as u
 
 from scopesim import UserCommands
-from scopesim.effects.metis_wcu import WCUSource
+from scopesim.effects.metis_wcu import WCUSource, FPMask
 from scopesim.utils import seq
 
 def _patched_cmds(mode="wcu_lms", wavelen=3.9, bin_width=0.0003):
@@ -149,3 +149,15 @@ class TestWCUSource:
         bbsource.get_wavelength()
         lam = seq(1.15, 1.37, 0.002)
         assert np.all(bbsource.wavelength.value == lam)
+
+
+@pytest.fixture(name="fpmask", scope="function")
+def fixture_fpmask(mock_path):
+    return FPMask(filename=str(mock_path / "fp_mask_pinhole.dat"))
+
+class TestFPMask:
+    def test_initialises_correctly(self, fpmask):
+        assert isinstance(fpmask, FPMask)
+
+    def test_has_table(self, fpmask):
+        assert fpmask.data_container.table is not None

--- a/scopesim/tests/tests_effects/test_fits_headers.py
+++ b/scopesim/tests/tests_effects/test_fits_headers.py
@@ -121,7 +121,7 @@ class TestExtraFitsKeywordsApplyTo:
                             optical_train=simplecado_opt)
 
         assert hdul[0].header["HIERARCH SIM dark_current"] == 0.1
-        assert hdul[0].header["HIERARCH SIM telescope_area"] == 0.
+        assert hdul[0].header["HIERARCH SIM telescope_area"] == 1.
 
     def test_full_yaml_string(self, yaml_string, simplecado_opt, comb_hdul):
         eff = fh.ExtraFitsKeywords(yaml_string=yaml_string)
@@ -129,7 +129,7 @@ class TestExtraFitsKeywordsApplyTo:
         pri_hdr = hdul[0].header
 
         # resolved keywords
-        assert pri_hdr["HIERARCH ESO TEL area"] == 0             # !-str
+        assert pri_hdr["HIERARCH ESO TEL area"] == 1             # !-str
         assert pri_hdr["HIERARCH ESO TEL pixel_scale"] == 0.004  # !-str
         assert pri_hdr["HIERARCH ESO DAR VALUE"] == 0.1          # #-str
         assert pri_hdr["HIERARCH ESO TEL its_over"] == 9000      # normal

--- a/scopesim/tests/tests_effects/test_fits_headers.py
+++ b/scopesim/tests/tests_effects/test_fits_headers.py
@@ -1,3 +1,6 @@
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
 import pytest
 from unittest.mock import patch
 
@@ -12,16 +15,16 @@ from scopesim.source.source_templates import star
 import scopesim as sim
 
 
-@pytest.fixture(scope="function")
-def simplecado_opt(mock_path_yamls):
+@pytest.fixture(name="simplecado_opt", scope="function")
+def fixture_simplecado_opt(mock_path_yamls):
     with patch("scopesim.rc.__currsys__"):
         simplecado_yaml = str(mock_path_yamls / "SimpleCADO.yaml")
         cmd = sim.UserCommands(yamls=[simplecado_yaml])
         yield sim.OpticalTrain(cmd)
 
 
-@pytest.fixture(scope="function")
-def comb_hdul():
+@pytest.fixture(name="comb_hdul", scope="function")
+def fixture_comb_hdul():
     pri = fits.PrimaryHDU(header=fits.Header({"EXTNAME": "PriHDU"}))
     im = fits.ImageHDU(header=fits.Header({"EXTNAME": "ImHDU"}))
     tbl = fits.BinTableHDU(header=fits.Header({"EXTNAME": "BinTblHDU"}))
@@ -31,8 +34,8 @@ def comb_hdul():
 
 
 # taken from the example yaml in docstring of ExtraFitsKeywords
-@pytest.fixture(scope="function")
-def yaml_string():
+@pytest.fixture(name="yaml_string", scope="function")
+def fixture_yaml_string():
     return """
 - ext_type: PrimaryHDU
   keywords:

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -272,11 +272,8 @@ def find_file(filename, path=None, silent=False):
         logger.error(msg)
 
     # TODO: Not sure what to do here
-    # [OC]: I don't think it's useful to raise an error - let user decide what
-    #       to do if no file is found (i.e. None is returned). (also: why not
-    #       FileNotFoundError?)
-    # if from_currsys("!SIM.file.error_on_missing_file"):
-    #    raise ValueError(msg)
+    if from_currsys("!SIM.file.error_on_missing_file"):
+       raise ValueError(msg)
 
     return None
 

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -272,8 +272,11 @@ def find_file(filename, path=None, silent=False):
         logger.error(msg)
 
     # TODO: Not sure what to do here
-    if from_currsys("!SIM.file.error_on_missing_file"):
-        raise ValueError(msg)
+    # [OC]: I don't think it's useful to raise an error - let user decide what
+    #       to do if no file is found (i.e. None is returned). (also: why not
+    #       FileNotFoundError?)
+    # if from_currsys("!SIM.file.error_on_missing_file"):
+    #    raise ValueError(msg)
 
     return None
 


### PR DESCRIPTION
This pull request includes Scopesim functionality to describe the METIS warm calibration unit. The idea is to have an empty source (`empty_sky`, taken as the default of `OpticalTrain.observe`, cf. https://github.com/AstarVienna/ScopeSim/pull/483), and add the emission at the exit of the integrating sphere as (subclasses of) `TERCurve` (`BlackBodySource` and `LaserSource`).  Further effects describe the aperture masks (including thermal emission from the opaque parts). 

The computation of the integrating-sphere exit radiance follows Roy van Boekel's radiometric model described in E-REP-MPIA-1203.