### PR TITLE
Remove mention of deprecated GitHub download from docs

### DIFF
--- a/docs/source/5_liners/loading_packages.ipynb
+++ b/docs/source/5_liners/loading_packages.ipynb
@@ -85,42 +85,6 @@
    "source": [
     "sim.download_packages(\"test_package\", release=\"latest\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "indie-house",
-   "metadata": {},
-   "source": [
-    "### Bleeding-edge versions from GitHub\n",
-    "\n",
-    "We can also pull the latest verisons of a package from GitHub. This is useful if you are the one writing the package and want to test how it works on a different machine.\n",
-    "\n",
-    "The following strings will work:\n",
-    "\n",
-    "- Latest from a branch: `release=\"github:<branch-name>\"`\n",
-    "- From a specific tag: `release=\"github:<tag>\"`\n",
-    "- From a specific commit: `release=\"github:<super-long-commit-hash>\"`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "happy-thought",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sim.download_packages(\"test_package\", release=\"github:dev_master\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "neither-netscape",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sim.download_packages(\"LFOA\", release=\"github:3c136cd59ceeca551c01c6fa79f87377997f33f9\")"
-   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This caused a rare failure because of GitHubs rate limits and also is deprecated anyway.