### PR TITLE
Split `FieldOfView` into subclasses

### DIFF
--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -21,7 +21,7 @@ from .spectral_trace_list_utils import Transform2D
 from .spectral_trace_list_utils import make_image_interpolations
 from .apertures import ApertureMask
 from .ter_curves import TERCurve
-from ..optics.fov import FieldOfView
+from ..optics.fov import FieldOfView, FieldOfView3D
 from ..optics.fov_volume_list import FovVolumeList
 
 
@@ -87,7 +87,7 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
             if obj.hdu is not None and obj.hdu.header["NAXIS"] == 3:
                 obj.cube = obj.hdu
             elif obj.hdu is None and obj.cube is None:
-                obj.cube = obj.make_cube_hdu()
+                obj.cube = obj.make_hdu()
 
             fovcube = obj.cube.data
             n_z, n_y, n_x = fovcube.shape
@@ -132,9 +132,9 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
                                                fovcube[islice], kx=1, ky=1)
                     slicecube[islice] = ifov(yfov, xfov, grid=False)
 
-                slicefov = FieldOfView(obj.header,
-                                       [obj.meta["wave_min"],
-                                        obj.meta["wave_max"]])
+                slicefov = FieldOfView3D(obj.header,
+                                         [obj.meta["wave_min"],
+                                          obj.meta["wave_max"]])
                 slicefov.detector_header = obj.detector_header
                 slicefov.meta["xi_min"] = obj.meta["xi_min"]
                 slicefov.meta["xi_max"] = obj.meta["xi_max"]

--- a/scopesim/effects/psfs/discrete.py
+++ b/scopesim/effects/psfs/discrete.py
@@ -249,7 +249,7 @@ class FieldVaryingPSF(DiscretePSF):
             return fov
 
         if fov.hdu is None or fov.hdu.data is None:
-            fov.hdu = fov.make_image_hdu()
+            fov.hdu = fov.make_hdu()
 
         old_shape = fov.hdu.data.shape
 

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -237,7 +237,7 @@ class SpectralTraceList(Effect):
                 pass
             elif obj.hdu is None and obj.cube is None:
                 logger.info("Making cube")
-                obj.cube = obj.make_cube_hdu()
+                obj.cube = obj.make_hdu()
 
             spt = self.spectral_traces[obj.trace_id]
             obj.hdu = spt.map_spectra_to_focal_plane(obj)

--- a/scopesim/optics/__init__.py
+++ b/scopesim/optics/__init__.py
@@ -12,6 +12,6 @@ from .surface import SpectralSurface
 from . import surface_utils
 from . import radiometry_utils
 
-from .fov import FieldOfView
+from .fov import FieldOfView, FieldOfView1D, FieldOfView2D, FieldOfView3D
 from .fov_manager import FOVManager
 from .fov_volume_list import FovVolumeList

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -66,27 +66,6 @@ class FieldOfView:
 
     """
 
-    def __new__(
-        cls,
-        *args,
-        hdu_type: Literal["spectrum", "image", "cube"] = "image",
-        **kwargs,
-    ):
-        """Override creation to create subclasses."""
-        if cls is not FieldOfView:
-            # Allow for direct subclass access
-            return super().__new__(cls)
-
-        if hdu_type == "spectrum":
-            return super().__new__(FieldOfView1D)
-        if hdu_type == "image":
-            return super().__new__(FieldOfView2D)
-        if hdu_type == "cube":
-            return super().__new__(FieldOfView3D)
-
-        # If we get here, something went wrong
-        raise TypeError(f"{hdu_type=} not recognized.")
-
     def __init__(self, header, waverange, detector_header=None, cmds=None, **kwargs):
         self.meta = {
             "id": None,
@@ -109,7 +88,6 @@ class FieldOfView:
             "trace_id": None,
             "aperture_id": None,
         }
-        kwargs.pop("hdu_type", None)
         self.meta.update(kwargs)
 
         self.cmds = cmds
@@ -250,8 +228,6 @@ class FieldOfView:
 
         Parameters
         ----------
-        hdu_type : {"image", "cube", "spectrum"}
-            DESCRIPTION.
         sub_pixel : bool | None, optional
             If None (the default), use value from meta.
 

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -133,8 +133,6 @@ class FieldOfView:
 
         # These are apparently not supposed to be used?
         self.cube = None        # 3D array for IFU, long-lit, Slicer-MOS
-        # self.image = None       # 2D array for Imagers
-        # self.spectrum = None    # SourceSpectrum for Fibre-fed MOS
 
         self._waverange = None
         self._wavelength = None
@@ -474,12 +472,8 @@ class FieldOfView:
         """Return either hdu.data, image, cube, spectrum or None."""
         if self.hdu is not None:
             return self.hdu.data
-        if self.image is not None:
-            return self.image
         if self.cube is not None:
             return self.cube
-        if self.spectrum is not None:
-            return self.spectrum
         return None
 
     def get_corners(self, new_unit: str = None):
@@ -801,10 +795,6 @@ class FieldOfView2D(FieldOfView):
         Used for imaging.
 
         Output image units are ph s-1 pixel-1
-
-        .. note:: ``self.make_image()`` does NOT store anything in ``self.image``
-
-            See make_cube for an explanation
 
         Make canvas image from NAXIS1,2 from fov.header
 

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -5,7 +5,6 @@ from warnings import warn
 from copy import deepcopy
 from itertools import chain
 from collections.abc import Iterable, Generator
-from typing import Literal
 
 import numpy as np
 from scipy.interpolate import interp1d
@@ -234,6 +233,11 @@ class FieldOfView:
         Returns
         -------
         self.hdu : fits.ImageHDU, synphot.SourceSpectrum
+
+        .. versionchanged:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+           Removed `hdu_type` and `use_photlam` arguments, this is now handled
+           by the subclasses.
 
         """
         if sub_pixel is not None:
