### PR TITLE
Don't fail subpixels for edge sources

### DIFF
--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -411,7 +411,10 @@ class FieldOfView(FieldOfViewBase):
                 # enabled, it is therefore not necessary to deploy the fix
                 # below in the else-branch.
                 assert not isinstance(x, Iterable), "x must be an integer"
-                canvas_image_hdu.data[y, x] += flux * weight
+                try:
+                    canvas_image_hdu.data[y, x] += flux * weight
+                except IndexError:
+                    continue
             else:
                 # Mask out any stars that were pushed out of the fov by rounding
                 mask = ((x < canvas_image_hdu.data.shape[1]) *


### PR DESCRIPTION
Using the subpixel flag could in a rare edge case result in an IndexError in the FOV, when a source sits right at the edge of the FOV and thus two of the four pixels affected by the subpixel functionality end up outside the canvas HDU. This fix will simply ignore those cases and move on.