### PR TITLE
Generatorify `stringify_dict` function

### DIFF
--- a/scopesim/detector/detector.py
+++ b/scopesim/detector/detector.py
@@ -41,8 +41,7 @@ class Detector(DetectorBase):
     @property
     def hdu(self):
         """Return internal HDU."""
-        new_meta = stringify_dict(self.meta)
-        self._hdu.header.update(new_meta)
+        self._hdu.header.update(stringify_dict(self.meta))
 
         pixel_scale = from_currsys("!INST.pixel_scale", self.cmds)
         plate_scale = from_currsys("!INST.plate_scale", self.cmds)

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -499,7 +499,7 @@ def has_needed_keywords(header, suffix=""):
     return all(key in header.keys() for key in keys)
 
 
-def stringify_dict(dic, ignore_types=(str, int, float)):
+def stringify_dict(dic, ignore_types=(str, int, float, bool)):
     """Turn a dict entries into strings for addition to FITS headers."""
     for key, value in dic.items():
         if isinstance(value, ignore_types):

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -501,12 +501,11 @@ def has_needed_keywords(header, suffix=""):
 
 def stringify_dict(dic, ignore_types=(str, int, float)):
     """Turn a dict entries into strings for addition to FITS headers."""
-    dic_new = deepcopy(dic)
-    for key in dic_new:
-        if not isinstance(dic_new[key], ignore_types):
-            dic_new[key] = str(dic_new[key])
-
-    return dic_new
+    for key, value in dic.items():
+        if isinstance(value, ignore_types):
+            yield key, value
+        else:
+            yield key, str(value)
 
 
 def from_currsys(item, cmds=None):


### PR DESCRIPTION
This aux function is only used in HDU.header.update() calls, which can eat pair-generators just fine (yes I tested that). This also removed the need for creating a deepcopy of the original dict in memory (not that it matters much but still), because the input dict is never mutated anyway. Looking at the internal implementation of HDU.header.update(), this actually does mean in this case that the generator is processed item-by-item and never turned into a full dict or anything.

In theory, this could be expanded in the future to also process comments, e.g. whenever the dict value is a 2-tuple, simply yield a 3-tuple, which HDU.header.update() will understand as a key-value-comment group...