### PR TITLE
Functionality for MOSAIC minimum viable product

### DIFF
--- a/scopesim/effects/__init__.py
+++ b/scopesim/effects/__init__.py
@@ -8,6 +8,7 @@ from .obs_strategies import *
 from .spectral_trace_list import *
 from .spectral_efficiency import *
 from .metis_lms_trace_list import *
+from .mosaic_trace_list import *
 from .surface_list import *
 from .ter_curves import *
 from . import ter_curves_utils

--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -84,6 +84,7 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
 
         if isinstance(obj, FieldOfView):
             # Application to field of view
+            logger.debug("Executing %s, FoV", self.meta['name'])
             if obj.hdu is not None and obj.hdu.header["NAXIS"] == 3:
                 obj.cube = obj.hdu
             elif obj.hdu is None and obj.cube is None:

--- a/scopesim/effects/mosaic_trace_list.py
+++ b/scopesim/effects/mosaic_trace_list.py
@@ -72,10 +72,6 @@ class MosaicSpectralTraceList(SpectralTraceList):
             ## This is the place where we need to look at the apertures
             ## - collapse each aperture to 1D spectrum by integrating spatially
             ## - map each 1D spectrum to detector/fov
-            fovimage = np.zeros((obj.detector_header["NAXIS2"],
-                                 obj.detector_header["NAXIS1"]),
-                                dtype=np.float32)
-            pixscale = self.meta['pixel_scale']
 
             image = np.zeros((naxis2d, naxis1d), dtype=np.float32)
             imgwcs = WCS(naxis=2)
@@ -89,11 +85,10 @@ class MosaicSpectralTraceList(SpectralTraceList):
             for sptid, spt in tqdm(self.spectral_traces.items(),
                                    desc="Fiber traces", position=2):
                 theap = self.aplist[self.aplist['id'] == sptid]
+
                 # solid angle in arcsec**2
                 solid_angle  = ((theap["right"] - theap["left"]) *
                                 (theap["top"] - theap["bottom"]))
