### PR TITLE
Update internal dependencies more often

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,14 +33,6 @@ updates:
       semver-minor-days: 14
       semver-patch-days: 7
     groups:
-      internal-dependencies:
-        applies-to: version-updates
-        patterns:
-          - "astar*"
-          - "scopesim*"
-          - "spextra"
-          - "skycalc-ipy"
-          - "anisocado*"
       main-dependencies:
         # Applies to all dependencies defined in the main section of pyproject.toml
         applies-to: version-updates
@@ -55,3 +47,28 @@ updates:
         update-types:
           - "major"
           - "minor"
+
+  # Separate setup for internal dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    allow:
+      # Allow both direct and indirect updates for all packages.
+      - dependency-type: "production"
+    cooldown:
+      # Don't include too new versions
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 2
+    groups:
+      internal-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "astar*"
+          - "scopesim*"
+          - "spextra"
+          - "skycalc-ipy"
+          - "anisocado*"


### PR DESCRIPTION
I saw somewhere that you can have multiple sections for the same ecosystem (`pip` in this case) with different setups, so let's try if that really works. It seems useful to update our internal dependencies very regularly, but don't be bothered by the other too often. It has happened one to many times that I forgot to update something internal...