### PR TITLE
Rename `Effect.__getitem__()` ➡️ `.get_from_meta()`

### DIFF
--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -302,23 +302,29 @@ Meta-data
         else:
             p.text(str(self))
 
-    def __getitem__(self, item):
-        if isinstance(item, str) and item.startswith("#"):
-            if len(item) > 1:
-                if item.endswith("!"):
-                    key = item.removeprefix("#").removesuffix("!")
-                    if len(key) > 0:
-                        value = from_currsys(self.meta[key], self.cmds)
-                    else:
-                        value = from_currsys(self.meta, self.cmds)
-                else:
-                    value = self.meta[item.removeprefix("#")]
-            else:
-                value = self.meta
-        else:
-            raise ValueError(f"__getitem__ calls must start with '#': {item}")
+    def get_from_meta(self, item: str):
+        if not isinstance(item, str):
+            raise TypeError("Effect.resolve_meta() needs a string.")
 
-        return value
+        if not item.startswith("#"):
+            raise ValueError(f"resolve_meta calls must start with '#': {item}")
+
+        if len(item) == 1:
+            return self.meta  # When do we actually need/want this??
+
+        key = item.removeprefix("#")
+
+        if not key.endswith("!"):
+            return self.meta[key]
+
+        key = key.removesuffix("!")
+        if key == "":
+            return from_currsys(self.meta, self.cmds)
+
+        return from_currsys(self.meta[key], self.cmds)
+
+    def __getitem__(self, item):
+        return self.get_from_meta(item)
 
     def _get_path(self):
         if any(key not in self.meta for key in ("path", "filename_format")):

--- a/scopesim/optics/optical_element.py
+++ b/scopesim/optics/optical_element.py
@@ -180,7 +180,7 @@ class OpticalElement:
     def __add__(self, other) -> None:
         self.add_effect(other)
 
-    def __getitem__(self, item):
+    def get_from_meta(self, item):
         """
         Return Effects of Effect meta properties.
 
@@ -218,7 +218,7 @@ class OpticalElement:
         elif isinstance(item, str):
             if item.startswith("#") and "." in item:
                 eff, meta = item.replace("#", "").split(".")
-                obj = self[eff][f"#{meta}"]
+                obj = self[eff].get_from_meta(f"#{meta}")
             else:
                 obj = [eff for eff in self.effects
                        if eff.meta["name"] == item]
@@ -230,6 +230,9 @@ class OpticalElement:
         #         "No result for key: '%s'. Did you mean '#%s'?", item, item)
 
         return obj
+
+    def __getitem__(self, item):
+        return self.get_from_meta(item)
 
     def write_string(self, stream: TextIO, list_effects: bool = True) -> None:
         """Write formatted string representation to I/O stream."""

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -341,7 +341,7 @@ Summary of Effects in Optical Elements:
             if item.startswith("#") and "." in item:
                 opt_el_name = item.replace("#", "").split(".")[0]
                 new_item = item.replace(f"{opt_el_name}.", "")
-                obj = self[opt_el_name][new_item]
+                obj = self[opt_el_name].get_from_meta(new_item)
             else:
                 # get all optical elements that match "item"
                 obj = [opt_el for opt_el in self.optical_elements


### PR DESCRIPTION
And adapt to changes elsewhere. The `.__getitem__()` still wraps the new name by default, to avoid breaking existing code, but this will throw a DeprecationWarning in v0.12. Should solve #644, because `.__getitem__()` can now savely be overloaded by subclasses, without breaking the meta resolving required by the fits header effects.