### PR TITLE
Ignore patch updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
+    ignore:
+      # For all packages, ignore all patch updates, the "version-update" only targets non-security related updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
     groups:
       internal-dependencies:
         applies-to: version-updates


### PR DESCRIPTION
Now I'm confused if we'll still get patch level updates for our internal dependencies, which I'd like to keep. Well, only one way to find out...