### PR TITLE
Move logging config to separate yaml, configure individual loggers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ScopeSim"
-version = "0.9.1a2"
+version = "0.9.1a3"
 description = "Generalised telescope observation simulator"
 license = "GPL-3.0-or-later"
 authors = ["Kieran Leschinski <kieran.leschinski@unive.ac.at>"]

--- a/scopesim/defaults.yaml
+++ b/scopesim/defaults.yaml
@@ -54,53 +54,6 @@ properties :
     image_format: "png"
     preamble_file: None
 
-  logging :
-    # This sub-dict enables direct configuration of logging.
-    # The corresponding schema can be found at:
-    # https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
-
-    version: 1
-    disable_existing_loggers: False  # Not sure what's best here??
-
-    root:  # To allow e.g. warnings -> logging
-      level: INFO
-      handlers: [console]  # [console, file] or just [console]
-
-    loggers:
-      astar:
-        level: WARNING
-        handlers: [console]  # [console, file] or just [console]
-        propagate: False  # Any logging from astar stops here.
-        # Or don't add handlers here, but let it propagate to root?
-      # This doesn't work because NestedMapping doesn't like "." in keys...
-      # astar.scopesim:
-      #   level: DEBUG
-      #   propagate: True  # Goes through to astar logger.
-
-    handlers:
-      console:
-        class: logging.StreamHandler
-        level: INFO
-        formatter: color
-        stream: ext://sys.stdout
-      file:
-        class : logging.handlers.RotatingFileHandler
-        level: DEBUG
-        formatter: verbose
-        filename: ".scopesim.log"
-        mode: "w"   # w - overwrite, a - append
-        encoding: "utf-8"
-        delay: True
-        maxBytes: 32768
-        backupCount: 3
-
-    formatters:
-      verbose:
-        format: '%(asctime)s - %(levelname)-8s - %(name)s - %(funcName)s - %(message)s'
-      color:
-        '()': astar_utils.loggers.ColoredFormatter
-        show_name: True
-
   tests :
     # overridden in tests/__init__.py
     run_integration_tests : True

--- a/scopesim/logconfig.yaml
+++ b/scopesim/logconfig.yaml
@@ -1,0 +1,54 @@
+### LOGGING CONFIGURATION FOR SCOPESIM
+# The corresponding schema can be found at:
+# https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
+
+version: 1  # required
+disable_existing_loggers: False  # Not sure what's best here??
+
+root:  # To allow e.g. warnings -> logging
+  level: INFO
+  handlers: [console]  # [console, file] or just [console]
+
+loggers:
+  astar:
+    level: WARNING
+    handlers: [console]  # [console, file] or just [console]
+    propagate: False     # Any logging from astar stops here.
+    # Or don't add handlers here, but let it propagate to root?
+  astar.scopesim:
+    level: DEBUG     # Generally allow debug logging from ScopeSim.
+    propagate: True  # Goes through to astar logger by default.
+  # The following loggers produce lots of log spam on DEBUG level, so switch
+  # them to INFO by default. They can be re-enabled individually if needed.
+  astar.scopesim.optics.image_plane:
+    level: INFO
+  astar.scopesim.optics.image_plane_utils:
+    level: INFO
+  astar.scopesim.optics.surface:
+    level: INFO
+  astar.scopesim.commands.user_commands:
+    level: INFO
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: INFO
+    formatter: color
+    stream: ext://sys.stdout
+  file:
+    class : logging.handlers.RotatingFileHandler
+    level: DEBUG
+    formatter: verbose
+    filename: ".scopesim.log"
+    mode: "w"   # w - overwrite, a - append
+    encoding: "utf-8"
+    delay: True
+    maxBytes: 32768
+    backupCount: 3
+
+formatters:
+  verbose:
+    format: '%(asctime)s - %(levelname)-8s - %(name)s - %(funcName)s - %(message)s'
+  color:
+    '()': astar_utils.loggers.ColoredFormatter
+    show_name: True

--- a/scopesim/rc.py
+++ b/scopesim/rc.py
@@ -13,7 +13,6 @@ __pkg_dir__ = Path(__file__).parent
 with (__pkg_dir__ / "defaults.yaml").open(encoding="utf-8") as file:
     dicts = list(yaml.full_load_all(file))
 
-
 try:
     with (Path.home() / ".scopesim_rc.yaml").open(encoding="utf-8") as file:
         dicts.extend(list(yaml.full_load_all(file)))
@@ -21,8 +20,13 @@ except FileNotFoundError:
     pass
 
 
+with (__pkg_dir__ / "logconfig.yaml").open(encoding="utf-8") as file:
+    logconfig = yaml.full_load(file)
+
+
 __config__ = NestedMapping(dicts, title="SystemDict")
 __currsys__ = deepcopy(__config__)
