### PR TITLE
Use `.to_value(<unit>)` instead of `.to(<unit>).value`

### DIFF
--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -119,9 +119,9 @@ class ApertureMask(Effect):
         if isinstance(obj, FovVolumeList):
             logger.debug("Executing %s, FoV setup", self.meta['name'])
             x = quantity_from_table("x", self.table,
-                                    u.arcsec).to(u.arcsec).value
+                                    u.arcsec).to_value(u.arcsec)
             y = quantity_from_table("y", self.table,
-                                    u.arcsec).to(u.arcsec).value
+                                    u.arcsec).to_value(u.arcsec)
             obj.shrink(["x", "y"], ([min(x), max(x)], [min(y), max(y)]))
 
             # ..todo: HUGE HACK - Get rid of this!
@@ -156,8 +156,8 @@ class ApertureMask(Effect):
 
     def get_header(self):
         self.meta = from_currsys(self.meta, self.cmds)
-        x = quantity_from_table("x", self.table, u.arcsec).to(u.deg).value
-        y = quantity_from_table("y", self.table, u.arcsec).to(u.deg).value
+        x = quantity_from_table("x", self.table, u.arcsec).to_value(u.deg)
+        y = quantity_from_table("y", self.table, u.arcsec).to_value(u.deg)
         pix_scale_deg = self.meta["pixel_scale"] / 3600.
         header = imp_utils.header_from_list_of_xy(x, y, pix_scale_deg)
         header["APERTURE"] = self.meta["id"]
@@ -180,8 +180,8 @@ class ApertureMask(Effect):
         self.meta = from_currsys(self.meta, self.cmds)
 
         if self.meta["no_mask"] is False:
-            x = quantity_from_table("x", self.table, u.arcsec).to(u.deg).value
-            y = quantity_from_table("y", self.table, u.arcsec).to(u.deg).value
+            x = quantity_from_table("x", self.table, u.arcsec).to_value(u.deg)
+            y = quantity_from_table("y", self.table, u.arcsec).to_value(u.deg)
             pixel_scale_deg = self.meta["pixel_scale"] / 3600.
             mask = mask_from_coords(x, y, pixel_scale_deg)
         else:

--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -222,10 +222,10 @@ class DetectorList(Effect):
         y_det_min = np.min(ycen - dy)
         y_det_max = np.max(ycen + dy)
 
-        x_det = [x_det_min.to(u.mm).value, x_det_max.to(u.mm).value]
-        y_det = [y_det_min.to(u.mm).value, y_det_max.to(u.mm).value]
+        x_det = [x_det_min.to_value(u.mm), x_det_max.to_value(u.mm)]
+        y_det = [y_det_min.to_value(u.mm), y_det_max.to_value(u.mm)]
 
-        pixel_size = pixel_size.to(u.mm).value
+        pixel_size = pixel_size.to_value(u.mm)
         hdr = header_from_list_of_xy(x_det, y_det, pixel_size, "D")
         hdr["IMGPLANE"] = self.image_plane_id
 

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -177,9 +177,9 @@ class SpectralTrace:
 
         # WCSD from the FieldOfView - this is the full detector plane
         pixsize = fov_header["CDELT1D"] * u.Unit(fov_header["CUNIT1D"])
-        pixsize = pixsize.to(u.mm).value
+        pixsize = pixsize.to_value(u.mm)
         pixscale = fov_header["CDELT1"] * u.Unit(fov_header["CUNIT1"])
-        pixscale = pixscale.to(u.arcsec).value
+        pixscale = pixscale.to_value(u.arcsec)
 
         fpa_wcsd = WCS(det_header, key="D")
         naxis1d, naxis2d = det_header["NAXIS1"], det_header["NAXIS2"]

--- a/scopesim/effects/surface_list.py
+++ b/scopesim/effects/surface_list.py
@@ -124,7 +124,7 @@ class SurfaceList(TERCurve):
 
     @property
     def area(self):
-        areas = [0] + [self.surfaces[key].area.to(u.m**2).value
+        areas = [0] + [self.surfaces[key].area.to_value(u.m**2)
                        for key in self.surfaces
                        if self.surfaces[key].area is not None]
         return np.max(areas) * u.m**2

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -143,8 +143,8 @@ class TERCurve(Effect):
             wave_min = wave[max(0, valid_waves[0][0] - 1)]
             wave_max = wave[min(len(wave) - 1, valid_waves[-1][0] + 1)]
 
-            obj.shrink("wave", [wave_min.to(u.um).value,
-                                wave_max.to(u.um).value])
+            obj.shrink("wave", [wave_min.to_value(u.um),
+                                wave_max.to_value(u.um)])
 
         return obj
 

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -95,9 +95,9 @@ def _make_bounding_header_from_headers(*headers, pixel_scale=1*u.arcsec):
 
     if unit.physical_type == "angle":
         unit = "deg"
-        pixel_scale = pixel_scale.to(u.deg).value
+        pixel_scale = pixel_scale.to_value(u.deg)
     else:
-        pixel_scale = pixel_scale.to(unit).value
+        pixel_scale = pixel_scale.to_value(unit)
 
     extents = [calc_footprint(header, wcs_suffix, unit) for header in headers]
     pnts = np.vstack(extents)
@@ -967,7 +967,7 @@ def calc_table_footprint(table: Table, x_name: str, y_name: str,
 
     """
     if padding is not None:
-        padding = padding.to(new_unit).value
+        padding = padding.to_value(new_unit)
     else:
         padding = 0.
 

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -377,7 +377,7 @@ class OpticalTrain:
             new_data = np.zeros((fov_waveset.shape[0], data.shape[1], data.shape[2]),
                                 dtype=np.float32)
             for j in range(data.shape[1]):
-                cube_interp = interp1d(wave.to(u.um).value, data[:, j, :],
+                cube_interp = interp1d(wave.to_value(u.um), data[:, j, :],
                                        axis=0, kind="linear",
                                        bounds_error=False, fill_value=0)
                 new_data[:, j, :] = cube_interp(fov_waveset.value)

--- a/scopesim/tests/tests_optics/test_ImagePlane.py
+++ b/scopesim/tests/tests_optics/test_ImagePlane.py
@@ -824,7 +824,7 @@ class TestMakeImagePlaneHeader:
 #         tbl = Table(names=["x", "y"], data=[x, y])
 #         xsky, ysky = impl_utils.get_corner_sky_coords([tbl, image_hdu_square])
 #
-#         assert np.all((xsky == x.to(u.deg).value))
+#         assert np.all((xsky == x.to_value(u.deg)))
 #
 
 

--- a/scopesim/tests/tests_optics/test_SpectralSurface.py
+++ b/scopesim/tests/tests_optics/test_SpectralSurface.py
@@ -263,7 +263,7 @@ class TestMakeEmissionFromEmissivity:
         wave = np.arange(3, 20, dlam) * u.um
         wavemax = wave[np.argmax(flux(wave))]
         if isinstance(temp, u.Quantity):
-            temp = temp.to(u.Kelvin, equivalencies=u.temperature()).value
+            temp = temp.to_value(u.Kelvin, equivalencies=u.temperature())
         wienmax = 3669.7 * u.um / temp
         assert np.abs(wavemax - wienmax.to(u.um)) < dlam * u.um
 


### PR DESCRIPTION
Just a plain simple refactoring. Avoids creating a temporary instance of `Quantity` just to destroy it immediately. Also theoretically marginally faster for arrays, but that's most likely irrelevant.

Omitted some cases in fov and fovutls on purpose to avoid conflicts.