### PR TITLE
Convert to signed float before chopnodcombine

### DIFF
--- a/scopesim/effects/obs_strategies.py
+++ b/scopesim/effects/obs_strategies.py
@@ -95,7 +95,7 @@ def chop_nod_image(img, chop_offsets, nod_offsets=None):
     if nod_offsets is None:
         nod_offsets = tuple(-np.array(chop_offsets))
 
-    im_aa = np.copy(img)
+    im_aa = img.copy().astype(np.float32)    # in case img is uint
     im_ab = np.roll(im_aa, chop_offsets, (1, 0))
     im_ba = np.roll(im_aa, nod_offsets, (1, 0))
     im_bb = np.roll(im_ba, chop_offsets, (1, 0))

--- a/scopesim/tests/tests_effects/test_obs_strategies.py
+++ b/scopesim/tests/tests_effects/test_obs_strategies.py
@@ -43,6 +43,7 @@ class TestChopNodCombinerApplyTo:
             plt.show()
 
         outimg = basic_detector.hdu.data
+        assert outimg.dtype == np.float32
         assert outimg.sum() == 0
         assert ((outimg == 0.).sum() / outimg.size) > .8  # most elements zero
 
@@ -56,5 +57,6 @@ class TestChopNodCombinerApplyTo:
             plt.show()
 
         outimg = basic_detector.hdu.data
+        assert outimg.dtype == np.float32
         assert outimg.sum() == 0
         assert ((outimg == 0.).sum() / outimg.size) > .8  # most elements zero


### PR DESCRIPTION
`ChopNodCombiner` is a convenience effect that mimics a pipeline recipe rather than an instrument feature. It therefore comes after `ADConversion`. Since the combiner produces negative pixel values an input image with unsigned int data (as produced by `ADConversion`) needs to be converted to a signed data type. As expected for the pipeline recipe, we choose `np.float32`.   