### PR TITLE
Ignore strip_cdata warning by lxml, introduced by bs4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,8 @@ filterwarnings = [
     "ignore:datetime.datetime.utcfromtimestamp()*:DeprecationWarning",
     # Pytest Notebook stuff
     "ignore:Proactor*:RuntimeWarning",
+    # lxml warning introduced by beautifulsoup
+    "ignore:The 'strip_cdata' option of HTMLParser*:DeprecationWarning",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
Should be fixed in beautifulsoup 4.13

I'm just going to merge this though, to see how far https://github.com/AstarVienna/ScopeSim_Data/pull/20 comes without having to explicitly specify branches and such.