### PR TITLE
Enable DeprecationWarnings by default

### DIFF
--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -22,7 +22,8 @@ from astropy.utils.exceptions import AstropyWarning
 
 warnings.simplefilter('ignore', UserWarning)
 warnings.simplefilter('ignore', FutureWarning)
-warnings.simplefilter('ignore', RuntimeWarning)    # warnings for the developer
+warnings.simplefilter('ignore', RuntimeWarning)  # warnings for the developer
+warnings.simplefilter('default', DeprecationWarning)  # allow in general
 warnings.simplefilter('ignore', category=AstropyWarning)
 yaml.warnings({'YAMLLoadWarning': False})
 


### PR DESCRIPTION
After some frustration about (intended) warnings that sometimes wouldn't show up, I found out that DeprecationWarnings from *anywhere but the `__main__` module* are ignored by default. This is not what we want when we put those in on purpose, so I changed this here.