### PR TITLE
Interactive updating of SkycalcTERCurve

### DIFF
--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -440,6 +440,14 @@ class SkycalcTERCurve(AtmosphericTERCurve):
         if item is True and self.skycalc_table is None:
             self.load_skycalc_table()
 
+    ## Nice to have, but would need a setter
+    ##        self.parameters['pwv'] = 20.
+    ## This would have to set self.meta['pwv'] at the same time,
+    ## otherwise meta would always override.
+    #@property
+    #def parameters(self):
+    #    return self.skycalc_conn.values
+
     def load_skycalc_table(self):
         """Download skycalc table based on the current parameters"""
         use_local_file = from_currsys(self.meta["use_local_skycalc_file"],
@@ -502,7 +510,9 @@ class SkycalcTERCurve(AtmosphericTERCurve):
 
     def update(self, **kwargs):
         """Update the skycalc table with new parameter values"""
+        # Needed to update the source field
         self._background_source = None
+
         # Validate parameters
         for key in kwargs:
             if key not in self.skycalc_conn.keys:

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -318,21 +318,21 @@ class AtmoLibraryTERCurve(AtmosphericTERCurve):
             remote_filename = from_currsys(kwargs["remote_filename"], cmds)
             kwargs["filename"] = self._download_library(remote_filename)
 
+        self.param = 'pwv'
         super().__init__(cmds=cmds, **kwargs)
         self.meta.update(kwargs)
         self.load_table_from_library()
 
     def update(self, **kwargs):
         """Update the atmo library."""
-        param = 'pwv'
-        if param not in kwargs:
-            logger.warning("Can only update with parameter %s", param)
+        if self.param not in kwargs:
+            logger.warning("Can only update with parameter %s", self.param)
             return
 
         if "remote_filename" in kwargs:
             kwargs["filename"] = self._download_library(kwargs["remote_filename"])
 
-        self.meta[param] = kwargs[param]
+        self.meta[self.param] = kwargs[self.param]
         self.load_table_from_library()
 
     @staticmethod
@@ -371,6 +371,13 @@ class AtmoLibraryTERCurve(AtmosphericTERCurve):
 
         self.surface.table = tbl
         self.surface.meta.update(tbl.meta)
+
+    def __str__(self) -> str:
+        """Return str(self)."""
+        msg = (f"{self.__class__.__name__}: \"{self.display_name}\"\n"
+               f"  - Parameter: {self.param} = {self.value}\n"
+               )
+        return msg
 
 
 class SkycalcTERCurve(AtmosphericTERCurve):

--- a/scopesim/optics/surface.py
+++ b/scopesim/optics/surface.py
@@ -185,14 +185,14 @@ class SpectralSurface:
             response_curve : ``synphot.SpectralElement``
 
         """
-        compliment_names = ["transmission", "emissivity", "reflection"]
-        ii = np.where([ter_property == name for name in compliment_names])[0][0]
-        compliment_names.pop(ii)
+        complement_names = ["transmission", "emissivity", "reflection"]
+        ii = np.where([ter_property == name for name in complement_names])[0][0]
+        complement_names.pop(ii)
 
         wave = self._get_array("wavelength")
         value_arr = self._get_array(ter_property)
         if value_arr is None:
-            value_arr = self._compliment_array(*compliment_names)
+            value_arr = self._complement_array(*complement_names)
 
         if value_arr is not None and wave is not None and fmt == "synphot":
             response_curve = SpectralElement(Empirical1D, points=wave,
@@ -205,9 +205,9 @@ class SpectralSurface:
 
         return response_curve
 
-    def _compliment_array(self, colname_a, colname_b):
+    def _complement_array(self, colname_a, colname_b):
         """
-        Return an complimentary array using: ``a + b + c = 1``.
+        Return an complementary array using: ``a + b + c = 1``.
 
         E.g. ``Emissivity = 1 - (Transmission + Reflection)``
 
@@ -221,20 +221,18 @@ class SpectralSurface:
         Returns
         -------
         actual : ``synphot.SpectralElement``
-            Complimentary spectrum to those given
+            Complementary spectrum to those given
 
         """
-        compliment_a = self._get_array(colname_a)
-        compliment_b = self._get_array(colname_b)
-
-        if compliment_a is not None and compliment_b is not None:
-            actual = 1 * compliment_a.unit - (compliment_a + compliment_b)
-        elif compliment_a is not None and compliment_b is None:
-            actual = 1 * compliment_a.unit - compliment_a
-        elif compliment_b is not None and compliment_a is None:
-            actual = 1 * compliment_b.unit - compliment_b
-        elif compliment_b is None and compliment_a is None:
-            actual = None
+        complement_a = self._get_array(colname_a)
+        complement_b = self._get_array(colname_b)
+        actual = None
+        if complement_a is not None and complement_b is not None:
+            actual = 1 * complement_a.unit - (complement_a + complement_b)
+        elif complement_a is not None and complement_b is None:
+            actual = 1 * complement_a.unit - complement_a
+        elif complement_b is not None and complement_a is None:
+            actual = 1 * complement_b.unit - complement_b
 
         return actual
 

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -449,4 +449,4 @@ class BackgroundSourceField(SpectrumSourceField):
         return np.array([-np.inf, np.inf])
 
     def _write_stream(self, stream: TextIO) -> None:
-        stream.write(f"Background field ref. spectrum {self.spectrum[0]}")
+        stream.write(f"Background field ref. spectrum {self.spectrum}")

--- a/scopesim/tests/tests_optics/test_SpectralSurface.py
+++ b/scopesim/tests/tests_optics/test_SpectralSurface.py
@@ -3,7 +3,7 @@
 # pylint: disable=missing-function-docstring
 
 # 1 read in a table
-# 2 compliment the table based on columns in file
+# 2 complement the table based on columns in file
 # 3 have @property methods for: transmission, ermission, reflection
 
 import pytest
@@ -142,7 +142,7 @@ class TestSpectralSurfaceEmissionProperty:
                            srf.emission(wave))
 
 
-class TestSpectralSurfaceComplimentArray:
+class TestSpectralSurfaceComplementArray:
     @pytest.mark.parametrize("colname1, colname2, col1, col2, expected",
                              [("A", "B", [0.8]*u.um, [0.1]*u.um, [0.1]*u.um),
                               ("A", "B", [0.8]*u.um, None,       [0.2]*u.um),
@@ -152,7 +152,7 @@ class TestSpectralSurfaceComplimentArray:
         srf = opt_surf.SpectralSurface()
         srf.meta[colname1] = col1
         srf.meta[colname2] = col2
-        col3 = srf._compliment_array(colname1, colname2)
+        col3 = srf._complement_array(colname1, colname2)
         assert np.allclose(col3.data, expected.data)
         assert col3.unit == expected.unit
 
@@ -163,7 +163,7 @@ class TestSpectralSurfaceComplimentArray:
         srf = opt_surf.SpectralSurface()
         srf.meta[colname1] = col1
         srf.meta[colname2] = col2
-        col3 = srf._compliment_array(colname1, colname2)
+        col3 = srf._complement_array(colname1, colname2)
         assert col3 is None
 
     @pytest.mark.parametrize("col2_arr, expected",
@@ -177,7 +177,7 @@ class TestSpectralSurfaceComplimentArray:
         if col2_arr:
             srf.table.add_column(Column(name="col2", data=col2_arr))
 
-        col3 = srf._compliment_array("col1", "col2")
+        col3 = srf._complement_array("col1", "col2")
         assert col3.data == pytest.approx(expected)
         assert len(col3.data) == len(expected)
 


### PR DESCRIPTION
`SkycalcTERCurve` gains a prettier `__str__` and can be updated on the fly with, e.g.,
```
metis['skycalc_atmosphere'].update(pwv=20, airmass=3)
```

(the name of the branch is somewhat misleading as there is only a small change to `AtmoLibraryTERCurve`)