### PR TITLE
Deprecate direct attribute access in `SourceField`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ScopeSim"
-version = "0.10.1a2"
+version = "0.10.1a3"
 description = "Generalised telescope observation simulator"
 license = "GPL-3.0-or-later"
 authors = ["Kieran Leschinski <kieran.leschinski@unive.ac.at>"]

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -500,8 +500,8 @@ class FieldOfView:
         * yield each spectrum * sum of weights to be added to canvas flux
         """
         for field in self._get_table_fields():
-            refs = np.array(field["ref"])
-            weights = np.array(field["weight"])
+            refs = np.array(field.field["ref"])
+            weights = np.array(field.field["weight"])
             # TODO: could do grouping of table with both columns??
             for ref in set(refs):
                 weight = np.sum(weights, where=refs == ref)
@@ -590,8 +590,8 @@ class FieldOfView:
         for field in self._get_table_fields():
             # x, y are ALWAYS in arcsec - crval is in deg
             xpix, ypix = imp_utils.val2pix(self.header,
-                                           field["x"] / 3600,
-                                           field["y"] / 3600)
+                                           field.field["x"] / 3600,
+                                           field.field["y"] / 3600)
 
             fluxes = {
                 ref: spec(fov_waveset).value.sum() if use_photlam
@@ -601,7 +601,7 @@ class FieldOfView:
             }
 
             if self.sub_pixel:
-                for idx, row in enumerate(field):
+                for idx, row in enumerate(field.field):
                     xs, ys, fracs = imp_utils.sub_pixel_fractions(xpix[idx],
                                                                   ypix[idx])
                     for x, y, frac in zip(xs, ys, fracs):
@@ -611,8 +611,8 @@ class FieldOfView:
                 # TODO: could these be something more numpythonic grid-ish?
                 x = np.array(xpix).astype(int)
                 y = np.array(ypix).astype(int)     # quickest way to round
-                flux = np.array([fluxes[int(ref)] for ref in field["ref"]])
-                yield flux, np.array(field["weight"]), x, y
+                flux = np.array([fluxes[int(ref)] for ref in field.field["ref"]])
+                yield flux, np.array(field.field["weight"]), x, y
 
     def _make_image_backfields(self, fov_waveset, bin_widths, use_photlam):
         for field in self._get_background_fields():
@@ -773,7 +773,7 @@ class FieldOfView:
             # Cube should be in PHOTLAM arcsec-2 for SpectralTrace mapping
             # Point sources are in PHOTLAM per pixel
             # Point sources need to be scaled up by inverse pixel_area
-            for row in field:
+            for row in field.field:
                 xsky, ysky = row["x"] / 3600, row["y"] / 3600
                 # x, y are ALWAYS in arcsec - crval is in deg
                 # TODO: Change this to some proper WCS function!

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -109,9 +109,9 @@ class SourceField:
         # For backwards-combatibility to allow direct access of
         # Source.fields[x][y] if possible. Maybe in the long run get rid of
         # this and force the use of .field...
-        # warn("Direct item assignment for source fields may become deprecated "
-        #      "in the future. Use the .field attribute instead.",
-        #      PendingDeprecationWarning, stacklevel=2)
+        warn("Direct item assignment for source fields may become deprecated "
+             "in the future. Use the .field attribute instead.",
+             PendingDeprecationWarning, stacklevel=2)
         self.field.__setitem__(key, value)
 
     @property

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -100,9 +100,9 @@ class SourceField:
         # For backwards-combatibility to allow direct access of
         # Source.fields[x][y] if possible. Maybe in the long run get rid of
         # this and force the use of .field...
-        # warn("Direct item access for source fields may become deprecated "
-        #      "in the future. Use the .field attribute instead.",
-        #      PendingDeprecationWarning, stacklevel=2)
+        warn("Direct item access for source fields may become deprecated "
+             "in the future. Use the .field attribute instead.",
+             PendingDeprecationWarning, stacklevel=2)
         return self.field.__getitem__(key)
 
     def __setitem__(self, key, value):

--- a/scopesim/tests/mocks/py_objects/source_objects.py
+++ b/scopesim/tests/mocks/py_objects/source_objects.py
@@ -184,14 +184,14 @@ def _combined_source(im_angle=0, dx=(0, 0, 0), dy=(0, 0, 0), weight=(1, 1, 1)):
     tblsrc1 = _table_source()
 
     tblsrc2 = _table_source()
-    tblsrc2.fields[0]["x"] += dx[0]
-    tblsrc2.fields[0]["y"] += dy[0]
-    tblsrc2.fields[0]["weight"] *= weight[0]
+    tblsrc2.fields[0].field["x"] += dx[0]
+    tblsrc2.fields[0].field["y"] += dy[0]
+    tblsrc2.fields[0].field["weight"] *= weight[0]
 
     tblsrc3 = _table_source()
-    tblsrc3.fields[0]["x"] += dx[1]
-    tblsrc3.fields[0]["y"] += dy[1]
-    tblsrc3.fields[0]["weight"] *= weight[1]
+    tblsrc3.fields[0].field["x"] += dx[1]
+    tblsrc3.fields[0].field["y"] += dy[1]
+    tblsrc3.fields[0].field["weight"] *= weight[1]
 
     imsrc = _image_source(dx[2], dy[2], im_angle, weight[2])
 

--- a/scopesim/tests/tests_optics/test_FieldOfView.py
+++ b/scopesim/tests/tests_optics/test_FieldOfView.py
@@ -306,7 +306,7 @@ class TestMakeImage:
 
         in_sum = 0
         waveset = fov.fields[0].spectra[0].waveset
-        for x, y, ref, weight in src_table.fields[0]:
+        for x, y, ref, weight in src_table.fields[0].field:
             flux = src_table.spectra[ref](waveset).to(u.ph/u.s/u.m**2/u.um)
             flux *= 1 * u.m**2 * 0.02 * u.um * 0.9      # 0.9 is to catch the half bins at either end
             in_sum += np.sum(flux).value * weight
@@ -329,7 +329,7 @@ class TestMakeImage:
 
         in_sum = 0
         waveset = fov.fields[0].spectra[0].waveset
-        for x, y, ref, weight in src_table.fields[0]:
+        for x, y, ref, weight in src_table.fields[0].field:
             flux = src_table.spectra[ref](waveset).to(u.ph/u.s/u.m**2/u.um)
             flux *= 1 * u.m**2 * 0.02 * u.um * 0.9      # 0.9 is to catch the half bins at either end
             if y >= 9.9:  # edge source ends up with half the flux

--- a/scopesim/tests/tests_optics/test_FieldOfView.py
+++ b/scopesim/tests/tests_optics/test_FieldOfView.py
@@ -59,8 +59,8 @@ class TestExtractFrom:
     #                            "is extracted..."))
     def test_extract_point_sources_from_table(self):
         src = so._table_source()
-        src.fields[0]["x"] = [-15, -5, 0, 0] * u.arcsec
-        src.fields[0]["y"] = [0, 0, 5, 15] * u.arcsec
+        src.fields[0].field["x"] = [-15, -5, 0, 0] * u.arcsec
+        src.fields[0].field["y"] = [0, 0, 5, 15] * u.arcsec
         fov = _fov_190_210_um()
         fov.extract_from(src)
 
@@ -99,8 +99,8 @@ class TestExtractFrom:
     #                            "is extracted..."))
     def test_extract_one_of_each_type_from_source_object(self):
         src_table = so._table_source()              # 4 sources, put two outside of FOV
-        src_table.fields[0]["x"] = [-15, -5, 0, 0] * u.arcsec
-        src_table.fields[0]["y"] = [0, 0, 5, 15] * u.arcsec
+        src_table.fields[0].field["x"] = [-15, -5, 0, 0] * u.arcsec
+        src_table.fields[0].field["y"] = [0, 0, 5, 15] * u.arcsec
         src_image = so._image_source(dx=10)         # 10x10" @ 0.2"/pix
         src_cube = so._cube_source()                # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
         src = src_cube + src_image + src_table
@@ -123,7 +123,7 @@ class TestExtractFrom:
 
     def test_ignores_fields_outside_fov_boundary(self):
         src = so._combined_source(dx=[200, 200, 200])
-        src.fields[0]["x"] += 200
+        src.fields[0].field["x"] += 200
 
         fov = _fov_197_202_um()
         fov.extract_from(src)

--- a/scopesim/tests/tests_source/test_source_Source.py
+++ b/scopesim/tests/tests_source/test_source_Source.py
@@ -209,16 +209,16 @@ class TestSourceAddition:
     def test_ref_column_always_references_correct_spectrum(self, table_source,
                                                            image_source):
         image_source.append(table_source)
-        comb_refs = image_source.fields[1]["ref"]
-        tbl_refs = table_source.fields[0]["ref"]
+        comb_refs = image_source.fields[1].field["ref"]
+        tbl_refs = table_source.fields[0].field["ref"]
         assert all(tbl_refs.data + 1 == comb_refs.data)
         assert image_source.fields[0].header["SPEC_REF"] == 0
         image_source.shift(0.1, 0.2)
 
     def test_same_as_above_but_reversed(self, table_source, image_source):
         new_source = table_source + image_source
-        comb_refs = new_source.fields[0]["ref"]
-        tbl_refs = table_source.fields[0]["ref"]
+        comb_refs = new_source.fields[0].field["ref"]
+        tbl_refs = table_source.fields[0].field["ref"]
         assert all(tbl_refs.data == comb_refs.data)
         assert new_source.fields[1].header["SPEC_REF"] == 3
         new_source.shift(0.1, 0.2)
@@ -272,8 +272,8 @@ class TestSourceImageInRange:
     @pytest.mark.filterwarnings("ignore:Adding a table directly*:DeprecationWarning")
     def test_flux_from_table_on_image_is_as_expected(self, table_source):
         ph = table_source.photons_in_range(1*u.um, 2*u.um)
-        ref = table_source.fields[0]["ref"]
-        weight = table_source.fields[0]["weight"]
+        ref = table_source.fields[0].field["ref"]
+        weight = table_source.fields[0].field["weight"]
         counts = np.sum([ph.value[r] * w for r, w in zip(ref, weight)])
 
         im = table_source.image_in_range(1*u.um, 2*u.um)
@@ -289,9 +289,9 @@ class TestSourceImageInRange:
     def test_combines_more_that_one_field_into_image(self, image_source,
                                                      table_source):
         ph = table_source.photons_in_range(1 * u.um, 2 * u.um)
-        tbl = table_source.fields[0]
-        tbl_sum = u.Quantity([ph[tbl["ref"][ii]] * tbl["weight"][ii]
-                              for ii in range(len(tbl))])
+        fld = table_source.fields[0]
+        tbl_sum = u.Quantity([ph[fld.field["ref"][ii]] * fld.field["weight"][ii]
+                              for ii in range(len(fld.field))])
         tbl_sum = np.sum(tbl_sum.value)
 
         ph = image_source.photons_in_range(1 * u.um, 2 * u.um)[0]

--- a/scopesim/tests/tests_source/test_source_templates.py
+++ b/scopesim/tests/tests_source/test_source_templates.py
@@ -17,7 +17,7 @@ class TestStar:
     @pytest.mark.parametrize("flux", [5, 5*u.ABmag, 36.31*u.Jy])
     def test_accepts_mag_ABmag_jansky(self, flux):
         src = src_ts.star(flux=flux)
-        assert src.fields[0]["weight"] == approx(0.01, rel=0.01)
+        assert src.fields[0].field["weight"] == approx(0.01, rel=0.01)
         src.shift(0.1, 0.2)
 
 
@@ -34,13 +34,13 @@ class TestStarField:
     def test_star_fields_data(self):
         src = src_ts.star_field(100, 15, 25, 60)
         assert isinstance(src.fields[0].field, Table)
-        assert all(src.fields[0]["weight"] == 10**(-0.4 * src.fields[0]["mag"]))
+        assert all(src.fields[0].field["weight"] == 10**(-0.4 * src.fields[0].field["mag"]))
         src.shift(0.1, 0.2)
 
     def test_makes_grid_for_jansky_flux(self):
         src = src_ts.star_field(4, 3631*u.Jy, 36.31*u.Jy, 1)
-        assert src.fields[0]["weight"][0] == approx(1, rel=0.01)
-        assert src.fields[0]["weight"][-1] == approx(0.01, rel=0.01)
+        assert src.fields[0].field["weight"][0] == approx(1, rel=0.01)
+        assert src.fields[0].field["weight"][-1] == approx(0.01, rel=0.01)
         src.shift(0.1, 0.2)
 
 


### PR DESCRIPTION
Those methods were added mainly to preserve some backwards capability anyway. They don't really "hurt", hence only the `PendingDeprecationWarning` for now, but removing them would make it a lot easier to make `SourceField` an abstract metaclass and also they're rather smelly anyway, and the alternative (forcing to access the actual `field`, i.e. table or HDU) is more explicit.