### PR TITLE
Deprecate downloading IRDB packages directly from GitHub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ScopeSim"
-version = "0.10.1a1"
+version = "0.10.1a2"
 description = "Generalised telescope observation simulator"
 license = "GPL-3.0-or-later"
 authors = ["Kieran Leschinski <kieran.leschinski@unive.ac.at>"]

--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -68,7 +68,12 @@ from .commands.user_commands import UserCommands
 from .commands.scopesimple import Simulation
 from .source.source import Source
 
-from .server.database import (list_packages, download_packages, download_package,
-                              list_example_data, download_example_data)
+from .server import (
+    list_packages,
+    download_packages,
+    list_example_data,
+    download_example_data,
+)
+from .server.database import download_package  # remove in v0.12
 
 from .tests.mocks.load_basic_instrument import load_example_optical_train, example_simulation

--- a/scopesim/server/__init__.py
+++ b/scopesim/server/__init__.py
@@ -1,5 +1,11 @@
-from .database import (download_packages,
-                       list_packages,
-                       get_all_packages_on_server,
-                       check_packages)
+# -*- coding: utf-8 -*-
+"""Utilities for remotely stores data."""
+
+from .download_utils import ServerError
+from .database import (
+    download_packages,
+    list_packages,
+    get_all_packages_on_server,
+    check_packages,
+)
 from .example_data_utils import download_example_data, list_example_data

--- a/scopesim/server/example_data_utils.py
+++ b/scopesim/server/example_data_utils.py
@@ -93,13 +93,26 @@ def download_example_data(*files: str,
     -------
     save_path : list of Paths
         The absolute path(s) to the saved files
+
+    .. versionchanged:: 0.8.4
+
+       Passing a list to ``download_example_data`` is deprecated since version
+       0.8.4, this function now accepts multiple file names in *args-style.
+
+    .. versionchanged:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+       Passing a list to ``download_example_data`` as the first argument will
+       now throw a TypeError. This is to catch any remaining uses of the old
+       call signature of this function. From version 0.12 onwards, agruments
+       will be silently passed to the `retriever`.
+
     """
-    if isinstance(files[0], list):  # to preserve combatibility with notebooks
-        warn("Passing a list to download_example_data is deprecated. "
-             "Simply pass filenames as *args, i.e. "
-             "download_example_data(\"foo.fits\", \"bar.fits\").",
-             DeprecationWarning, stacklevel=2)
-        files = files[0]
+    if isinstance(files[0], list):
+        raise TypeError(
+            "Passing a list to download_example_data is deprecated. "
+            "Simply pass filenames as *args, i.e. "
+            "download_example_data(\"foo.fits\", \"bar.fits\")."
+        )
 
     retriever = _create_retriever(save_dir, url)
 

--- a/scopesim/server/github_utils.py
+++ b/scopesim/server/github_utils.py
@@ -11,8 +11,8 @@ Original comment for these functions:
 """
 
 import re
+from warnings import warn
 from pathlib import Path
-from typing import Union
 
 from .download_utils import handle_download, send_get, create_client
 from ..utils import get_logger
@@ -26,7 +26,14 @@ def create_github_url(url: str) -> None:
     From the given url, produce a URL compatible with Github's REST API.
 
     Can handle blob or tree paths.
+
+    .. deprecated:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+       This function is deprecated and will be removed in version 0.12.
     """
+    warn("The function ``create_github_url`` is deprecated and will be "
+         "removed in version 0.12.", DeprecationWarning, stacklevel=2)
+
     repo_only_url = re.compile(r"https:\/\/github\.com\/[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}\/[a-zA-Z0-9]+$")
     re_branch = re.compile("/(tree|blob)/(.+?)/")
 
@@ -47,13 +54,20 @@ def create_github_url(url: str) -> None:
 
 
 def download_github_folder(repo_url: str,
-                           output_dir: Union[Path, str] = "./") -> None:
+                           output_dir: Path | str = "./") -> None:
     """
     Download the files and directories in repo_url.
 
     Re-written based on the on the download function
     `here <https://github.com/sdushantha/gitdir/blob/f47ce9d85ee29f8612ce5ae804560a12b803ddf3/gitdir/gitdir.py#L55>`_
+
+    .. deprecated:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+       This function is deprecated and will be removed in version 0.12.
     """
+    warn("The function ``download_github_folder`` is deprecated and will be "
+         "removed in version 0.12.", DeprecationWarning, stacklevel=2)
+
     output_dir = Path(output_dir)
 
     # convert repo_url into an api_url


### PR DESCRIPTION
Closes #726, see discussion there for details.

Also replace some long-standing deprecation warnings here with actual errors, to be completely removed later.