### PR TITLE
fix fp mask emission

### DIFF
--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -102,7 +102,7 @@ class WCUSource(TERCurve):
         self.bb_to_is = self.bb_to_is_throughput()
         self.rho_tube = get_reflectivity(self.meta['rho_tube'])
         self.rho_is = get_reflectivity(self.meta['rho_is'])
-        self.rho_mask = get_reflectivity(self.meta['rho_mask'])
+        self.emiss_mask = self.meta['emiss_mask']
 
         # Compute the emission components
         self.compute_lamp_emission()
@@ -367,13 +367,13 @@ class WCUSource(TERCurve):
     def compute_fp_emission(self):
         """Compute the emission spectrum from the opaque part of the focal-plane mask"""
         self.wcu_temp = self.meta["wcu_temp"] << u.K
-        self.emiss_mask = 1 - self.meta["rho_mask"]       # <<<<<< that needs to be a function
 
         lam = self.wavelength
 
-        # continuum black-body source
+        # We assume that T_mask = T_WCU, so that we use RvB's eq.(17) rather than (18)
+        # This is independent of the mask emissivity and gives maximum mask emission.
         self.mask_em = BlackBody(self.wcu_temp, scale=self.bb_scale)
-        self.intens_fp = self.emiss_mask * self.mask_em(lam)
+        self.intens_fp = self.mask_em(lam)
 
         tbl = Table()
         tbl.add_column(lam, name="wavelength")
@@ -423,8 +423,6 @@ class WCUSource(TERCurve):
 
 
 
-
-# TODO: put into metis_wcu_utils.py
 def get_reflectivity(file_or_number):
     """
     Get a reflectivity from either a file or a number

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -42,7 +42,7 @@ def fixture_bbsource():
                      bb_to_is=None,
                      rho_tube=0.95,
                      rho_is=0.95,
-                     rho_mask=0.95,
+                     emiss_mask=1.,
                      diam_is=250,
                      diam_is_in=25.4,
                      diam_is_out=100.,


### PR DESCRIPTION
This fixes the flux from the opaque parts of the focal-plane mask. We had used erroneously a high reflectivity for the mask, whereas the conservative case should use a high emissivity. In fact, using Eq.(17) of RvB's document, the intensity from the mask is independent of the emissivity and is just pure black-body intensity.