### PR TITLE
Add proper error message for removed `Quantization` effect

### DIFF
--- a/scopesim/effects/electronic/__init__.py
+++ b/scopesim/effects/electronic/__init__.py
@@ -26,3 +26,11 @@ from .noise import (Bias, PoorMansHxRGReadoutNoise, BasicReadoutNoise,
 from .exposure import AutoExposure, SummedExposure, ExposureOutput
 from .pixels import ReferencePixelBorder, BinnedImage, UnequalBinnedImage
 from .dmps import DetectorModePropertiesSetter
+
+
+# TODO: rm this in v1.0
+def Quantization(*args, **kwargs):
+    raise AttributeError(
+        "The `Quantization` effect was removed in vPLACEHOLDER_NEXT_RELEASE_VERSION. Please update the "
+        "requested IRDB package by running `download_packages(<package_name>)`"
+        "or by updating your local IRDB clone.")


### PR DESCRIPTION
When running ScopeSim v>=0.10.0 with an old METIS version, the error was just `AttributeError: module 'scopesim.effects' has no attribute 'Quantization'`, rather unhelpful to the end user. Now it shows what the actual "problem" is.

Given that ScopeSim and the IRDB packages are released separately, it could be argued that the `Quantization` effect should have been deprecated more carefully. But then again, it could also be argued that it shouldn't have existed in the first place. And we're still in a 0.x version after all, so whatever. This is better then nothing.

I've listed this under `documentation`, since it kind of serves as a piece of documentation in telling the user why their METIS simulations are now broken 😛 