### PR TITLE
Use progress bar for spectral traces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ScopeSim"
-version = "0.10.0b1"
+version = "0.10.0b2"
 description = "Generalised telescope observation simulator"
 license = "GPL-3.0-or-later"
 authors = ["Kieran Leschinski <kieran.leschinski@unive.ac.at>"]

--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -4,6 +4,7 @@
 import copy
 import warnings
 
+from tqdm.auto import tqdm
 import numpy as np
 from scipy.interpolate import RectBivariateSpline
 
@@ -104,7 +105,8 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
                                  obj.detector_header["NAXIS1"]),
                                 dtype=np.float32)
 
-            for sptid, spt in self.spectral_traces.items():
+            for sptid, spt in tqdm(self.spectral_traces.items(),
+                                   desc="  Spectral Traces", position=2):
                 ymin = spt.meta["fov"]["y_min"]
                 ymax = spt.meta["fov"]["y_max"]
 

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -158,7 +158,7 @@ class SpectralTrace:
         The method returns a section of the fov image along with info on
         where this image lies in the focal plane.
         """
-        logger.info("Mapping %s", fov.trace_id)
+        logger.debug("Mapping %s", fov.trace_id)
         # Initialise the image based on the footprint of the spectral
         # trace and the focal plane WCS
         wave_min = fov.meta["wave_min"].value       # [um]


### PR DESCRIPTION
This used to be done via individual info logs, which I decreased to debug.

As presented in today's Science Team Meeting.