### PR TITLE
Add a few more `@pytest.mark.slow` markers

### DIFF
--- a/scopesim/tests/test_basic_instrument/test_basic_instrument.py
+++ b/scopesim/tests/test_basic_instrument/test_basic_instrument.py
@@ -124,6 +124,7 @@ class TestSourceImageNotAffected:
     where the source is applied to multiple FOVs via FieldOfView._make_cube_imagefields()
     """
 
+    @pytest.mark.slow
     def test_runs(self):
         src = st.uniform_source()
         src_int = np.mean(src.fields[0].field.data) # original source image intensity

--- a/scopesim/tests/tests_effects/test_AnisocadoConstPSF.py
+++ b/scopesim/tests/tests_effects/test_AnisocadoConstPSF.py
@@ -51,6 +51,7 @@ class TestGetKernel:
     def test_strehl_map_is_in_data(self, psf_object):
         assert isinstance(psf_object._file[0], fits.PrimaryHDU)
 
+    @pytest.mark.slow
     def test_returns_kernel(self, psf_object, fov_object):
         kernel = psf_object.get_kernel(fov_object)
 
@@ -77,6 +78,7 @@ class TestGetKernel:
         assert isinstance(kernel, np.ndarray)
 
 
+@pytest.mark.slow
 class TestApplyTo:
     def test_is_applied_to_point_sources(self, mock_path):
         n = 10

--- a/scopesim/tests/tests_integrations/test_simplecado.py
+++ b/scopesim/tests/tests_integrations/test_simplecado.py
@@ -67,6 +67,7 @@ def obs_dict():
             }
 
 
+@pytest.mark.slow
 @pytest.mark.usefixtures("protect_currsys")
 def test_simplecado(obs_dict, det_yaml):
 

--- a/scopesim/tests/tests_optics/test_FOVManager.py
+++ b/scopesim/tests/tests_optics/test_FOVManager.py
@@ -19,6 +19,7 @@ class TestInit:
 
 @pytest.mark.usefixtures("patch_mock_path")
 class TestGenerateFovList:
+    @pytest.mark.slow
     def test_returns_default_single_entry_fov_list_for_no_effects(self):
         fov_man = FOVManager(pixel_scale=1, plate_scale=1)
         assert len(fov_man.volumes_list) == 1, "volumes_list should have only 1 element initially."

--- a/scopesim/tests/tests_optics/test_OpticalTrain.py
+++ b/scopesim/tests/tests_optics/test_OpticalTrain.py
@@ -112,6 +112,7 @@ class TestInit:
         assert opt["detector QE curve"].include is False
 
 
+@pytest.mark.slow
 @pytest.mark.usefixtures("patch_mock_path")
 class TestObserve:
     """


### PR DESCRIPTION
This should now cover all individual tests that take more than around 0.6 s to run on my machine. Just a small quality of (dev) life improvement...