### PR TITLE
Remove base class check in `Effect.apply_to()`

### DIFF
--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, field, InitVar, fields
 from typing import NewType, ClassVar
 
 from .data_container import DataContainer
-from .. import base_classes as bc
 from ..utils import from_currsys, write_report
 from ..reports.rst_utils import table_to_rst
 
@@ -57,15 +56,8 @@ class Effect:
         self.meta.update(kwargs)
 
     def apply_to(self, obj, **kwargs):
-        """TBA."""
-        if not isinstance(obj, (bc.FOVSetupBase, bc.SourceBase,
-                                bc.FieldOfViewBase, bc.ImagePlaneBase,
-                                bc.DetectorBase)):
-            raise ValueError("object must one of the following: FOVSetupBase, "
-                             "Source, FieldOfView, ImagePlane, Detector: "
-                             f"{type(obj)}")
-
-        return obj
+        """Apply the effect to the corresponding object."""
+        raise NotImplementedError("Subclasses should implement this.")
 
     def fov_grid(self, which="", **kwargs):
         """

--- a/scopesim/tests/tests_effects/test_Effects.py
+++ b/scopesim/tests/tests_effects/test_Effects.py
@@ -24,7 +24,7 @@ class TestEffectInit:
 
     def test_base_class_apply_to_throws(self):
         with pytest.raises(NotImplementedError):
-            Effect().apply_to()
+            Effect().apply_to("bogus")
 
     def test_has_method_waveset(self):
         assert hasattr(Effect(), "fov_grid")

--- a/scopesim/tests/tests_effects/test_Effects.py
+++ b/scopesim/tests/tests_effects/test_Effects.py
@@ -22,6 +22,10 @@ class TestEffectInit:
     def test_has_method_apply_to(self):
         assert hasattr(Effect(), "apply_to")
 
+    def test_base_class_apply_to_throws(self):
+        with pytest.raises(NotImplementedError):
+            Effect().apply_to()
+
     def test_has_method_waveset(self):
         assert hasattr(Effect(), "fov_grid")
 


### PR DESCRIPTION
This caused a lot more trouble than it's worth (e.g. in the scope of #241). The various effect subclasses each perform the appropriate check anyway.

Ultimately, the `Effect` base class might be turned into an ABC, but that's for later...