### PR TITLE
Bring dependency versions back in sync with lock file

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4214,4 +4214,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.13"
-content-hash = "c22c0b2749ac4121e49e14da3283090f35292a994764b3654b22f022f8bf43da"
+content-hash = "f4a999e7ca0126d27cf8c02692a3a3be5e6ab420668c8289d5fbae093d58a394"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ python = ">=3.10, <3.13"
 numpy = "^1.26.4"
 scipy = "^1.14.1"
 astropy = "^6.1.5"
-matplotlib = "^3.8.2"
+matplotlib = "^3.10.1"
 pooch = "^1.8.2"
 
 docutils = "^0.19"
@@ -44,10 +44,10 @@ astar-utils = ">=0.3.2"
 optional = true
 
 [tool.poetry.group.dev.dependencies]
-jupyter = "^1.0"
-jupytext = "^1.10.0"
+jupyter = "^1.1.1"
+jupytext = "^1.16.6"
 ipykernel = "^6.24.0"
-ipympl = "^0.9.4"
+ipympl = "^0.9.6"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3.5"
@@ -59,13 +59,13 @@ ipykernel = "^6.24.0"
 optional = true
 
 [tool.poetry.group.docs.dependencies]
-sphinx = ">=5.3,<8.0"
-sphinx-book-theme = "^1.1.0"
-jupyter-sphinx = ">=0.2.3,<0.6.0"
+sphinx = "^7.3.7"
+sphinx-book-theme = "^1.1.3"
+jupyter-sphinx = ">=0.5.3"
 sphinx-copybutton = "^0.5.2"
-myst-nb = "^1.0.0"
-sphinxcontrib-apidoc = ">=0.4,<0.6"
-nbsphinx = "^0.9.3"
+myst-nb = "^1.2.0"
+sphinxcontrib-apidoc = ">=0.5.0"
+nbsphinx = "^0.9.6"
 numpydoc = "^1.6.0"
 scopesim_templates = ">=0.6.0"
 ipykernel = "^6.24.0"


### PR DESCRIPTION
These got out of sync because of dependabot. It's not critical, but our minimumdependency approach mandates that the versions in the lock file should be equal to the minimum specified version in the toml file.

Fortunatly, this now doesn't include any of our "important" dependencies, so I don't expect any major surprises here (famous last words).