### PR TITLE
Switch off spammy INFO logs from httpx

### DIFF
--- a/scopesim/logconfig.yaml
+++ b/scopesim/logconfig.yaml
@@ -28,6 +28,8 @@ loggers:
     level: INFO
   astar.scopesim.commands.user_commands:
     level: INFO
+  httpx:  # Switch off INFO calls from httpx, they're spammy.
+    level: WARNING
 
 handlers:
   console:


### PR DESCRIPTION
This was getting annoying while I was working on something else. Also it was sometimes cluttering the notebooks on RTD.

I like how this nicely shows how well our logging configuration is working now. Making this change was as simple as adding the offending logger to the yaml file. This can ofc be done for any others that we might want to modify in the future.

Since this is a bit hard to test, here's a before and after view of one of our functions that used to trigger that.

Before:

![before](https://github.com/user-attachments/assets/ec5ed117-7689-4b39-998b-f8b285fba3c9)

After:

![after](https://github.com/user-attachments/assets/ac35e7eb-2b26-4758-a4b5-b182ed2bc6f8)

These logs really didn't add any meaningful information to the user. They should be debug level in my opinion, but whatever.
