### PR TITLE
Fixup adding mock path to UserCommands (again)

### DIFF
--- a/scopesim/tests/conftest.py
+++ b/scopesim/tests/conftest.py
@@ -104,3 +104,17 @@ def protect_currsys():
     """Prevent modification of global currsys."""
     with patch("scopesim.rc.__currsys__"):
         yield
+
+
+@pytest.fixture(scope="function")
+def protect_config():
+    """Prevent modification of global config."""
+    with patch.dict("scopesim.rc.__config__"):
+        yield
+
+
+@pytest.fixture(scope="function")
+def protect_search_path():
+    """Prevent modification of global search_path."""
+    with patch("scopesim.rc.__search_path__"):
+        yield

--- a/scopesim/tests/test_utils_functions.py
+++ b/scopesim/tests/test_utils_functions.py
@@ -265,7 +265,7 @@ class TestSeq:
         assert arr[1:] - arr[:-1] == approx(step)
 
 
-@pytest.mark.usefixtures("protect_currsys")
+@pytest.mark.usefixtures("protect_config")
 def test_setting_instpkgspath():
     utils.link_irdb("bogus")
     assert rc.__config__["!SIM.file.local_packages_path"] == "bogus"

--- a/scopesim/tests/tests_commands/test_UserCommands.py
+++ b/scopesim/tests/tests_commands/test_UserCommands.py
@@ -113,12 +113,11 @@ class TestTrackIpAddress:
         _ = UserCommands(use_instrument="test_package")
 
 
+@pytest.mark.usefixtures("no_file_error", "protect_search_path", "protect_config")
 class TestIffyPkgPaths:
-    @pytest.mark.usefixtures("protect_currsys")
     def test_finds_basic_instrument(self):
         UserCommands(use_instrument="basic_instrument")
 
-    @pytest.mark.usefixtures("protect_currsys")
     def test_throws_for_bogus_inst(self):
         with pytest.raises(ValueError):
             UserCommands(use_instrument="bogus_instrument")


### PR DESCRIPTION
There was a weird bug that running the tests would add a "bogus" directory which was then used to install the test_package - yikes.

Also, turns out splitting the fixtures onto functions was redundant, because the fixture is defined as acting on function level anyway...