@@ -600,7 +604,13 @@ class FieldOfView:
 
 
 class FieldOfView1D(FieldOfView):
-    """For inkoherent MOS instruments, output 1D spectrum."""
+    """For inkoherent MOS instruments, output 1D spectrum.
+
+    .. versionadded:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+       Split ``FieldOfView`` into nD-subclasses.
+
+    """
 
     def _make_cubefields(self):
         """
@@ -681,7 +691,11 @@ class FieldOfView1D(FieldOfView):
         return spectrum
 
     def plot_data(self):
-        """Plot spectrum data if already exists."""
+        """Plot spectrum data if already exists.
+
+        .. versionadded:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+        """
         if self.hdu is None:
             raise ValueError("FOV HDU is empty.")
         fig, ax = figure_factory()
@@ -692,7 +706,13 @@ class FieldOfView1D(FieldOfView):
 
 
 class FieldOfView2D(FieldOfView):
-    """For imaging, output 2D image."""
+    """For imaging, output 2D image.
+
+    .. versionadded:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+       Split ``FieldOfView`` into nD-subclasses.
+
+    """
 
     def _make_cubefields(self):
         """
@@ -851,14 +871,24 @@ class FieldOfView2D(FieldOfView):
         return canvas_image_hdu  # [ph s-1]
 
     def plot_data(self):
-        """Plot HDU data if already exists."""
+        """Plot HDU data if already exists.
+
+        .. versionadded:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+        """
         if self.hdu is None:
             raise ValueError("FOV HDU is empty.")
         return image_plotter(self.hdu)
 
 
 class FieldOfView3D(FieldOfView):
-    """For spectroscopy, output 3D datacube (wave, x, y)."""
+    """For spectroscopy, output 3D datacube (wave, x, y).
+
+    .. versionadded:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+       Split ``FieldOfView`` into nD-subclasses.
+
+    """
 
     def _make_cubefields(self, fov_waveset):
         """
@@ -1077,7 +1107,11 @@ class FieldOfView3D(FieldOfView):
         return canvas_cube_hdu  # [ph s-1 um-1 (arcsec-2)]
 
     def plot_data(self):
-        """Plot HDU data if already exists."""
+        """Plot HDU data if already exists.
+
+        .. versionadded:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+        """
         if self.hdu is None:
             raise ValueError("FOV HDU is empty.")
         return cube_plotter(self.hdu)

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -1072,7 +1072,7 @@ class FieldOfView3D(FieldOfView):
             fov_waveset, self.spline_order),
             start=canvas_cube_hdu.data)
 
-        for flux, x, y in self._maketablefields(fov_waveset):
+        for flux, x, y in self._make_tablefields(fov_waveset):
             # To prevent adding array values in this manner.
             assert not isinstance(x, Iterable), "x should be integer"
             canvas_cube_hdu.data[:, y, x] += flux

--- a/scopesim/optics/fov_manager.py
+++ b/scopesim/optics/fov_manager.py
@@ -54,7 +54,7 @@ from ..effects import DetectorList
 from ..effects import effects_utils as eu
 from ..utils import from_currsys, get_logger
 
-from .fov import FieldOfView
+from .fov import FieldOfView, FieldOfView1D, FieldOfView2D, FieldOfView3D
 from .fov_volume_list import FovVolumeList
 
 
@@ -134,7 +134,7 @@ class FOVManager:
 
         Yields
         ------
-        Iterator[FieldOfView]
+        new_fov : Iterator[FieldOfView]
             Generator-Iterator of FieldOfView objects.
 
         """
@@ -178,19 +178,22 @@ class FOVManager:
                 #       .detector_headers()[0] or something?
 
             if not self.is_spectroscope:
-                hdu_type = "image"
+                fovcls = FieldOfView2D
             else:
                 if self.is_coherent:
