### PR TITLE
Clean up FieldVaryingPSF

### DIFF
--- a/scopesim/effects/psfs/discrete.py
+++ b/scopesim/effects/psfs/discrete.py
@@ -290,10 +290,9 @@ class FieldVaryingPSF(DiscretePSF):
                 canvas = np.zeros(new_image.shape)
 
             # mask convolution + combine with convolved image
-            mask = None    # TODO: remove
             if mask is not None:
-                new_mask = convolve(mask, kernel, mode="same")
-                canvas += (new_image + bkg_level) * new_mask
+                #new_mask = convolve(mask, kernel, mode="same")
+                canvas += (new_image + bkg_level) * mask
             else:
                 canvas = new_image + bkg_level
 


### PR DESCRIPTION
Cf. Issue #825 . This PR does the following in `FieldVaryingPSF.apply_to()`:
- Subtract background before convolution as in `PSF.apply_to()`
- Apply `PSF._round_kernel_edges` (this could maybe include circular cosine tapering?)
- Set `mask = None` to get a clean background. This needs to be discussed, as there was certainly some purpose to using these masks.