### PR TITLE
Improve handling of DeprecationWarnings

### DIFF
--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -14,7 +14,7 @@ except metadata.PackageNotFoundError:
 
 
 ###############################################################################
-#                            TURN OFF WARNINGS                                #
+#                         TURN OFF SOME WARNINGS                              #
 ###############################################################################
 
 import warnings
@@ -22,9 +22,16 @@ import yaml
 from astropy.utils.exceptions import AstropyWarning
 
 warnings.simplefilter('ignore', UserWarning)
-warnings.simplefilter('ignore', FutureWarning)
 warnings.simplefilter('ignore', RuntimeWarning)  # warnings for the developer
-warnings.simplefilter('default', DeprecationWarning)  # allow in general
+
+try:
+    if __version__.is_prerelease or __version__.is_devrelease:
+        # Those are usually ignored, but in development we should see them.
+        warnings.simplefilter("default", DeprecationWarning)
+        warnings.simplefilter("default", PendingDeprecationWarning)
+except AttributeError:  # catch __version__ = "undetermined"
+    pass
+
 warnings.simplefilter('ignore', category=AstropyWarning)
 yaml.warnings({'YAMLLoadWarning': False})
 

--- a/scopesim/effects/data_container.py
+++ b/scopesim/effects/data_container.py
@@ -85,7 +85,7 @@ class DataContainer:
 
         if filename is None and "file_name" in kwargs:
             warn("The 'file_name' kwarg is deprecated and will raise an error "
-                 "in the future, please use 'filename' instead!",
+                 "from version 0.12 onwards, please use 'filename' instead!",
                  DeprecationWarning, stacklevel=2)
             filename = kwargs["file_name"]
 

--- a/scopesim/effects/psfs/semianalytical.py
+++ b/scopesim/effects/psfs/semianalytical.py
@@ -141,7 +141,7 @@ class AnisocadoConstPSF(SemiAnalyticalPSF):
              "will be removed in a future release. If you are using this "
              "method, pleas let us know by creating an issue at: "
              "https://github.com/AstarVienna/ScopeSim/issues",
-             DeprecationWarning, stacklevel=2)
+             FutureWarning, stacklevel=2)
         self._kernel = None
         return self.get_kernel(x)
 

--- a/scopesim/optics/image_plane.py
+++ b/scopesim/optics/image_plane.py
@@ -134,9 +134,9 @@ class ImagePlane:
         else:
             if isinstance(hdus_or_tables, Table):
                 warn("Adding a table directly to the ImagePlane is deprecated "
-                     "since v0.10.0. Passing a table "
-                     "to ImagePlane.add() will raise an error in the future. "
-                     "Use FOV to add tables and image HDUs together before.",
+                     "since v0.10.0. Passing a table to ImagePlane.add() will "
+                     "raise an error from version 0.12 onwards. Use FOV to "
+                     "add tables and image HDUs together before.",
                      DeprecationWarning, stacklevel=2)
                 self.hdu = add_table_to_imagehdu(hdus_or_tables, self.hdu,
                                                  sub_pixel, wcs_suffix)


### PR DESCRIPTION
Quoting myself from #726

> Also FWIW, after reading through [the docs](https://docs.python.org/3/library/warnings.html#warning-categories) (again), this should probably emit a [FutureWarning](https://docs.python.org/3/library/exceptions.html#FutureWarning) instead of a [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning) I guess, because it concerns user-facing code. It seems DeprecationWarning is more meant for other developers that use your library, whereas FutureWarning should be used for applications (such as ScopeSim sort of is) when "talking to the user". Although of course that line can be very blurry and I remember seeing much more DeprecationWarnings "in the wild" than FutureWarnings...

This also applies to some other warnings in ScopeSim, so I decided to remove the "ignore" on FutureWarnings (we really shouldn't ignore those anyway) and make the behavior of DeprecationWarning and PendingDeprecationWarning dependent on whether the version number is stable or not. That way, if we run (some part of) ScopeSim during development (i.e. installed from source), we will see them, but for end users, their behavior is the one specified in the Python docs.

In fact I think it's overall a rather smelly idea to temper with the warnings in the top-level `__init__.py` file. We can certainly ignore some things after careful evaluation in specific locations, but then that ignoring should happen locally. The way it is now, just importing ScopeSim has the side effect of disabling all UserWarnings and RuntimeWarnings, which is somewhat questionable.

Also, I decided to make v0.12 a rather large breaking update, so I replaced some of the "in the future" messages in various deprecation warnings with that specific version number. The reason for v0.12 is that it's still _two_ versions away, so in theory gives users enough time to read the new messages (same with the deprecations in #727, where I also specified v0.12).