-                    hdu_type = "cube"
+                    fovcls = FieldOfView3D
                 else:
-                    hdu_type = "spectrum"
+                    fovcls = FieldOfView1D
 
-            yield FieldOfView(skyhdr,
-                              waverange,
-                              detector_header=dethdr,
-                              cmds=self.cmds,
-                              hdu_type=hdu_type,
-                              **vol["meta"])
+            new_fov = fovcls(
+                skyhdr,
+                waverange,
+                detector_header=dethdr,
+                cmds=self.cmds,
+                **vol["meta"],
+            )
+
+            yield new_fov
 
     @property
     def fovs(self):

--- a/scopesim/optics/fov_manager.py
+++ b/scopesim/optics/fov_manager.py
@@ -106,6 +106,7 @@ class FOVManager:
         self.effects = effects or []
         self._fovs_list = []
         self.is_spectroscope = eu.is_spectroscope(self.effects)
+        self.is_coherent = True  # incoherent MOS not yet implemented
 
         if from_currsys(self.meta["preload_fovs"], self.cmds):
             logger.debug("Generating initial fovs_list.")
@@ -176,10 +177,19 @@ class FOVManager:
                 # TODO: Why is this .image_plane_header and not
                 #       .detector_headers()[0] or something?
 
+            if not self.is_spectroscope:
+                hdu_type = "image"
+            else:
+                if self.is_coherent:
+                    hdu_type = "cube"
+                else:
+                    hdu_type = "spectrum"
+
             yield FieldOfView(skyhdr,
                               waverange,
                               detector_header=dethdr,
                               cmds=self.cmds,
+                              hdu_type=hdu_type,
                               **vol["meta"])
 
     @property

--- a/scopesim/optics/image_plane.py
+++ b/scopesim/optics/image_plane.py
@@ -189,7 +189,11 @@ class ImagePlane:
         return wcs
 
     def plot(self):
-        """Plot data in image plane."""
+        """Plot data in image plane.
+
+        .. versionadded:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+        """
         if self.header["NAXIS"] == 3:
             return cube_plotter(self.hdu)
         return image_plotter(self.hdu)

--- a/scopesim/optics/image_plane.py
+++ b/scopesim/optics/image_plane.py
@@ -106,6 +106,10 @@ class ImagePlane:
            Adding a table directly to the ImagePlane is deprecated. Use FOV to
            add tables and image HDUs together before adding them to here.
 
+        .. versionchanged:: PLACEHOLDER_NEXT_RELEASE_VERSION
+
+           Here's a version changed message.
+
         Parameters
         ----------
         hdus_or_tables : `fits.ImageHDU` or `astropy.Table`

--- a/scopesim/optics/image_plane.py
+++ b/scopesim/optics/image_plane.py
@@ -106,10 +106,6 @@ class ImagePlane:
            Adding a table directly to the ImagePlane is deprecated. Use FOV to
            add tables and image HDUs together before adding them to here.
 
-        .. versionchanged:: PLACEHOLDER_NEXT_RELEASE_VERSION
-
-           Here's a version changed message.
-
         Parameters
         ----------
         hdus_or_tables : `fits.ImageHDU` or `astropy.Table`

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -273,8 +273,7 @@ class OpticalTrain:
             for fov in tqdm(fovs, desc=" FOVs", position=0, disable=nobar):
                 fov.extract_from(source)
 
