### PR TITLE
Allow PSF interpolation to be switched off

### DIFF
--- a/scopesim/effects/psfs/discrete.py
+++ b/scopesim/effects/psfs/discrete.py
@@ -141,6 +141,9 @@ class FieldConstantPSF(DiscretePSF):
             + fov.hdu.header["CRVAL3"]
         )
 
+        if not self.cmds.get("!OBS.interp_psf", True):
+            lam = lam[len(lam)//2]
+
         # adapt the size of the output cube to the FOV's spatial shape
         nxpsf = min(512, 2 * nxfov + 1)
         nypsf = min(512, 2 * nyfov + 1)
@@ -149,9 +152,6 @@ class FieldConstantPSF(DiscretePSF):
         ext = self.current_layer_id
         hdr = self._file[ext].header
         refwave = hdr[self.meta["wave_key"]]
-
-        if not self.cmds.get("!OBS.interp_psf", True):
-            lam = np.array([refwave])
 
         if "CUNIT1" in hdr:
             unit_factor = u.Unit(hdr["CUNIT1"].lower()).to(

--- a/scopesim/effects/psfs/discrete.py
+++ b/scopesim/effects/psfs/discrete.py
@@ -142,7 +142,7 @@ class FieldConstantPSF(DiscretePSF):
         )
 
         if not self.cmds.get("!OBS.interp_psf", True):
-            lam = lam[len(lam)//2]
+            lam = np.array([lam[len(lam)//2]])
 
         # adapt the size of the output cube to the FOV's spatial shape
         nxpsf = min(512, 2 * nxfov + 1)

--- a/scopesim/effects/psfs/discrete.py
+++ b/scopesim/effects/psfs/discrete.py
@@ -150,6 +150,9 @@ class FieldConstantPSF(DiscretePSF):
         hdr = self._file[ext].header
         refwave = hdr[self.meta["wave_key"]]
 
+        if not self.cmds.get("!OBS.interp_psf", True):
+            lam = np.array([refwave])
+
         if "CUNIT1" in hdr:
             unit_factor = u.Unit(hdr["CUNIT1"].lower()).to(
                 u.Unit(fov_pixel_unit))
@@ -189,7 +192,8 @@ class FieldConstantPSF(DiscretePSF):
             outcube[i,] = (ipsf(ypsf, xpsf, grid=False)
                            * fov_pixel_scale**2 / psf_wave_pixscale**2)
 
-        self.kernel = outcube.reshape((lam.shape[0], nypsf, nxpsf))
+        # .squeeze() gets rid of any axes with length one
+        self.kernel = outcube.reshape((lam.shape[0], nypsf, nxpsf)).squeeze()
         # fits.writeto("test_psfcube.fits", data=self.kernel, overwrite=True)
 
     def plot(self):


### PR DESCRIPTION
Solves some performance issues encountered in the simple IFU mode. Defaults to original behavior in absence of the `"!OBS.interp_psf"` key, so shouldn't break anything.