### PR TITLE
Limit scipy version to below 1.15.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2796,7 +2796,7 @@ files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
 ]
-markers = {dev = "sys_platform != \"win32\" or os_name != \"nt\"", docs = "sys_platform != \"win32\"", test = "sys_platform != \"win32\""}
+markers = {dev = "os_name != \"nt\" or sys_platform != \"win32\"", docs = "sys_platform != \"win32\"", test = "sys_platform != \"win32\""}
 
 [[package]]
 name = "pure-eval"
@@ -3070,7 +3070,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4196,4 +4195,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.13"
-content-hash = "3cccfdc4a607aeeac661e83139d9aa7578f2aba0d73f1053e6fd2b095f72aeb1"
+content-hash = "2f99cf6109f3f2f8748ae95c6b655af830b0a465943fbf0a963e5b61b0d3b313"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.10, <3.13"
 numpy = "^1.26.3"
-scipy = "^1.14.1"
+scipy = ">=1.14.1, <1.15.0"
 astropy = "^6.0.1"
 matplotlib = "^3.8.2"
 pooch = "^1.8.2"


### PR DESCRIPTION
Our RTD build fails with scipy >= 1.15.0 because we use the deprecated `scipy.misc` module somewhere, which [has been removed in scipy 1.15.0](https://docs.scipy.org/doc/scipy/release/1.15.0-notes.html#expired-deprecations). Ultimately, we should remove that, wherever it is, but for now at least make sure the incompatible version cannot be installed.