-                hdu_type = "cube" if self.fov_manager.is_spectroscope else "image"
-                fov.view(hdu_type)
+                fov.view()
                 foveffs = self.optics_manager.fov_effects
                 nobar = len(foveffs) <= 1
                 for effect in tqdm(foveffs, disable=nobar,

--- a/scopesim/tests/mocks/py_objects/fov_objects.py
+++ b/scopesim/tests/mocks/py_objects/fov_objects.py
@@ -2,7 +2,7 @@ import numpy as np
 from astropy import units as u
 
 from scopesim.optics import image_plane_utils as imp_utils
-from scopesim.optics.fov import FieldOfView
+from scopesim.optics.fov import FieldOfView2D
 
 
 def _centre_fov(n=55, waverange=(1.0, 2.0)):
@@ -11,7 +11,7 @@ def _centre_fov(n=55, waverange=(1.0, 2.0)):
     sky_hdr = imp_utils.header_from_list_of_xy(xsky, ysky, 1/3600.)
     imp_hdr = imp_utils.header_from_list_of_xy([-n, n], [-n, n], 1, "D")
     imp_hdr.update(sky_hdr)
-    fov = FieldOfView(imp_hdr, waverange=waverange*u.um, area=1*u.m**2)
+    fov = FieldOfView2D(imp_hdr, waverange=waverange*u.um, area=1*u.m**2)
 
     return fov
 
@@ -24,6 +24,6 @@ def _centre_micado_fov(n=128, waverange=(1.9, 2.4)):
     sky_hdr = imp_utils.header_from_list_of_xy(xsky, ysky, pixscale)
     imp_hdr = imp_utils.header_from_list_of_xy([-n, n], [-n, n], pixscale, "D")
     imp_hdr.update(sky_hdr)
-    fov = FieldOfView(imp_hdr, waverange=waverange*u.um, area=1*u.m**2)
+    fov = FieldOfView2D(imp_hdr, waverange=waverange*u.um, area=1*u.m**2)
 
     return fov

--- a/scopesim/tests/tests_effects/test_AnisocadoConstPSF.py
+++ b/scopesim/tests/tests_effects/test_AnisocadoConstPSF.py
@@ -97,7 +97,7 @@ class TestApplyTo:
         psf.apply_to(fov)
 
         if PLOTS:
-            plt.imshow(fov.data, norm=LogNorm(), vmin=1)
+            plt.imshow(fov.hdu.data, norm="log", vmin=1)
             plt.show()
 
-        assert 1e-99 < np.average(fov.data) < 1e99
+        assert 1e-99 < np.average(fov.hdu.data) < 1e99

--- a/scopesim/tests/tests_effects/test_AnisocadoConstPSF.py
+++ b/scopesim/tests/tests_effects/test_AnisocadoConstPSF.py
@@ -10,7 +10,6 @@ from scopesim.tests.mocks.py_objects import fov_objects as fovobj
 from scopesim.tests.mocks.py_objects import source_objects as srcobj
 
 import matplotlib.pyplot as plt
-from matplotlib.colors import LogNorm
 
 
 PLOTS = False
@@ -56,7 +55,7 @@ class TestGetKernel:
         kernel = psf_object.get_kernel(fov_object)
 
         if PLOTS:
-            plt.imshow(kernel, norm=LogNorm())
+            plt.imshow(kernel, norm="log")
             plt.show()
 
         assert isinstance(kernel, np.ndarray)
@@ -72,7 +71,7 @@ class TestGetKernel:
         kernel = psf.get_kernel(0.004)
 
         if PLOTS:
-            plt.imshow(kernel, norm=LogNorm())
+            plt.imshow(kernel, norm="log")
             plt.show()
 
         assert isinstance(kernel, np.ndarray)

--- a/scopesim/tests/tests_effects/test_GaussianDiffractionPSF.py
+++ b/scopesim/tests/tests_effects/test_GaussianDiffractionPSF.py
@@ -12,7 +12,6 @@ from scopesim.tests.mocks.py_objects.source_objects import _image_source
 from scopesim.tests.mocks.py_objects.header_objects import _basic_fov_header
 
 import matplotlib.pyplot as plt
-from matplotlib.colors import LogNorm
 
 PLOTS = False
 
@@ -60,7 +59,7 @@ class TestApplyTo:
 
         if PLOTS:
             plt.subplot(121)
-            plt.imshow(basic_fov.fields[0].data, origin="lower", norm=LogNorm())
+            plt.imshow(basic_fov.fields[0].data, origin="lower", norm="log")
             plt.subplot(122)
             plt.imshow(basic_fov.hdu.data, origin="lower", norm="log")
             plt.show()

--- a/scopesim/tests/tests_effects/test_GaussianDiffractionPSF.py
+++ b/scopesim/tests/tests_effects/test_GaussianDiffractionPSF.py
@@ -5,7 +5,7 @@ import numpy as np
 from astropy import units as u
 
 from scopesim import effects as efs
-from scopesim.optics.fov import FieldOfView
+from scopesim.optics.fov import FieldOfView2D
 from scopesim.optics.image_plane_utils import pix2val
 
 from scopesim.tests.mocks.py_objects.source_objects import _image_source
@@ -18,7 +18,7 @@ PLOTS = False
 
 def _basic_fov():
     src = _image_source()
-    fov = FieldOfView(_basic_fov_header(), waverange=[1, 2]*u.um, area=1*u.m**2)
+    fov = FieldOfView2D(_basic_fov_header(), waverange=[1, 2]*u.um, area=1*u.m**2)
     fov.extract_from(src)
 
     return fov

--- a/scopesim/tests/tests_effects/test_GaussianDiffractionPSF.py
+++ b/scopesim/tests/tests_effects/test_GaussianDiffractionPSF.py
@@ -62,7 +62,7 @@ class TestApplyTo:
             plt.subplot(121)
             plt.imshow(basic_fov.fields[0].data, origin="lower", norm=LogNorm())
             plt.subplot(122)
-            plt.imshow(basic_fov.data, origin="lower", norm=LogNorm())
+            plt.imshow(basic_fov.hdu.data, origin="lower", norm="log")
             plt.show()
 
 

--- a/scopesim/tests/tests_effects/test_NonCommonPathAberation.py
+++ b/scopesim/tests/tests_effects/test_NonCommonPathAberation.py
@@ -4,13 +4,11 @@ from pytest import approx
 
 import numpy as np
 from matplotlib import pyplot as plt
-from matplotlib.colors import LogNorm
 from astropy import units as u
 
 from scopesim.effects.psfs import NonCommonPathAberration
 from scopesim.effects.psfs.analytical import _strehl2sigma, _sigma2gauss, wfe2gauss, wfe2strehl
 from scopesim.optics import FieldOfView, ImagePlane
-from scopesim.utils import from_currsys
 
 from scopesim.tests.mocks.py_objects.source_objects import _single_table_source
 from scopesim.tests.mocks.py_objects.header_objects import \
@@ -77,7 +75,7 @@ class TestGetKernel:
         assert np.sum(kernel) == approx(1)
 
         if PLOTS:
-            plt.imshow(kernel, norm=LogNorm(), vmax=1, vmin=1e-4)
+            plt.imshow(kernel, norm="log", vmax=1, vmin=1e-4)
             plt.colorbar()
             plt.show()
 
@@ -92,7 +90,7 @@ class TestApplyTo:
         assert post_max_flux/pre_max_flux == approx(0.954, rel=0.002)
 
         if PLOTS:
-            plt.imshow(fov_Ks.image[40:60, 40:60], norm=LogNorm())
+            plt.imshow(fov_Ks.image[40:60, 40:60], norm="log")
             plt.show()
 
     def test_ignores_classes_other_than_fov(self, ncpa_kwargs):

--- a/scopesim/tests/tests_effects/test_NonCommonPathAberation.py
+++ b/scopesim/tests/tests_effects/test_NonCommonPathAberation.py
@@ -85,9 +85,9 @@ class TestGetKernel:
 class TestApplyTo:
     def test_convolves_kernel_with_fov_image(self, ncpa_kwargs, fov_Ks):
         ncpa = NonCommonPathAberration(**ncpa_kwargs)
-        pre_max_flux = np.max(fov_Ks.data)
+        pre_max_flux = np.max(fov_Ks.hdu.data)
         fov_Ks = ncpa.apply_to(fov_Ks)
-        post_max_flux = np.max(fov_Ks.data)
+        post_max_flux = np.max(fov_Ks.hdu.data)
 
         assert post_max_flux/pre_max_flux == approx(0.954, rel=0.002)
 

--- a/scopesim/tests/tests_effects/test_NonCommonPathAberation.py
+++ b/scopesim/tests/tests_effects/test_NonCommonPathAberation.py
@@ -8,7 +8,7 @@ from astropy import units as u
 
 from scopesim.effects.psfs import NonCommonPathAberration
 from scopesim.effects.psfs.analytical import _strehl2sigma, _sigma2gauss, wfe2gauss, wfe2strehl
-from scopesim.optics import FieldOfView, ImagePlane
+from scopesim.optics import FieldOfView2D, ImagePlane
 
 from scopesim.tests.mocks.py_objects.source_objects import _single_table_source
 from scopesim.tests.mocks.py_objects.header_objects import \
@@ -21,7 +21,7 @@ PLOTS = False
 @pytest.fixture(scope="function")
 def fov_Ks():
     _src = _single_table_source()
-    _fov = FieldOfView(header=_fov_header(), waverange=(1.9, 2.4), area=1*u.m**2)
+    _fov = FieldOfView2D(header=_fov_header(), waverange=(1.9, 2.4), area=1*u.m**2)
     _fov.extract_from(_src)
     _fov.view()
     return _fov

--- a/scopesim/tests/tests_effects/test_Vibration.py
+++ b/scopesim/tests/tests_effects/test_Vibration.py
@@ -4,7 +4,7 @@ import numpy as np
 from astropy import units as u
 
 from scopesim.effects import Vibration
-from scopesim.optics.fov import FieldOfView
+from scopesim.optics.fov import FieldOfView2D
 from scopesim.optics.image_plane import ImagePlane
 from scopesim.tests.mocks.py_objects.header_objects import _fov_header, \
                                                            _implane_header
@@ -43,7 +43,7 @@ class TestInit:
 
 class TestApplyTo:
     def test_nothing_happens_if_apply_to_fov(self, fov_hdr):
-        fov = FieldOfView(header=fov_hdr, waverange=[0.5, 2.5], area=1*u.m**2)
+        fov = FieldOfView2D(header=fov_hdr, waverange=[0.5, 2.5], area=1*u.m**2)
         fov.view()
         fov.hdu.data = np.zeros((11, 11))
         fov.hdu.data[5, 5] = 1

--- a/scopesim/tests/tests_integrations/test_source_fov_imageplane_play_nicely.py
+++ b/scopesim/tests/tests_integrations/test_source_fov_imageplane_play_nicely.py
@@ -8,7 +8,7 @@ from pytest import approx
 
 from astropy import units as u
 
-from scopesim.optics.fov import FieldOfView
+from scopesim.optics.fov import FieldOfView2D
 from scopesim.optics.image_plane import ImagePlane
 
 from scopesim.tests.mocks.py_objects import source_objects as src
@@ -45,7 +45,7 @@ class TestInteractionBetweenSourceFOVImagePlane:
     def test_can_extract_the_source_in_a_fov(self, fov_hdr, comb_src,
                                              implane_hdr):
 
-        fov = FieldOfView(fov_hdr, waverange=[0.5, 2.5]*u.um, area=1*u.m**2)
+        fov = FieldOfView2D(fov_hdr, waverange=[0.5, 2.5]*u.um, area=1*u.m**2)
         imp = ImagePlane(implane_hdr)
 
         fov.extract_from(comb_src)

--- a/scopesim/tests/tests_optics/test_FieldOfView.py
+++ b/scopesim/tests/tests_optics/test_FieldOfView.py
@@ -14,27 +14,27 @@ from scopesim.optics.fov import FieldOfView
 PLOTS = False
 
 
-def _fov_190_210_um():
+def _fov_190_210_um(hdu_type="image"):
     """ A FOV compatible with 11 slices of so._cube_source()"""
     hdr = ho._fov_header()  # 20x20" @ 0.2" --> [-10, 10]"
     wav = [1.9, 2.1] * u.um
-    fov = FieldOfView(hdr, wav, area=1 * u.m ** 2)
+    fov = FieldOfView(hdr, wav, area=1 * u.m ** 2, hdu_type=hdu_type)
     return fov
 
 
-def _fov_190_210_um_subpx():
+def _fov_190_210_um_subpx(hdu_type="image"):
     """ A FOV compatible with 11 slices of so._cube_source()"""
     hdr = ho._fov_header()  # 20x20" @ 0.2" --> [-10, 10]"
     wav = [1.9, 2.1] * u.um
-    fov = FieldOfView(hdr, wav, area=1 * u.m ** 2, sub_pixel=True)
+    fov = FieldOfView(hdr, wav, area=1 * u.m ** 2, sub_pixel=True, hdu_type=hdu_type)
     return fov
 
 
-def _fov_197_202_um():
+def _fov_197_202_um(hdu_type="image"):
     """ A FOV compatible with 3 slices of so._cube_source()"""
     hdr = ho._fov_header()  # 20x20" @ 0.2" --> [-10, 10]"
     wav = [1.97000000001, 2.02] * u.um  # Needs [1.98, 2.00, 2.02] µm --> 3 slices
-    fov = FieldOfView(hdr, wav, area=1*u.m**2)
+    fov = FieldOfView(hdr, wav, area=1*u.m**2, hdu_type=hdu_type)
     return fov
 
 
@@ -167,10 +167,10 @@ class TestMakeCube:
     @pytest.mark.xfail(reason="cube flux is broken")
     def test_makes_cube_from_table(self):
         src_table = so._table_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
-        fov = _fov_190_210_um()
+        fov = _fov_190_210_um(hdu_type="cube")
         fov.extract_from(src_table)
 
-        cube = fov.make_cube_hdu()
+        cube = fov.make_hdu()
 
         in_sum = 0
         waveset = fov.spectra[0].waveset
@@ -189,10 +189,10 @@ class TestMakeCube:
     @pytest.mark.xfail(reason="cube flux is broken")
     def test_makes_cube_from_imagehdu(self):
         src_image = so._image_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
-        fov = _fov_190_210_um()
+        fov = _fov_190_210_um(hdu_type="cube")
         fov.extract_from(src_image)
 
-        cube = fov.make_cube_hdu()
+        cube = fov.make_hdu()
 
         waveset = np.linspace(1.9, 2.1, np.shape(cube)[0]) * u.um
         spec = fov.spectra[0](waveset).to(u.ph/u.s/u.m**2/u.um).value
@@ -210,10 +210,10 @@ class TestMakeCube:
         import scopesim as sim
         sim.rc.__currsys__["!SIM.spectral.spectral_bin_width"] = 0.01
         src_cube = so._cube_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
-        fov = _fov_197_202_um()
+        fov = _fov_197_202_um(hdu_type="cube")
         fov.extract_from(src_cube)
 
-        cube = fov.make_cube_hdu()
+        cube = fov.make_hdu()
 
         # layer 74 to 77 are extracted by FOV
         in_sum = np.sum(src_cube.fields[0].data[74:77, :, :])
@@ -229,10 +229,10 @@ class TestMakeCube:
     @pytest.mark.xfail(reason="cube flux is broken")
     def test_makes_cube_from_two_similar_cube_imagehdus(self):
         src_cube = so._cube_source() + so._cube_source(dx=1)            # 2 cubes 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
-        fov = _fov_197_202_um()
+        fov = _fov_197_202_um(hdu_type="cube")
         fov.extract_from(src_cube)
 
-        cube = fov.make_cube_hdu()
+        cube = fov.make_hdu()
 
         # layer 74 to 77 are extracted by FOV
         bin_widths = np.array([0.01, 0.02, 0.01])[:, None, None] * 1e4      # um -> AA
@@ -252,10 +252,10 @@ class TestMakeCube:
                   so._image_source(dx=-4, dy=-4) + \
                   so._cube_source(weight=1e-8, dx=4)
 
-        fov = _fov_190_210_um()
+        fov = _fov_190_210_um(hdu_type="cube")
         fov.extract_from(src_all)
 
-        cube = fov.make_cube_hdu()
+        cube = fov.make_hdu()
 
         # sum up the expected flux in the output cube
         # bin_width * half width edge bin * PHOTLAM -> SI
@@ -286,10 +286,10 @@ class TestMakeCube:
                                      so._image_source(),
                                      so._cube_source()])
     def test_cube_has_full_wcs(self, src):
