### PR TITLE
Allow log level to be lower case

### DIFF
--- a/scopesim/tests/test_logging.py
+++ b/scopesim/tests/test_logging.py
@@ -58,3 +58,5 @@ def test_set_console_log_level():
     assert base_logger.handlers[0].level == logging.ERROR
     sim.set_console_log_level()
     assert base_logger.handlers[0].level == logging.INFO
+    sim.set_console_log_level("debug")
+    assert base_logger.handlers[0].level == logging.DEBUG

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -919,7 +919,7 @@ def set_console_log_level(level="INFO"):
 
     .. versionadded:: 0.8.0
     """
-    rc.__logging_config__["handlers"]["console"]["level"] = level
+    rc.__logging_config__["handlers"]["console"]["level"] = level.upper()
     update_logging()
 
 


### PR DESCRIPTION
`set_console_log_level` uses `level.upper()` to allow users to specify `level` in lower (or mixed...) case, e.g. `set_console_log_level('debug')`. 