### PR TITLE
Fix two more issues with ScopeSimple

### DIFF
--- a/scopesim/commands/scopesimple.py
+++ b/scopesim/commands/scopesimple.py
@@ -181,15 +181,6 @@ class Simulation:
             List of HDUs containing simulation results.
 
         """
-        # If we have AutoExposure in the optical train and no dit or ndit was
-        # passed, assume the user wants to re-estimate them from given exptime.
-        if "auto_exposure" in self.optical_train:
-            kwargs["dit"] = kwargs.get("dit")
-            kwargs["ndit"] = kwargs.get("ndit")
-        else:
-            # Without AutoExposure, we need to get dit, ndit into !OBS
-            self.settings["!OBS.dit"] = kwargs.get("dit")
-            self.settings["!OBS.ndit"] = kwargs.get("ndit")
         self._last_readout = self.optical_train.readout(filename, **kwargs)
         return self.last_readout[0]
 

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -291,7 +291,7 @@ class UserCommands(NestedChainMap):
                     mode_yaml = self.modes_dict[mode_name]
                     self._load_yaml_dict(mode_yaml)
 
-        if modes := kwargs.get("set_modes"):
+        if modes := list(kwargs.get("set_modes", [])):
             self.set_modes(*modes)
 
         # Calling underlying NestedMapping's update method to avoid recursion

--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -459,7 +459,7 @@ class EffectsMetaKeywords(ExtraFitsKeywords):
                     eff_name = eff_name.split()[0]
 
                 # get a resolved meta dict from the effect
-                eff_meta = deepcopy(opt_train[f"#{eff_name}.!"])
+                eff_meta = deepcopy(opt_train[eff_name].meta)
 
                 if self.meta["add_excluded_effects"] and not eff_meta["include"]:
                     continue

--- a/scopesim/tests/tests_commands/test_scopesimple.py
+++ b/scopesim/tests/tests_commands/test_scopesimple.py
@@ -19,6 +19,14 @@ class TestScopeSimple:
         simple = Simulation("basic_instrument")
         assert "basic_instrument" in str(simple)
 
+    def test_default_mode_works(self):
+        simple = Simulation("basic_instrument")
+        assert simple.mode == "imaging"
+
+    def test_init_mode_works(self):
+        simple = Simulation("basic_instrument", "spectroscopy")
+        assert simple.mode == "spectroscopy"
+
     @pytest.mark.xfail(reason="DIT, NDIT currently broken")
     def test_full_workflow_runs(self):
         simple = Simulation("basic_instrument")

--- a/scopesim/tests/tests_commands/test_scopesimple.py
+++ b/scopesim/tests/tests_commands/test_scopesimple.py
@@ -27,7 +27,6 @@ class TestScopeSimple:
         simple = Simulation("basic_instrument", "spectroscopy")
         assert simple.mode == "spectroscopy"
 
-    @pytest.mark.xfail(reason="DIT, NDIT currently broken")
     def test_full_workflow_runs(self):
         simple = Simulation("basic_instrument")
         src = st.star(flux=15)


### PR DESCRIPTION
The bang-keys in meta in SummedExposure were somehow overwritten with the corresponding cmds values in the ExtraFitsKeywords, this should no longer occur. The previously added 3rd level in cmds makes the hack in scopesimple obsolete.

The default instrument mode wasn't actually applied by scopesimple, because of a mistreatment of an empty iterator. Fixed that and added tests to verify.