### PR TITLE
Use lower case photlam for headers

### DIFF
--- a/scopesim/effects/metis_wcu/fpmask.py
+++ b/scopesim/effects/metis_wcu/fpmask.py
@@ -43,7 +43,7 @@ class FPMask:
         "CUNIT2": "arcsec",
         "CDELT1": 0.00547,
         "CDELT2": 0.00547,
-        "BUNIT": "PHOTLAM arcsec-2",
+        "BUNIT": "photlam arcsec-2",
         "SOLIDANG": "arcsec-2",
     }
 

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -174,7 +174,7 @@ class TERCurve(Effect):
                 # "CUNIT2": "ARCSEC",
                 # "CDELT1": 0,
                 # "CDELT2": 0,
-                "BUNIT": "PHOTLAM arcsec-2",
+                "BUNIT": "photlam arcsec-2",
                 "SOLIDANG": "arcsec-2",
             })
             bkg_fld = BackgroundSourceField(field=None, spectra=bkg_spec, header=bkg_hdr)

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -362,7 +362,7 @@ class OpticalTrain:
 
             data = (data * factor).value
 
-            cube.header["BUNIT"] = "PHOTLAM/arcsec2"    # ..todo: make this more explicit?
+            cube.header["BUNIT"] = "photlam/arcsec2"    # ..todo: make this more explicit?
 
             # The imageplane_utils like to have the spatial WCS in units of "deg". Ensure
             # that the cube is passed on accordingly

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -307,7 +307,8 @@ class HDUSourceField(SourceField):
         .. versionadded:: PLACEHOLDER_NEXT_RELEASE_VERSION
 
         """
-        return u.Unit(self.header.get("BUNIT", ""))
+        value = self.header.get("BUNIT", "").replace("PHOTLAM", "photlam")
+        return u.Unit(value)
 
     @property
     def is_bunit_spatially_differential(self) -> bool:

--- a/scopesim/source/source_templates.py
+++ b/scopesim/source/source_templates.py
@@ -219,7 +219,7 @@ def uniform_illumination(xs, ys, pixel_scale, flux=None, spectrum=None):
         scale_factor = pixel_scale ** 2 * 10 ** (-0.4 * flux)
     elif spectrum is not None:
         spec = spectrum
-        mag_unit = "PHOTLAM"
+        mag_unit = "photlam"
         scale_factor = pixel_scale ** 2
     else:
         raise ValueError(f"Either flux or spectrum must be passed: {flux}, {spectrum}")


### PR DESCRIPTION
Apparently, FITS keywords values should be `"photlam"` rather than `"PHOTLAM"`. `astropy.units.Unit("PHOTLAM")` throws a `ValueError`, whereas `astropy.units.Unit("photlam")` works fine (after importing `synphot.units.PHOTLAM`). This PR fixes all occurrences where scopesim sets `BUNIT` explicitely. In addition another `bunit.replace("PHOTLAM", "photlam")` is introduced  so that scopesim should work with `"PHOTLAM"`, although that is discouraged. 

Cf. https://github.com/AstarVienna/irdb/pull/281 for notebook tests