### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,25 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    ignore:
+      # For all packages, ignore all patch updates, the "version-update" only targets non-security related updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      minor-versions:
+        # The "version-update" only targets non-security related updates
+        applies-to: version-updates
+        patterns:
+          - "*"
+        # Group minor and patch level update, keep separate PRs for major versions
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Tweak the dependabot setup to avoid the worst of the PR spam. I'd keep this in ScopeSim for now, and if it works (i.e. once we get a security PR), we can roll it out to our other repos. Reading through the docs again, I'm pretty confident they made sure security updates always get though, unless explicitly specified by something that catches them. That is, I think we're fine in only specifying the github-actions part of things (which IIRC was the original concern). But I'd still wait for the next security update, so we know for sure.

## Github Actions dependencies

- Only run weekly (defaults to Monday) instead of daily
- Ignore all non-security related patch level updates

## pip (poetry) dependencies

- Only run weekly (defaults to Monday) instead of daily
- Only label them with the `dependencies` label (get rid of the utterly useless `python` label)
- Group all (weekly) version (i.e. non-security) updates of minor and patch level into one PR, avoiding more spam. Major version updates (and security updates) will still get their own PR if and when they occur.
