### PR TITLE
Transmission curves to extrapolate with value 0

### DIFF
--- a/scopesim/effects/ter_curves_utils.py
+++ b/scopesim/effects/ter_curves_utils.py
@@ -131,7 +131,7 @@ def download_svo_filter(filter_name, return_style="synphot"):
     trans = votbl.array["Transmission"].data
 
     if return_style == "synphot":
-        return SpectralElement(Empirical1D, points=wave, lookup_table=trans)
+        return SpectralElement(Empirical1D, points=wave, lookup_table=trans, fill_value=0.)
     if return_style == "table":
         filt = Table(data=[wave, trans], names=["wavelength", "transmission"])
         filt.meta["wavelength_unit"] = str(wave.unit)
@@ -200,7 +200,8 @@ def get_filter(filter_name):
         tbl = ioascii.read(path)
         wave = quantity_from_table("wavelength", tbl, u.um).to(u.um)
         filt = SpectralElement(Empirical1D, points=wave,
-                               lookup_table=tbl["transmission"])
+                               lookup_table=tbl["transmission"],
+                               fill_value=0.)
     elif filter_name in FILTER_DEFAULTS:
         filt = download_svo_filter(FILTER_DEFAULTS[filter_name])
     else:


### PR DESCRIPTION
Some SVO filters (e.g. NACO filters) do not drop to zero transmission at the edges of their wavelength range. Scopesim's `download_svo_filter` used to create synphot `SpectralElements` with (implicit) `fill_value=nan`, which means that the filter curves are extrapolated with constant values equal to the edge values, resulting in potentially huge leaks. This PR sets `fill_value=0.` explicitely, removing those leaks.

This fixes the main discrepancy in https://github.com/AstarVienna/HowManyBloodyPhotons/issues/40.