### PR TITLE
Use `RegularGridInterpolator` for proper extrapolation of small PSF images

### DIFF
--- a/scopesim/effects/psfs/discrete.py
+++ b/scopesim/effects/psfs/discrete.py
@@ -7,7 +7,8 @@ import numpy as np
 from tqdm.auto import tqdm
 from scipy.signal import convolve
 from scipy.ndimage import zoom
-from scipy.interpolate import RectBivariateSpline, griddata
+from scipy.interpolate import (RectBivariateSpline, griddata,
+                               RegularGridInterpolator)
 
 from astropy import units as u
 from astropy.io import fits
@@ -151,6 +152,7 @@ class FieldConstantPSF(DiscretePSF):
             lam = np.array([lam[len(lam)//2]])
 
         # adapt the size of the output cube to the FOV's spatial shape
+        # TODO: Replace 512 by something else
         nxpsf = min(512, 2 * nxfov + 1)
         nypsf = min(512, 2 * nyfov + 1)
 
@@ -173,10 +175,11 @@ class FieldConstantPSF(DiscretePSF):
 
         # We need linear interpolation to preserve positivity. Might think of
         # more elaborate positivity-preserving schemes.
-        # Note: According to some basic profiling, this line is one of the
-        #       single largest hits on performance.
-        ipsf = RectBivariateSpline(np.arange(nyin), np.arange(nxin), psf,
-                                   kx=1, ky=1)
+        # An alternative would be to use method 'pchip', which uses monotonic
+        # splines to prevent overshooting (including to negative values)
+        ipsf = RegularGridInterpolator((np.arange(nyin), np.arange(nxin)),
+                                       psf, method='linear', bounds_error=False,
+                                       fill_value=0)
 
         xcube, ycube = np.meshgrid(np.arange(nxpsf), np.arange(nypsf))
         cubewcs = WCS(naxis=2)
@@ -197,7 +200,7 @@ class FieldConstantPSF(DiscretePSF):
             psfwcs.wcs.cdelt = [psf_wave_pixscale,
                                 psf_wave_pixscale]
             xpsf, ypsf = psfwcs.all_world2pix(xworld, yworld, 0)
-            outcube[i,] = (ipsf(ypsf, xpsf, grid=False)
+            outcube[i,] = (ipsf( (ypsf.ravel(), xpsf.ravel()) ).reshape(outcube[i,].shape)
                            * fov_pixel_scale**2 / psf_wave_pixscale**2)
 
         # .squeeze() gets rid of any axes with length one


### PR DESCRIPTION
This fixes #797 .
- The interpolator has been changed from `RectBilinearSpline` to `RegularGridInterpolator`. While the interface is more cumbersome it has better support for extrapolation - here we need `fill_value=0`. We still use linear interpolation but might consider using `pchip`; tests are needed.
- The spatial size of the scaled PSF cube is at most twice the slit size (ensures full coverage of the slit by the psf), otherwise it takes the size of the input PSF image. This can be further reduced by setting the parameter `cmd["!SIM.computing.psf_maxsize"]`; this can be done to improve computation speed at the expense of accuracy.