### PR TITLE
Add basic pylint config in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,3 +120,9 @@ filterwarnings = [
 
 [tool.coverage.report]
 omit = ["scopesim/tests/*", "docs/*"]
+
+[tool.pylint.main]
+ignored-classes = "astropy.units"
+fail-under = 8
+output-format = "colorized"
+ignore-paths = "scopesim.tests"


### PR DESCRIPTION
Seems useful to all use the same config when running pylint locally. Maybe also one day include it in the CI.
Feel free to add to the configuration here.

Current global evaluation rates our codebase at 8.96/10, which isn't terrible.