### PR TITLE
More logging and another progress bar

### DIFF
--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -106,7 +106,7 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
                                 dtype=np.float32)
 
             for sptid, spt in tqdm(self.spectral_traces.items(),
-                                   desc="  Spectral Traces", position=2):
+                                   desc=" Spectral Traces", position=2):
                 ymin = spt.meta["fov"]["y_min"]
                 ymax = spt.meta["fov"]["y_max"]
 

--- a/scopesim/effects/psfs/discrete.py
+++ b/scopesim/effects/psfs/discrete.py
@@ -4,6 +4,7 @@
 from typing import ClassVar
 
 import numpy as np
+from tqdm.auto import tqdm
 from scipy.signal import convolve
 from scipy.ndimage import zoom
 from scipy.interpolate import RectBivariateSpline, griddata
@@ -189,7 +190,9 @@ class FieldConstantPSF(DiscretePSF):
         outcube = np.zeros((lam.shape[0], nypsf, nxpsf), dtype=np.float32)
         logger.info("Interpolating PSF onto %s cube", outcube.shape)
 
-        for i, wave in enumerate(lam):
+        nlam = len(lam)
+        for i, wave in tqdm(enumerate(lam), desc=" PSF slices", position=2,
+                            total=nlam, disable=(nlam <= 1)):
             psf_wave_pixscale = ref_pixel_scale * wave / refwave
             psfwcs.wcs.cdelt = [psf_wave_pixscale,
                                 psf_wave_pixscale]

--- a/scopesim/effects/psfs/psf_base.py
+++ b/scopesim/effects/psfs/psf_base.py
@@ -97,6 +97,7 @@ class PSF(Effect):
                 # do the convolution
                 mode = from_currsys(self.meta["convolve_mode"], self.cmds)
 
+                logger.debug("PSF convolution start")
                 if image.ndim == 2 and kernel.ndim == 2:
                     new_image = convolve(image - bkg_level, kernel, mode=mode)
                 elif image.ndim == 3 and kernel.ndim == 2:
@@ -112,6 +113,7 @@ class PSF(Effect):
                             kernel[iplane,], mode=mode)
 
                 obj.hdu.data = new_image + bkg_level
+                logger.debug("PSF convolution done")
 
                 # TODO: careful with which dimensions mean what
                 d_x = new_image.shape[-1] - image.shape[-1]

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -192,6 +192,8 @@ class SpectralTraceList(Effect):
         list, identified by meta["trace_id"].
         """
         if isinstance(obj, FovVolumeList):
+            logger.debug("%s applied to %s", self.display_name,
+                         obj.__class__.__name__)
             # Setup of FieldOfView object
             # volumes = [spectral_trace.fov_grid()
             #            for spectral_trace in self.spectral_traces.values()]
@@ -224,6 +226,8 @@ class SpectralTraceList(Effect):
             obj.volumes = new_vols_list
 
         if isinstance(obj, FieldOfView):
+            logger.debug("%s applied to %s", self.display_name,
+                         obj.__class__.__name__)
             # Application to field of view
             if obj.hdu is not None and obj.hdu.header["NAXIS"] == 3:
                 obj.cube = obj.hdu
@@ -238,6 +242,7 @@ class SpectralTraceList(Effect):
             spt = self.spectral_traces[obj.trace_id]
             obj.hdu = spt.map_spectra_to_focal_plane(obj)
 
+        logger.debug("%s done", self.display_name)
         return obj
 
     @property

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -338,7 +338,7 @@ class SpectralTraceList(Effect):
         outhdul = fits.HDUList([pdu])
 
         for i, trace_id in tqdm(enumerate(self.spectral_traces, start=1),
-                                desc=" Traces"):
+                                desc=" Traces", total=len(self.spectral_traces)):
             hdu = self[trace_id].rectify(hdulist,
                                          interps=interps,
                                          bin_width=bin_width,


### PR DESCRIPTION
The progress bar around the PSF interpolation looks quite nice in practice in a notebook, the individual iterations take well under a second, but there're a lot of them, so you get a nice "actually moving" progress bar. And it's nice to see that there's something happening in the background...

The "x applied to y" debug log I'd actually like to add somehow to the `Effect` base class so we always get a (debug) log to see which effect is applied where. So I tried it here and might move it higher up eventually.