-        fov = _fov_190_210_um()
+        fov = _fov_190_210_um(hdu_type="cube")
         fov.extract_from(src)
 
-        cube = fov.make_cube_hdu()
+        cube = fov.make_hdu()
 
         assert "CDELT3" in cube.header
         assert "CRVAL3" in cube.header
@@ -301,7 +301,7 @@ class TestMakeCube:
 class TestMakeImage:
     def test_makes_image_from_table(self):
         src_table = so._table_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
-        fov = _fov_190_210_um()
+        fov = _fov_190_210_um(hdu_type="image")
         fov.extract_from(src_table)
 
         in_sum = 0
@@ -311,7 +311,7 @@ class TestMakeImage:
             flux *= 1 * u.m**2 * 0.02 * u.um * 0.9      # 0.9 is to catch the half bins at either end
             in_sum += np.sum(flux).value * weight
 
-        img = fov.make_image_hdu()
+        img = fov.make_hdu()
         out_sum = np.sum(img.data)
 
         if PLOTS:
@@ -324,7 +324,7 @@ class TestMakeImage:
         src_table = so._table_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
         # Shift one source very close to edge to provoke index error in canvas
         src_table.fields[0].field["y"][-1] = 9.9999
-        fov = _fov_190_210_um_subpx()
+        fov = _fov_190_210_um_subpx(hdu_type="image")
         fov.extract_from(src_table)
 
         in_sum = 0
