### PR TITLE
Remove numpy deprecation warning

### DIFF
--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -407,10 +407,10 @@ class MetisLMSSpectralTrace(SpectralTrace):
             for i in range(4):
                 for j in range(4):
                     sel_ij = (subpoly["Row"] == i) * (subpoly["Col"] == j)
-                    thematrix[i, j] = (subpoly["P3"][sel_ij] * angle**3 +
-                                       subpoly["P2"][sel_ij] * angle**2 +
-                                       subpoly["P1"][sel_ij] * angle +
-                                       subpoly["P0"][sel_ij])
+                    thematrix[i, j] = (subpoly["P3"][sel_ij][0] * angle**3 +
+                                       subpoly["P2"][sel_ij][0] * angle**2 +
+                                       subpoly["P1"][sel_ij][0] * angle +
+                                       subpoly["P0"][sel_ij][0])
 
             matrices[matnames[matid]] = thematrix
 


### PR DESCRIPTION
A little fix to attend to a numpy deprecation warning:
```
py.warnings - WARNING: /home/oczoske/ELT_Development/ScopeSim/scopesim/effects/metis_lms_trace_list.py:410: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  thematrix[i, j] = (subpoly["P3"][sel_ij] * angle**3 +
```
`subpoly` had to be further indexed with `[0]` (this is safe as `sel_ij` is supposed to select a single value anyway).