### PR TITLE
Remove obsolete `FovVolumeList.detector_limits`

### DIFF
--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -164,10 +164,6 @@ class DetectorList(Effect):
                    values=(tuple(zip(xy_sky.min(axis=0),
                                      xy_sky.max(axis=0)))))
 
-        lims = array_minmax(xy_mm)
-        keys = ["xd_min", "xd_max", "yd_min", "yd_max"]
-        obj.detector_limits = dict(zip(keys, lims.T.flatten()))
-
         return obj
 
     def fov_grid(self, which="edges", **kwargs):

--- a/scopesim/optics/fov_volume_list.py
+++ b/scopesim/optics/fov_volume_list.py
@@ -54,12 +54,6 @@ class FovVolumeList(MutableSequence):
             },
         }]
         self.volumes[0].update(initial_volume)  # .. TODO: Careful! This overwrites meta
-        self.detector_limits = {
-            "xd_min": 0,
-            "xd_max": 0,
-            "yd_min": 0,
-            "yd_max": 0,
-        }
 
     def split(self, axis, value, aperture_id=None) -> None:
         """

--- a/scopesim/tests/tests_optics/test_FOVManager.py
+++ b/scopesim/tests/tests_optics/test_FOVManager.py
@@ -56,12 +56,3 @@ class TestGenerateFovList:
         assert len(fovs) == 4
         assert fov_skycorners.min(axis=0)[0] == approx(-1024 / 3600)  # [deg] 2k detector / pixel_scale
         assert fovs[0].waverange[0] == 0.6 * u.um  # filter blue edge
-
-    def test_fov_volumes_have_detector_dimensions_from_detector_list(self):
-        effects = eo._mvs_effects_list()
-        fov_man = FOVManager(effects=effects, pixel_scale=1, plate_scale=1)
-        _ = list(fov_man.generate_fovs_list())
-        detector_limits = fov_man.volumes_list.detector_limits
-
-        assert detector_limits["xd_min"] != 0.0
-        assert detector_limits["yd_max"] != 0.0


### PR DESCRIPTION
This was never used anywhere except in testing and is likely a leftover from pre-ScopeSim days.

Came up during #654, but can be treated separately.