@@ -336,7 +336,7 @@ class TestMakeImage:
                 weight /= 2
             in_sum += np.sum(flux).value * weight
 
-        img = fov.make_image_hdu()
+        img = fov.make_hdu()
         out_sum = np.sum(img.data)
 
         if PLOTS:
@@ -347,10 +347,10 @@ class TestMakeImage:
 
     def test_makes_image_from_image(self):
         src_image = so._image_source()  # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
-        fov = _fov_190_210_um()
+        fov = _fov_190_210_um(hdu_type="image")
         fov.extract_from(src_image)
 
-        img = fov.make_image_hdu()
+        img = fov.make_hdu()
 
         src_im_sum = np.sum(src_image.fields[0].data)
         src_spec = src_image.spectra[0](fov.waveset).to(u.ph/u.s/u.m**2/u.um)
@@ -371,10 +371,10 @@ class TestMakeImage:
     @pytest.mark.xfail(reason="revisit fov.waveset e.g. use make_cube waveset")
     def test_makes_image_from_cube(self):
         src_cube = so._cube_source()  # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
-        fov = _fov_197_202_um()
+        fov = _fov_197_202_um(hdu_type="image")
         fov.extract_from(src_cube)
 
-        image = fov.make_image_hdu()
+        image = fov.make_hdu()
 
         # layer 74 to 77 are extracted by FOV
         in_sum = np.sum(src_cube.fields[0].data[74:77, :, :])