-                nx_slice = (theap["right"] - theap["left"]  ) / pixscale
-                ny_slice = (theap["top"]   - theap["bottom"]) / pixscale
 
                 # apertures are defined in arcsec. fovwcs is in degrees
                 xmin, xmax, ymin, ymax = (theap["left"]/3600, theap["right"]/3600,

--- a/scopesim/effects/mosaic_trace_list.py
+++ b/scopesim/effects/mosaic_trace_list.py
@@ -46,7 +46,6 @@ class MosaicSpectralTrace(SpectralTrace):
         super().__init__(trace_tbl, **kwargs)
 
     def compute_interpolation_functions(self):
-        print(self.table)
         x_arr = self.table[self.meta["x_colname"]]
         y_arr = self.table[self.meta["y_colname"]]
         xi_arr = self.table[self.meta["s_colname"]]

--- a/scopesim/effects/mosaic_trace_list.py
+++ b/scopesim/effects/mosaic_trace_list.py
@@ -127,6 +127,10 @@ class MosaicSpectralTraceList(SpectralTraceList):
         self.catalog = Table(self._file[self.ext_cat].data)
         spec_traces = {}
         for row in self.catalog:
+            # image_plane_id = -1 marks rows that should not be read,
+            # e.g. the aperture list. Although not necessary if the catalogue
+            # is formatted in a way that only traces are listed, this provides
+            # a possibility to "mask" traces.
             if row["image_plane_id"] == -1:
                 continue
             params = {col: row[col] for col in row.colnames}
@@ -229,7 +233,6 @@ class MosaicCollapseSpectralTraces(MosaicSpectralTraceList):
     def apply_to(self, det, **kwargs):
         """Apply to detector readout"""
         if not isinstance(det, Detector):
-            print("Type of det:", type(det))
             return det
 
         image = det._hdu.data

--- a/scopesim/effects/mosaic_trace_list.py
+++ b/scopesim/effects/mosaic_trace_list.py
@@ -1,0 +1,56 @@
+#  -*- coding: utf-8 -*-
+"""SpectralTraceList and SpectralTrace for MOSAIC"""
+import numpy as np
+from astropy.table import Table
+from astropy import units as u
+
+from .spectral_trace_list import SpectralTraceList
+from .spectral_trace_list_utils import SpectralTrace
+
+from ..utils import get_logger, quantify
+
+logger = get_logger(__name__)
+
+class MosaicSpectralTraceList(SpectralTraceList):
+    """SpectralTraceList for MOSAIC"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.aplist = self._file["Aperture List"].data
+
+        self.view = np.array([(self.aplist["right"].max() -
+                               self.aplist["left"].min()),
+                              (self.aplist["top"].max() -
+                               self.aplist["bottom"].min())])
+
+    def make_spectral_traces(self):
+        """Return a dictionary of spectral traces read in from a file."""
+        self.ext_data = self._file[0].header["EDATA"]
+        self.ext_cat = self._file[0].header["ECAT"]
+        self.catalog = Table(self._file[self.ext_cat].data)
+        spec_traces = {}
+        for row in self.catalog:
+            if row["image_plane_id"] == -1:
+                continue
+            params = {col: row[col] for col in row.colnames}
+            params.update(self.meta)
+            hdu = self._file[row["extension_id"]]
+            spec_traces[row["description"]] = MosaicSpectralTrace(hdu, **params)
+
+        self.spectral_traces = spec_traces
+
+class MosaicSpectralTrace(SpectralTrace):
+
+    def __init__(self, trace_tbl, **kwargs):
+        super().__init__(trace_tbl, **kwargs)
+
+    def compute_interpolation_functions(self):
+        print(self.table)
+        x_arr = self.table[self.meta["x_colname"]]
+        y_arr = self.table[self.meta["y_colname"]]
+        xi_arr = self.table[self.meta["s_colname"]]
+        lam_arr = self.table[self.meta["wave_colname"]]
+
+        self.wave_min = quantify(np.min(lam_arr), u.um).value
+        self.wave_max = quantify(np.max(lam_arr), u.um).value

--- a/scopesim/effects/mosaic_trace_list.py
+++ b/scopesim/effects/mosaic_trace_list.py
@@ -1,13 +1,20 @@
 #  -*- coding: utf-8 -*-
 """SpectralTraceList and SpectralTrace for MOSAIC"""
+from tqdm.auto import tqdm
+
 import numpy as np
 from astropy.table import Table
 from astropy import units as u
+from astropy.wcs import WCS
+from astropy.modeling import fitting
+from astropy.modeling.models import Polynomial1D
 
 from .spectral_trace_list import SpectralTraceList
 from .spectral_trace_list_utils import SpectralTrace
 
-from ..utils import get_logger, quantify
+from ..utils import get_logger, quantify, power_vector
+from ..optics.fov import FieldOfView
+from ..optics.fov_volume_list import FovVolumeList
 
 logger = get_logger(__name__)
 
@@ -18,11 +25,86 @@ class MosaicSpectralTraceList(SpectralTraceList):
         super().__init__(**kwargs)
 
         self.aplist = self._file["Aperture List"].data
-
         self.view = np.array([(self.aplist["right"].max() -
                                self.aplist["left"].min()),
                               (self.aplist["top"].max() -
                                self.aplist["bottom"].min())])
+
+    def apply_to(self, obj, **kwargs):
+        """See parent docstring."""
+        ### This is copied from MetisSpectralTraceList, make less redundant?
+        if isinstance(obj, FovVolumeList):
+            logger.debug("Executing %s, FoV setup", self.meta['name'])
+            # Create a single volume that covers the aperture and
+            # the maximum wavelength range of the grating
+            volumes = [spectral_trace.fov_grid()
+                       for spectral_trace in self.spectral_traces.values()]
+            wave_min = min(vol["wave_min"] for vol in volumes)
+            wave_max = max(vol["wave_max"] for vol in volumes)
+            extracted_vols = obj.extract(axes=["wave"],
+                                         edges=([[wave_min, wave_max]]))
+            obj.volumes = extracted_vols
+            print("Mosaic Spectral Trace List:", obj)
+
+        if isinstance(obj, FieldOfView):
+            # Application to field of view
+            logger.debug("Executing %s, FoV", self.meta['name'])
+            if obj.hdu is not None and obj.hdu.header["NAXIS"] == 3:
+                obj.cube = obj.hdu
+            elif obj.hdu is None and obj.cube is None:
+                print("MosSpTrL: Making cube")
+                obj.cube = obj.make_cube_hdu()
+
+            fovcube = obj.cube.data
+            n_z, n_y, n_x = fovcube.shape
+            fovwcs = WCS(obj.cube.header)
+            # Make this linear to avoid jump at RA 0 deg
+            fovwcs.wcs.ctype = ["LINEAR", "LINEAR", fovwcs.wcs.ctype[2]]
+            fovwcs_spat = fovwcs.sub(2)
+
+            ## This is the place where we need to look at the apertures
+            ## - collapse each aperture to 1D spectrum by integrating spatially
+            ## - map each 1D spectrum to detector/fov
+            fovimage = np.zeros((obj.detector_header["NAXIS2"],
+                                 obj.detector_header["NAXIS1"]),
+                                dtype=np.float32)
+
+            for sptid, spt in tqdm(self.spectral_traces.items(),
+                                   desc="Fiber traces", position=2):
+                nx_slice = (self.aplist[sptid]["right"] - self.aplist[sptid]["left"])/pixscale
+                nx_slice = (self.aplist[sptid]["top"] - self.aplist[sptid]["bottom"])/pixscale
+
+                ymin = spt.meta["fov"]["y_min"]
+                ymax = spt.meta["fov"]["y_max"]
+
+                slicewcs = fovwcs.deepcopy()
+                slicewcs.wcs.ctype = ["LINEAR", "LINEAR",
+                                      slicewcs.wcs.ctype[2]]
+                slicewcs.wcs.crpix[0] = (nx_slice + 1) / 2
+                slicewcs.wcs.crpix[1] = (ny_slice + 1) / 2
+                slicewcs.wcs.crval[0] = (xmin + xmax) / 2 / 3600
+                slicewcs.wcs.crval[1] = (ymin + ymax) / 2 / 3600
+                slicewcs.wcs.cdelt[0] = (ymax - ymin) / ny_slice / 3600
+                slicewcs.wcs.cdelt[1] = (ymax - ymin) / ny_slice / 3600
+                slicewcs_spat = slicewcs.sub(2)
+
+                # World coordinates for the slice
+                xworld, yworld = slicewcs_spat.app_pix2world(xslice, yslice, 0)
+                # FOV pixel coordinates for the slice
+                xfov, yfov = fovwcs_spat.all_world2pix(xworld, yworld, 0)
+
+                for islice in range(n_z):
+                    # this should not be necessary
+                    ifov = RectBivariateSpline(np.arange(n_y),
+                                               np.arange(n_x),
+                                               fovcube[islice], kx=1, ky=1)
+                    fovcube[islice, yfov, xfov].sum()
+                # build slicefov = FieldOfView1D(...)
+                # fovimage[] += slicefov.hdu.data (better integer row = slicefov...)
+
+        return obj
+
+
 
     def make_spectral_traces(self):
         """Return a dictionary of spectral traces read in from a file."""
@@ -40,10 +122,13 @@ class MosaicSpectralTraceList(SpectralTraceList):
 
         self.spectral_traces = spec_traces
 
+
 class MosaicSpectralTrace(SpectralTrace):
 
     def __init__(self, trace_tbl, **kwargs):
         super().__init__(trace_tbl, **kwargs)
+
+
 
     def compute_interpolation_functions(self):
         x_arr = self.table[self.meta["x_colname"]]
@@ -53,3 +138,66 @@ class MosaicSpectralTrace(SpectralTrace):
 
         self.wave_min = quantify(np.min(lam_arr), u.um).value
         self.wave_max = quantify(np.max(lam_arr), u.um).value
+
+
+
+class Transform1D():
+    """
+    1-dimensional polynomial transform.
+    """
+
+    def __init__(self, coeffs, pretransform=None,
+                 posttransform=None):
+        self.coeffs = np.asarray(coeffs)
+        self.nx = self.coeffs.shape[0]
+        self.pretransform = self._repackage(pretransform)
+        self.posttransform = self._repackage(posttransform)
+
+    def _repackage(self, trafo):
+        """Make sure `trafo` is a tuple."""
+        if trafo is not None and not isinstance(trafo, tuple):
+            trafo = (trafo, {})
+        return trafo
+
+    def __call__(self, x, **kwargs):
+        """
+        Apply the polynomial transform.
+
+        The transformation is a polynomial based on the simple monomials x^i.
+        """
+
+        if "pretransform" in kwargs:
+            self.pretransform = self._repackage(kwargs["pretransform"])
+        if "postransform" in kwargs:
+            self.posttransform = self._repackage(kwargs["posttransform"])
+
+        x = np.array(x)
+
+        # Apply pre transform
+        if self.pretransform is not None:
+            x = self.pretransform[0](x, **self.pretransform[1])
+
+        xvec = power_vector(x, self.nx - 1)
+
+        result = self.coeffs @ xvec
+
+        # Apply posttransform
+        if self.posttransform is not None:
+            result = self.posttransform[0](result, **self.posttransform[1])
+
+        return result
+
+    @classmethod
+    def fit(cls, xin, xout, degree=4):
+        """Determine polynomial fit"""
+        pinit = Polynomial1D(degree=degree)
+        fitter = fitting.LinearLSQFitter()
+        fit = fitter(pinit, xin, xout)
+        return Transform1D(fit.parameters)
+
+    def gradient(self):
+        """Compute the gradient of a 1d polynomial transformation"""
+        coeffs = self.coeffs
+
+        dcoeffs = (coeffs * np.arange(self.nx))[1:]
+        return Transform1D(dcoeffs)

--- a/scopesim/tests/tests_effects/test_mosaic_trace_list.py
+++ b/scopesim/tests/tests_effects/test_mosaic_trace_list.py
@@ -1,0 +1,64 @@
+"""Unit tests for mosaic_trace_list.py"""
+
+# pylint: disable=missing-function-docstring
+# pylint: disable=invalid-name
+# pylint: disable=too-few-public-methods
+import pytest
+
+import numpy as np
+
+from astropy.io import fits
+
+from scopesim.utils import power_vector
+from scopesim.effects.mosaic_trace_list import Transform1D
+
+@pytest.fixture(name="tf1d", scope="class")
+def fixture_tf1d():
+    """Instantiate a Transform1D"""
+    coeffs = np.array([2, -1, 1])
+    return Transform1D(coeffs)
+
+@pytest.fixture(name="quadratic", scope="class")
+def fixture_quadratic():
+    """Quadratic model, analytic and coeffients"""
+    coeffs = np.array([1, -1, 2])
+
+    def quadfunc(x):
+        z_a = 1 - 1 * x + 2 * x**2
+        return z_a
+
+    def dquad_dx(x):
+        return -1 + 4 * x
+
+    return {'coeffs': coeffs,
+            'function': quadfunc,
+            'gradient': dquad_dx}
+
+class TestTransform1D:
+    """Tests for Transform1D()"""
+    def test_initialises_with_coeffs(self, tf1d):
+        assert isinstance(tf1d, Transform1D)
+
+    def test_call_gives_correct_result(self, quadratic):
+        x = np.random.randn()
+
+        # coefficients and explicit function
+        tf1d = Transform1D(quadratic['coeffs'])
+        assert tf1d(x) == quadratic['function'](x)
+
+    def test_gradient_gives_correct_result(self, quadratic):
+        x = np.random.randn()
+
+        tf2d = Transform1D(quadratic['coeffs'])
+        tf2d_grad = tf2d.gradient()
+
+        assert tf2d_grad(x) == quadratic['gradient'](x)
+
+    def test_fit_gives_correct_coeffs(self):
+        x = np.linspace(0, 1, 10)
+        y = 1 - 0.5 * x + 2.3 * x**2 - 3 * x**3
+
+        coeffs = np.array([1, -0.5, 2.3, -3])
+        tf1d = Transform1D.fit(x, y, degree=3)
+
+        assert tf1d.coeffs == pytest.approx(coeffs)


### PR DESCRIPTION
This PR implements Scopesim functionality that enables a very simple ETC-like implementation of MOSAIC. The main effect is `MosaicSpectralTraceList`, which collapses FOV cube to one-dimensional spectra by integrating over the fibre apertures and maps the 1D spectra onto the ImagePlane. The second new effect is `MosaicCollapseSpectralTraces` which adds up all the 1D spectra from the fibre bundle into a total spectrum. This is saved as a FITS table. 
Since the effects are implemented in an instrument-specific manner, no existing functionality should be affected by this PR.   
The PR has tests for the new `Transform1D` class but for the traces and trace lists it relies on tests for the parent classes.