### PR TITLE
Fix broken flux scaling for extended sources in spectroscopy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ScopeSim"
-version = "0.9.3a1"
+version = "0.9.3a2"
 description = "Generalised telescope observation simulator"
 license = "GPL-3.0-or-later"
 authors = ["Kieran Leschinski <kieran.leschinski@unive.ac.at>"]

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -21,7 +21,7 @@ from ..utils import (
     quantify,
     has_needed_keywords,
     get_logger,
-    unit_includes_per_physicyl_type,
+    unit_includes_per_physical_type,
 )
 from ..source.source import Source
 
@@ -486,14 +486,9 @@ class FieldOfView:
                 data=np.zeros((self.header["NAXIS2"], self.header["NAXIS1"])),
                 header=self.header)
             # FIX: Do not scale source data - make a copy first.
-            # Note: Use NOT "Pixel scale conversion" as above, because the
-            #       values are in photons/second/pixel (see comments above),
-            #       but need to be converted to arcsec-2.
-            #       self.pixel_area is in arcsec-2(/pixel, implicitly), so that
-            #       works out. Need to add unit checks somehow...
             bunit = u.Unit(field.header.get("BUNIT", ""))
             field_data = deepcopy(field.data)
-            if unit_includes_per_physicyl_type(bunit, "solid angle"):
+            if unit_includes_per_physical_type(bunit, "solid angle"):
                 # Field is in (PHOTLAM) / arcsec**2, need to scale by pixarea
                 field_data *= self._pixarea(field.header).value
             field_data /= self.pixel_area

--- a/scopesim/tests/test_utils_functions.py
+++ b/scopesim/tests/test_utils_functions.py
@@ -272,6 +272,6 @@ def test_setting_instpkgspath():
     assert rc.__config__["!SIM.file.local_packages_path"] == "bogus"
 
 
-def test_unit_includes_per_physicyl_type():
+def test_unit_includes_per_physical_type():
     unit = u.Unit("photlam") / u.arcsec**2
-    assert utils.unit_includes_per_physicyl_type(unit, "solid angle")
+    assert utils.unit_includes_per_physical_type(unit, "solid angle")

--- a/scopesim/tests/test_utils_functions.py
+++ b/scopesim/tests/test_utils_functions.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import numpy as np
 from astropy import wcs
+from astropy import units as u
 from astropy.io import ascii as ioascii, fits
 from astropy.table import Table
 
@@ -269,3 +270,8 @@ class TestSeq:
 def test_setting_instpkgspath():
     utils.link_irdb("bogus")
     assert rc.__config__["!SIM.file.local_packages_path"] == "bogus"
+
+
+def test_unit_includes_per_physicyl_type():
+    unit = u.Unit("photlam") / u.arcsec**2
+    assert utils.unit_includes_per_physicyl_type(unit, "solid angle")

--- a/scopesim/tests/tests_optics/test_FieldOfView.py
+++ b/scopesim/tests/tests_optics/test_FieldOfView.py
@@ -163,9 +163,8 @@ class TestExtractFrom:
         assert not np.isnan(fov.fields[0].data).any()
 
 
-# @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
 class TestMakeCube:
-    @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
+    @pytest.mark.xfail(reason="cube flux is broken")
     def test_makes_cube_from_table(self):
         src_table = so._table_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
         fov = _fov_190_210_um()
@@ -187,7 +186,7 @@ class TestMakeCube:
             plt.imshow(cube.data[0, :, :], origin="lower")
             plt.show()
 
-    # @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
+    @pytest.mark.xfail(reason="cube flux is broken")
     def test_makes_cube_from_imagehdu(self):
         src_image = so._image_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
         fov = _fov_190_210_um()
@@ -206,7 +205,7 @@ class TestMakeCube:
             plt.imshow(cube.data[0, :, :], origin="lower")
             plt.show()
 
-    @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
+    @pytest.mark.xfail(reason="cube flux is broken")
     def test_makes_cube_from_other_cube_imagehdu(self):
         import scopesim as sim
         sim.rc.__currsys__["!SIM.spectral.spectral_bin_width"] = 0.01
@@ -227,7 +226,7 @@ class TestMakeCube:
             plt.imshow(cube.data[0, :, :], origin="lower")
             plt.show()
 
-    @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
+    @pytest.mark.xfail(reason="cube flux is broken")
     def test_makes_cube_from_two_similar_cube_imagehdus(self):
         src_cube = so._cube_source() + so._cube_source(dx=1)            # 2 cubes 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
         fov = _fov_197_202_um()
@@ -247,7 +246,7 @@ class TestMakeCube:
             plt.imshow(cube.data[0, :, :], origin="lower")
             plt.show()
 
-    @pytest.mark.xfail(reason="apply make_cube's fov.waveset available to the outside ")
+    @pytest.mark.xfail(reason="cube flux is broken")
     def test_makes_cube_from_all_types_of_source_object(self):
         src_all = so._table_source() + \
                   so._image_source(dx=-4, dy=-4) + \

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -491,6 +491,14 @@ def unit_from_table(colname: str, table: Table,
     return u.Unit(default_unit)
 
 
+def unit_includes_per_physicyl_type(unit, physical_type):
+    """Check if one of the `unit`'s bases is of 1/`physical_type`."""
+    # TODO: Check again if there isn't any builtin functionality in astropy
+    #       for the same operation!
+    return any(1 / (base**power).physical_type == physical_type
+               for base, power in zip(unit.bases, unit.powers))
+
+
 def has_needed_keywords(header, suffix=""):
     """Check to see if the WCS keywords are in the header."""
     keys = {"CDELT1", "CRVAL1", "CRPIX1"}

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -491,7 +491,7 @@ def unit_from_table(colname: str, table: Table,
     return u.Unit(default_unit)
 
 
-def unit_includes_per_physicyl_type(unit, physical_type):
+def unit_includes_per_physical_type(unit, physical_type):
     """Check if one of the `unit`'s bases is of 1/`physical_type`."""
     # TODO: Check again if there isn't any builtin functionality in astropy
     #       for the same operation!


### PR DESCRIPTION
See added comment. Also update xfails.

Not an actual proper fix, more a revert of a part of #485. The actual problem is outlined in more detail in #632 et al.

However, the full fix will take a while and this issue was already causing problems for other users, so I think it's best to apply this temporary "fix" in the meantime...

Edit: I included a rudimentary check for `1/arcsec²` in `BUNIT` (there was an old TODO about that anyway), so hopefully this should now be closer to an actual fix rather that a quick hack.