### PR TITLE
Fix #490: make rescale_imagehdu more robust against dimension mismatches

### DIFF
--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -487,19 +487,22 @@ def rescale_imagehdu(imagehdu: fits.ImageHDU, pixel_scale: float | u.Quantity,
     primary_wcs = WCS(imagehdu.header, key=wcs_suffix[0])
 
     # make sure that units are correct and zoom factor is positive
+    # The length of the zoom factor will be determined by imagehdu.data,
+    # which might differ from the dimension of primary_wcs. Here, pick
+    # the spatial dimensions only.
     pixel_scale = pixel_scale << u.Unit(primary_wcs.wcs.cunit[0])
-    zoom = np.abs(primary_wcs.wcs.cdelt / pixel_scale.value)
+    zoom = np.abs(primary_wcs.wcs.cdelt[:2] / pixel_scale.value)
 
-    if primary_wcs.naxis == 3:
-        # zoom = np.append(zoom, [1])
-        zoom[2] = 1.
+    if len(imagehdu.data.shape) == 3:
+        zoom = np.append(zoom, [1.])  # wavelength dimension unscaled if present
+
+    logger.debug("zoom factor: %s", zoom)
+
     if primary_wcs.naxis != imagehdu.data.ndim:
+        # FIXME: this happens often - shouldn't WCSs be trimmed down before? (OC)
         logger.warning("imagehdu.data.ndim is %d, but primary_wcs.naxis with "
-                        "key %s is %d, both should be equal.",
-                        imagehdu.data.ndim, wcs_suffix, primary_wcs.naxis)
-        zoom = zoom[:2]
-
-    logger.debug("zoom %s", zoom)
+                       "key %s is %d, both should be equal.",
+                       imagehdu.data.ndim, wcs_suffix, primary_wcs.naxis)
 
     if all(zoom == 1.):
         # Nothing to do
@@ -525,28 +528,15 @@ def rescale_imagehdu(imagehdu: fits.ImageHDU, pixel_scale: float | u.Quantity,
             logger.warning("imagehdu.data.ndim is %d, but wcs.naxis with key "
                            "%s is %d, both should be equal.",
                            imagehdu.data.ndim, ww.wcs.alt, ww.naxis)
-            # TODO: could this be ww = ww.sub(2) instead? or .celestial?
-            # ww = WCS(imagehdu.header, key=key, naxis=imagehdu.data.ndim)
 
         if any(ctype != "LINEAR" for ctype in ww.wcs.ctype):
             logger.warning("Non-linear WCS rescaled using linear procedure.")
 
-        new_crpix = (zoom + 1) / 2 + (ww.wcs.crpix - 1) * zoom
-        #ew_crpix = np.round(new_crpix * 2) / 2  # round to nearest half-pixel
-        logger.debug("new crpix %s", new_crpix)
-        ww.wcs.crpix = new_crpix
+        ww.wcs.crpix[:2] = (zoom[:2] + 1) / 2 + (ww.wcs.crpix[:2] - 1) * zoom[:2]
+        logger.debug("new crpix %s", ww.wcs.crpix)
 
         # Keep CDELT3 if cube...
-        new_cdelt = ww.wcs.cdelt[:]
-        new_cdelt /= zoom
-        ww.wcs.cdelt = new_cdelt
-
-        # TODO: is forcing deg here really the best way?
-        # FIXME: NO THIS WILL MESS UP IF new_cdelt IS IN ARCSEC!!!!!
-        # new_cunit = [str(cunit) for cunit in ww.wcs.cunit]
-        # new_cunit[0] = "mm" if key == "D" else "deg"
-        # new_cunit[1] = "mm" if key == "D" else "deg"
-        # ww.wcs.cunit = new_cunit
+        ww.wcs.cdelt[:2] /= zoom[:2]
 
         imagehdu.header.update(ww.to_header())
 

--- a/scopesim/tests/mocks/py_objects/imagehdu_objects.py
+++ b/scopesim/tests/mocks/py_objects/imagehdu_objects.py
@@ -73,3 +73,30 @@ def _image_hdu_three_wcs():
     hdu.header.update(wcs_g.to_header())
 
     return hdu
+
+def _image_hdu_3d_data():
+    nx, ny = 100, 100
+    nz = 3
+
+    # a 3D WCS
+    the_wcs0 = wcs.WCS(naxis=3, key="")
+    the_wcs0.wcs.ctype = ["LINEAR", "LINEAR", "WAVE"]
+    the_wcs0.wcs.cunit = ["arcsec", "arcsec", "um"]
+    the_wcs0.wcs.cdelt = [1, 1, 0.1]
+    the_wcs0.wcs.crval = [0, 0, 2.2]
+    the_wcs0.wcs.crpix = [(nx + 1) / 2, (ny + 1) / 2, 1]
+
+    # a 2D WCS for spatial dimensions
+    the_wcsd = wcs.WCS(naxis=2, key="D")
+    the_wcsd.wcs.ctype = ["LINEAR", "LINEAR"]
+    the_wcsd.wcs.cunit = ["mm", "mm"]
+    the_wcsd.wcs.cdelt = [1, 1]
+    the_wcsd.wcs.crval = [0, 0]
+    the_wcsd.wcs.crpix = [(nx + 1) / 2, (ny + 1) / 2]
+
+    image = np.ones((nz, ny, nx))
+    hdr = the_wcs0.to_header()
+    hdr.extend(the_wcsd.to_header())
+    hdu = fits.ImageHDU(data=image, header=hdr)
+
+    return hdu


### PR DESCRIPTION
A failure in `image_plane_utils.rescale_imagehdu` was noted when running scopesim with a cube source (e.g. in notebook `LSS_AGN-01_preparation.ipynb` in `irdb/METIS`). 
The main change here is that the length of the `zoom` factor is taken from the data dimensions, not from the WCS. The fix has been tested with the three LSS notebooks for METIS and covered by an additional unit test.

Warnings about a mismatch between data and WCS dimensions occur often, which is likely more annoying than harmful; the origin of that lies elsewhere, in the creation of the `ImagePlaneHDU`. 