@@ -392,10 +392,10 @@ class TestMakeImage:
                   so._image_source(dx=-4, dy=-4) + \
                   so._cube_source(weight=1e-8, dx=4)
 
-        fov = _fov_190_210_um()
+        fov = _fov_190_210_um(hdu_type="image")
         fov.extract_from(src_all)
 
-        image = fov.make_image_hdu()
+        image = fov.make_hdu()
 
         # sum up the expected flux in the output cube
         waveset = fov.spectra[0].waveset
@@ -426,10 +426,10 @@ class TestMakeImage:
 class TestMakeSpectrum:
     def test_make_spectrum_from_table(self):
         src_table = so._table_source()            # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
-        fov = _fov_190_210_um()
+        fov = _fov_190_210_um(hdu_type="spectrum")
         fov.extract_from(src_table)
 
-        spec = fov.make_spectrum()
+        spec = fov.make_hdu()
 
         in_sum = np.sum([n * spec(fov.waveset).value
                         for n, spec in zip([3, 1, 1], src_table.spectra.values())])      # sum of weights [3,1,1]
@@ -439,10 +439,10 @@ class TestMakeSpectrum:
 
     def test_make_spectrum_from_image(self):
         src_image = so._image_source()  # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
-        fov = _fov_190_210_um()
+        fov = _fov_190_210_um(hdu_type="spectrum")
         fov.extract_from(src_image)
 
