### PR TITLE
Fix creation of cube source from file name

### DIFF
--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -324,10 +324,15 @@ class Source(SourceBase):
             wcs = WCS(cube)
         else:
             with fits.open(cube) as hdul:
-                data = hdul[ext].data
-                header = hdul[ext].header
-                header["FILENAME"] = Path(cube).name
-                wcs = WCS(cube)
+                try:
+                    data = hdul[ext].data
+                    header = hdul[ext].header
+                    header["FILENAME"] = Path(cube).name
+                    wcs = WCS(header)
+                except ValueError:  # e.g. TAB WCS
+                    self._from_cube(hdul, ext)
+                    self.fields[0].header["FILENAME"] = Path(cube).name
+                    return
 
         try:
             bunit = header["BUNIT"]


### PR DESCRIPTION
Found this in an unmerged local branch. There must have been a good reason to include this, probably in the context of the METIS notebooks. Codecov fails because there's no test for the condition this is trying to fix...