+__logging_config__ = logconfig
 
 # Order matters!
 __search_path__ = UniqueList([

--- a/scopesim/tests/test_logging.py
+++ b/scopesim/tests/test_logging.py
@@ -25,8 +25,7 @@ def reload_scopesim():
 
 @pytest.mark.usefixtures("reload_scopesim")
 def test_loggers_are_configured():
-    log_dict = sim.rc.__config__["!SIM.logging"]
-    base_logger_dict = log_dict["loggers"]["astar"]
+    base_logger_dict = sim.rc.__logging_config__["loggers"]["astar"]
 
     base_logger = logging.getLogger("astar")
     sim_logger = base_logger.getChild("scopesim")

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -700,19 +700,10 @@ def top_level_catch(func):
 
 
 def update_logging(capture_warnings=True):
-    """Reload logging configuration from ``rc.__config__``."""
+    """Reload logging configuration from ``rc.__logging_config__``."""
     # Need to access NestedMapping's internal dict here...
-    # HACK: remove this try-except after updating the minimum astar-utils version...
-    try:
-        dictConfig(rc.__config__["!SIM.logging"].dic)
-    except AttributeError:
-        dictConfig(rc.__config__["!SIM.logging"])
+    dictConfig(rc.__logging_config__)
     logging.captureWarnings(capture_warnings)
-
-    # This cannot be in the dict config (yet) because NestedMapping doesn't like
-    #   "." in keys (yet) ...
-    # Set the "astar.scopesim" logger
-    get_logger(__package__).setLevel(logging.DEBUG)
 
 
 def log_to_file(enable=True):
@@ -722,7 +713,7 @@ def log_to_file(enable=True):
     else:
         handlers = ["console"]
 
-    rc.__config__["!SIM.logging.loggers.astar.handlers"] = handlers
+    rc.__logging_config__["loggers"]["astar"]["handlers"] = handlers
     update_logging()
 
 
@@ -732,5 +723,5 @@ def set_console_log_level(level="INFO"):
     This controls what is actually printed to the console by ScopeSim.
     Accepted values are: DEBUG, INFO (default), WARNING, ERROR and CRITICAL.
     """
-    rc.__config__["!SIM.logging.handlers.console.level"] = level
+    rc.__logging_config__["handlers"]["console"]["level"] = level
     update_logging()


### PR DESCRIPTION
> _When you discover you are riding a dead horse, the best strategy is to dismount._

## TLDR

After thinking about this for a while and trying various things, I came to the conclusion that having the logging config in `rc.__config__` (and thus in the bottom level of all the cmds nested chainmap thingies) is indeed such a deceased hoofed creature. Thus, to cut losses now and avoid any sunken cost fallacy, I decided to remove the logging stuff from there and put it into a separate place `rc.__logging_config__`, and a new, separate yaml.

## But why?

### Problems with logging in the chainmap

- The `NestedMapping` didn't fully support keys containing a `.` character in the string, because it created an ambiguity when using dot-separated "bang keys". See below why this can't be properly fixed.
- Having all the logging sub-dicts in the whole cmds can create quite a bit of spam in the various printouts containing cmds, while not really adding any useful information in virtually all cases.
- The idea of the chain map cmds is to be able to override configurations on a local level (e.g. optical train instance). This doesn't really work for logging, as the loggers as they are used in ScopeSim are global objects. Thus any changes made to logging-related keys in higher levels of the chain map will either have no effect at all or can potentially lead to conflicts between e.g. different optical train instances. Considering this, I think it's better, easier and cleaner to just treat logging as global. I can't really imagine many cases where you'd _really_ need to configure it differently in different contexts _at the same time_.
- Somewhat related to the point above, the way the nested logging dicts are passed to the builtin configurator would be difficult (if not impossible) to achieve with the way the nested mapping classes return subdicts that are overridden on different levels.

### Why do we even need dots in keys?

Loggers follow a hierarchical namespace structure equivalent to Python's package.module.whatever namespace, separated by dots. To be able to configure individual loggers by default in the dict config (which is the cleanest method of initially configuring logging), we need to be able to include keys containing dots in this nested dict.

### Rejected alternative

I tried for a bit to enable keys containing dots for the `NestedMapping` class. In the end, I was able to make it work, but really only for retrieving existing keys. Adding a new key (or, to a lesser extent, modifying an existing one) created an ambiguity. Consider the following case: A `NestedMapping` instance contains a top-level key `"XYZ"`, which leads to a sub-dict with the key `"ab.cd"` that in turn leads to a dict containing the key `"m"`. Retrieving `"!XYZ.ab.cd.m"` can in theory (and indeed in practice, I did that) be implemented to look up the entire thing in a tree-like manner until the correct key is found. If a new item is to be set with the key `"!XYZ.ab.cd.k"`, how is the `NestedMapping` supposed to know if that's meant to be a key `"k"` in the sub-dict `"ab.cd"`, or in `"cd"`, which is in turn a sub-dict of `"ab"` (and that itself of `"XYZ"`)?

So, instead of implementing a hacky way to include these things and have potential ambiguities in there, I think it's preferable to simply accept it as a limitation of `NestedMapping` that keys cannot contain dots. As outlined above, this might have actually several benefits in the context of the logging config, in keeping it in a separate place.