### PR TITLE
Add version requirement support for IRDB packages

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4213,4 +4213,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.13"
-content-hash = "ceb7c99a4ea01de3393c27bfaf793ff166712fe44e0bec4e3e44310eaf3701ea"
+content-hash = "6852391a50c47bfdf02e6356bd69a8b6b1ec70d98c311cff3f3da670599c8037"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ lxml = "^5.2.2"
 pyyaml = "^6.0.1"
 more-itertools = "^10.2.0"
 tqdm = "^4.66.5"
+packaging = ">=23.2"
 
 synphot = "^1.5.0"
 skycalc-ipy = ">=0.5.1"

--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -1,13 +1,14 @@
 """Generalised telescope observation simulator."""
 
 from importlib import metadata
+from packaging.version import parse
 
 ###############################################################################
 #                          VERSION INFORMATION                                #
 ###############################################################################
 
 try:
-    __version__ = metadata.version(__package__)
+    __version__ = parse(metadata.version(__package__))
 except metadata.PackageNotFoundError:
     __version__ = "undetermined"
 

--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -609,7 +609,48 @@ def list_local_packages(action="display"):
         return main_pkgs, ext_pkgs
 
 
-def check_version(yaml_dict, mode=None):
+def check_version(yaml_dict: Mapping, mode: str | None = None) -> None:
+    """
+    Check if ScopeSim version required by instrument package or mode is met.
+
+    Check the `yaml_dict` for a key named "needs_scopesim". If found, try to
+    pare it into a version number and compare that to the currently installed
+    ScopeSim version. If a higher version is required for the selected
+    instrument package or mode, raise an exception. If the key is not found in
+    the yaml, silently proceed for backwards compatibility.
+
+    This can be called from either the top level of an instrument package's
+    default.yaml, in which case the version requirement is interpreted to apply
+    to the entire package as a minimum. If called from a "mode_yamls" section,
+    the requirement is interpreted to apply only to that mode. Different modes
+    in the same package may have different requirements, e.g. if one mode needs
+    an effect that was only added in a recent ScopeSim version, but the other
+    modes work without it. Note that a version requirement in the package level
+    (if any) serves as a minimum, meaning any mode can only have a stricter
+    requirement (or none, in which case the package level is used).
+
+    .. versionadded:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+    Parameters
+    ----------
+    yaml_dict : Mapping
+        Top-level or mode-level dict from the package's default.yaml.
+    mode : str | None, optional
+        Name of the mode if called from a mode section. If None (the default),
+        assumes called from the package top level. Only used for more
+        meaningful error message.
+
+    Raises
+    ------
+    NotImplementedError
+        Raised if the currently installed ScopeSim version is less than the
+        version required by the loaded instrument package or mode.
+
+    Returns
+    -------
+    None.
+
+    """
     try:
         needs_scopesim = parse(yaml_dict.get("needs_scopesim"))
         if __version__ < needs_scopesim:


### PR DESCRIPTION
Something I've been wanting to add for a while now: This allows to put a `needs_scopesim` key in either the package or mode level section of a package's `default.yaml` file, very similar in concept to the `status` key added not too long ago. Should be compatible in both direction, i.e. nothing fails when the key isn't present and using an IRDB package version _with_ that key on an older ScopeSim version will also just do nothing. Note that the value must be a `str`, not because something like `0.10` wouldn't work, but because it would be parsed as a `float` first by yaml and thus stripped of any trailing zeros, so:
`0.10 -> 0.1 -> Version('0.1')`, but `"0.10" -> "0.10" -> Version('0.10')`.

I couldn't think of an easy way to add a test for this, because the ScopeSim version will naturally change. But I did test all combinations I could think of and it seems to work.

This nominally adds `packaging` as a dependency, but this doesn't actually change anything, because this is already required by 12 (!) of our other dependencies...

"But...", I hear you cry, "We could make the IRDB into pip packages, that would solve this!!" - Yes, yes it would. It would also be too much work for now to do it properly (which we'd have to). This took less than an hour. It's fine for now.