### PR TITLE
Ignore a random DeprecationWarning from Pillow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,8 @@ filterwarnings = [
     "ignore:Proactor*:RuntimeWarning",
     # lxml warning introduced by beautifulsoup
     "ignore:The 'strip_cdata' option of HTMLParser*:DeprecationWarning",
+    # Suddenly appears from Pillow in a few tests
+    "ignore:'mode' parameter is deprecated and will be removed*:DeprecationWarning"
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
This suddenly occurs in a few tests when running with updated dependencies. Should probably properly fix this, but I don't have time now.