-        spec = fov.make_spectrum()
+        spec = fov.make_hdu()
 
         in_sum = np.sum(src_image.fields[0].data) * \
                  np.sum(src_image.spectra[0](fov.waveset).value)
@@ -452,10 +452,10 @@ class TestMakeSpectrum:
 
     def test_make_spectrum_from_cube(self):
         src_cube = so._cube_source()  # 10x10" @ 0.2"/pix, [0.5, 2.5]m @ 0.02µm
-        fov = _fov_197_202_um()
+        fov = _fov_197_202_um(hdu_type="spectrum")
         fov.extract_from(src_cube)
 
-        spec = fov.make_spectrum()
+        spec = fov.make_hdu()
 
         in_sum = np.sum(src_cube.fields[0].data[74:77, :, :]) * 1e-8
         out_sum = np.sum(spec(fov.waveset).value)
@@ -468,10 +468,10 @@ class TestMakeSpectrum:
         src_cube = so._cube_source(weight=1e-8, dx=4)
         src_all = src_table + src_image + src_cube
 
-        fov = _fov_190_210_um()
+        fov = _fov_190_210_um(hdu_type="spectrum")
         fov.extract_from(src_all)
 
-        spec = fov.make_spectrum()
+        spec = fov.make_hdu()
 
         table_sum = np.sum([
             n * spec(fov.waveset).value
@@ -494,24 +494,24 @@ class TestMakeSpectrum:
             plt.show()
 
 
-@pytest.mark.xfail(reason="revisit fov.waveset e.g. use make_cube waveset")
+@pytest.mark.skip(reason="needs split FOVs after subclass refactor")
 class TestMakeSpectrumImageCubeAllPlayNicely:
     def test_make_cube_and_make_spectrum_return_the_same_fluxes(self):
         src_all = so._table_source() + \
                   so._image_source(dx=-4, dy=-4) + \
                   so._cube_source(weight=1e-8, dx=4)
 
-        fov = _fov_190_210_um()
+        fov = _fov_190_210_um(hdu_type="cube")
         fov.extract_from(src_all)
 
         # if photlam, units of ph / s / cm2 / AA, else units of ph / s / voxel
-        cube = fov.make_cube_hdu()
+        cube = fov.make_hdu()
         # cube_waves = get_cube_waveset(cube.header)
         cube_spectrum = cube.data.sum(axis=2).sum(axis=1)
 
         # always units of ph / s / cm-2 / AA-1
         waves = fov.waveset
-        spectrum = fov.make_spectrum()(waves).value
+        spectrum = fov.make_hdu()(waves).value
 
         bin_width = 0.02        # um
         photlam_to_si = 1e8     # cm-2 AA-1 --> m-2 um-1
@@ -535,8 +535,8 @@ class TestMakeSpectrumImageCubeAllPlayNicely:
         fov.extract_from(src_all)
 
         # if photlam, units of ph / s / cm2 / AA, else units of ph / s / voxel
-        cube_sum = np.sum(fov.make_cube_hdu().data)
+        cube_sum = np.sum(fov.make_hdu().data)
         # if photlam, units of ph / s / cm2 / AA, else units of ph / s / pixel
-        image_sum = np.sum(fov.make_image_hdu().data)
+        image_sum = np.sum(fov.make_hdu().data)
 
         assert cube_sum == approx(image_sum, rel=0.05)


### PR DESCRIPTION
The `FieldOfView` used to produce either 1D (unused before MOS), 2D (imaging) or 3D (spectroscopy) outputs. The distinction between 2D and 3D was actually made well before in the `FOVManager`. Meaning by the time the `FieldOfView` object is created, it is already known which type of output will be produced. So it is not really needed at all to retain all three options all the way through the optical train.

In my opinion, splitting this into subclasses makes it quite a bit better structured to look at and understand what's happening in which case, and what attributes and methods are shared (i.e. belong to the base class). I used the `__new__()` "trick" to still enable creation via `fov = FieldOfView()` with the `hdu_type` argument as a distinction. I might change this later on to only directly instantiate the three subclasses, that depends somewhat on how the MOS stuff is implemented, because it will be the first thing to actually use the 1D variant (outside of unit tests).

I think refactoring the various `_make_xy` methods into something more consistent (think BUNIT on 2+1D sources) will be easier to navigate with this split.