### PR TITLE
Make random test deterministic

### DIFF
--- a/scopesim/tests/tests_effects/test_FVPSF.py
+++ b/scopesim/tests/tests_effects/test_FVPSF.py
@@ -154,7 +154,8 @@ class TestApplyTo:
         nax1, nax2 = centre_fov.header["NAXIS1"], centre_fov.header["NAXIS2"]
         centre_fov.hdu.data = np.zeros((nax2, nax1))
 
-        x, y = np.random.randint(6, nax1-6, (2, 150))
+        rng = np.random.RandomState(42)
+        x, y = rng.randint(6, nax1-6, (2, 150))
         centre_fov.hdu.data[x, y] = 1
         # centre_fov.hdu.data[6:nax1-6:10, 6:nax1-6:10] = 1
         centre_fov.fields = [1]


### PR DESCRIPTION
Fixes https://github.com/AstarVienna/ScopeSim/actions/runs/11993399220/job/33434342724

```
>       assert np.sum(fov_back.hdu.data) == approx(sum_orig, rel=1E-2)
E       assert 146.45611957005417 == 148.0 ± 1.5e+00
E         comparison failed
E         Obtained: 146.45611957005417
E         Expected: 148.0 ± 1.5e+00
```
