### PR TITLE
Check if all ref keys are found in spectra

### DIFF
--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -164,6 +164,9 @@ class TableSourceField(SpectrumSourceField):
     def __post_init__(self):
         """Validate input."""
         assert self.spectra, "Spectra must be non-empty for table source."
+        if not (uniquerefs := set(self.field["ref"])).issubset(self.spectra):
+            raise KeyError(f"Refs {uniquerefs.difference(self.spectra)} "
+                           "not found in spectra.")
         if "weight" not in self.field.colnames:
             self.field.add_column(
                 Column(name="weight", data=np.ones(len(self.field)))

--- a/scopesim/tests/tests_source/test_source_Source.py
+++ b/scopesim/tests/tests_source/test_source_Source.py
@@ -186,7 +186,7 @@ class TestSourceInit:
     def test_initialises_with_filename_and_spectrum(self, ii, dtype,
                                                     input_files, input_spectra):
         fname = input_files[ii]
-        spec = input_spectra if isinstance(dtype, Table) else input_spectra[0]
+        spec = input_spectra if issubclass(dtype, Table) else input_spectra[0]
         src = Source(filename=fname, spectra=spec)
         assert isinstance(src, Source)
         assert isinstance(src.spectra[0], SourceSpectrum)

--- a/scopesim/tests/tests_source/test_source_Source.py
+++ b/scopesim/tests/tests_source/test_source_Source.py
@@ -186,7 +186,8 @@ class TestSourceInit:
     def test_initialises_with_filename_and_spectrum(self, ii, dtype,
                                                     input_files, input_spectra):
         fname = input_files[ii]
-        src = Source(filename=fname, spectra=input_spectra)
+        spec = input_spectra if isinstance(dtype, Table) else input_spectra[0]
+        src = Source(filename=fname, spectra=spec)
         assert isinstance(src, Source)
         assert isinstance(src.spectra[0], SourceSpectrum)
         assert isinstance(src.fields[0].field, dtype)

--- a/scopesim/tests/tests_source/test_source_Source.py
+++ b/scopesim/tests/tests_source/test_source_Source.py
@@ -16,7 +16,7 @@ from synphot.units import PHOTLAM
 
 from scopesim.source import source_utils
 from scopesim.source.source import Source
-from scopesim.source.source_fields import CubeSourceField
+from scopesim.source.source_fields import CubeSourceField, TableSourceField
 
 from scopesim.optics.image_plane import ImagePlane
 from scopesim.utils import convert_table_comments_to_dict
@@ -186,7 +186,7 @@ class TestSourceInit:
     def test_initialises_with_filename_and_spectrum(self, ii, dtype,
                                                     input_files, input_spectra):
         fname = input_files[ii]
-        src = Source(filename=fname, spectra=input_spectra[0])
+        src = Source(filename=fname, spectra=input_spectra)
         assert isinstance(src, Source)
         assert isinstance(src.spectra[0], SourceSpectrum)
         assert isinstance(src.fields[0].field, dtype)
@@ -447,6 +447,14 @@ def test_cube_source_field():
 
     _, ax = plt.subplots()
     csf.plot(ax, "red")
+
+
+def test_throws_for_invalid_ref():
+    with pytest.raises(KeyError):
+        # Minimal Table
+        tbl = Table(data=[[0, 1]], names=["ref"])
+        TableSourceField(tbl, {0: None})
+
 
 #
 # class TestScaleImageHDU:


### PR DESCRIPTION
This would have prevented e.g. AstarVienna/ScopeSim_Templates#134