### PR TITLE
Local TER library

### DIFF
--- a/scopesim/tests/tests_effects/test_AtmoLibraryTERCurve.py
+++ b/scopesim/tests/tests_effects/test_AtmoLibraryTERCurve.py
@@ -1,0 +1,4 @@
+"""Tests for the AtmoLibraryTERCurve class"""
+
+class TestInit:
+    pass


### PR DESCRIPTION
This PR adds an effect that chooses an atmospheric TER curve from a local library file, based on some parameters (currently only PWV). The main purpose is to support simulations for METIS AIT observations of the sky in Leiden, but the effect should have broader usefulness.

Implements #763 