### PR TITLE
Fixup adding mock path to UserCommands

### DIFF
--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -522,7 +522,7 @@ def add_packages_to_rc_search(local_path, package_list):
         plocal_path = patch_fake_symlinks(Path(local_path))
     except FileNotFoundError:
         # retry with mocks
-        plocal_path = patch_fake_symlinks(Path("./scopesim/tests/mocks"))
+        plocal_path = rc.__pkg_dir__ / "tests/mocks"
 
     for pkg in package_list:
         pkg_dir = plocal_path / pkg

--- a/scopesim/tests/tests_commands/test_UserCommands.py
+++ b/scopesim/tests/tests_commands/test_UserCommands.py
@@ -113,11 +113,12 @@ class TestTrackIpAddress:
         _ = UserCommands(use_instrument="test_package")
 
 
-@pytest.mark.usefixtures("protect_currsys")
 class TestIffyPkgPaths:
+    @pytest.mark.usefixtures("protect_currsys")
     def test_finds_basic_instrument(self):
         UserCommands(use_instrument="basic_instrument")
 
+    @pytest.mark.usefixtures("protect_currsys")
     def test_throws_for_bogus_inst(self):
         with pytest.raises(ValueError):
             UserCommands(use_instrument="bogus_instrument")


### PR DESCRIPTION
As was pointed out by @hugobuddel in https://github.com/AstarVienna/ScopeSim/pull/627#discussion_r2030057287, using relative paths here is generally wrong.

Also, using patch_fake_symlinks on the mock path can create undesired results.

Also, over in the tests, the fixture needs to be applied on a function level.