### PR TITLE
WCU flux mismatch

### DIFF
--- a/scopesim/effects/metis_wcu/fpmask.py
+++ b/scopesim/effects/metis_wcu/fpmask.py
@@ -64,6 +64,7 @@ class FPMask:
         if maskname == "open":
             self.holehdu = fits.ImageHDU()
             self.holehdu.header.update(self.hdr)
+            self.holehdu.header['BG_SURF'] = "WCU FP mask open"
             self.opaquehdu = None
         else:
             # Try to find the file as a path
@@ -88,11 +89,13 @@ class FPMask:
         """
         holehdu = fits.ImageHDU()
         holehdu.header.update(header)
+        holehdu.header['BG_SURF'] = f"WCU FP mask {self.name} holes"
         holehdu.data = np.zeros((2047, 2047))
 
         opaquehdu = fits.ImageHDU()
         opaquehdu.header.update(header)
-        opaquehdu.data = np.ones((2047, 2047)) * self.pixarea.value
+        opaquehdu.header['BG_SURF'] = f"WCU FP mask {self.name} opaque"
+        opaquehdu.data = np.ones((2047, 2047)) #* self.pixarea.value
 
         # Hole locations
         tab = self.data_container.table
@@ -118,7 +121,7 @@ class FPMask:
             holearea = (d/2)**2 * np.pi
             xint, yint, fracs = sub_pixel_fractions(x, y)
             holehdu.data[yint, xint] = np.array(fracs) * holearea
-            opaquehdu.data[yint, xint] *= 1 - np.array(fracs) * holearea/self.pixarea.value
+            opaquehdu.data[yint, xint] *= 1 - np.array(fracs) * holearea#/self.pixarea.value
 
         self.xpix = xpix
         self.ypix = ypix

--- a/scopesim/effects/metis_wcu/fpmask.py
+++ b/scopesim/effects/metis_wcu/fpmask.py
@@ -118,7 +118,7 @@ class FPMask:
         in_field = (xpix > 0) * (xpix < 2047) * (ypix > 0) * (ypix < 2047)
 
         for x, y, d in zip(xpix[in_field], ypix[in_field], diam[in_field]):
-            holearea = (d/2)**2 * np.pi
+            holearea = (d/2)**2 * np.pi / self.pixarea.value  # effective no. of pixels
             xint, yint, fracs = sub_pixel_fractions(x, y)
             holehdu.data[yint, xint] = np.array(fracs) * holearea
             opaquehdu.data[yint, xint] *= 1 - np.array(fracs) * holearea#/self.pixarea.value

--- a/scopesim/effects/metis_wcu/fpmask.py
+++ b/scopesim/effects/metis_wcu/fpmask.py
@@ -32,7 +32,7 @@ class FPMask:
 
     hdr = {
         "BG_SRC": True,
-        "BG_SURF": "WCU focal plane mask",  # TODO: more specific?
+        "BG_SURF": "WCU focal plane mask",
         "CTYPE1": "LINEAR",
         "CTYPE2": "LINEAR",
         "CRPIX1": 1024.5,
@@ -90,12 +90,12 @@ class FPMask:
         holehdu = fits.ImageHDU()
         holehdu.header.update(header)
         holehdu.header['BG_SURF'] = f"WCU FP mask {self.name} holes"
-        holehdu.data = np.zeros((2047, 2047))
+        holehdu.data = np.zeros((2047, 2047), dtype=np.float32)
 
         opaquehdu = fits.ImageHDU()
         opaquehdu.header.update(header)
         opaquehdu.header['BG_SURF'] = f"WCU FP mask {self.name} opaque"
-        opaquehdu.data = np.ones((2047, 2047)) #* self.pixarea.value
+        opaquehdu.data = np.ones((2047, 2047), dtype=np.float32)
 
         # Hole locations
         tab = self.data_container.table
@@ -118,10 +118,11 @@ class FPMask:
         in_field = (xpix > 0) * (xpix < 2047) * (ypix > 0) * (ypix < 2047)
 
         for x, y, d in zip(xpix[in_field], ypix[in_field], diam[in_field]):
-            holearea = (d/2)**2 * np.pi / self.pixarea.value  # effective no. of pixels
+            # holearea is the effective number of pixels covered by the hole
+            holearea = (d/2)**2 * np.pi / self.pixarea.value
             xint, yint, fracs = sub_pixel_fractions(x, y)
             holehdu.data[yint, xint] = np.array(fracs) * holearea
-            opaquehdu.data[yint, xint] *= 1 - np.array(fracs) * holearea#/self.pixarea.value
+            opaquehdu.data[yint, xint] *= 1 - np.array(fracs) * holearea
 
         self.xpix = xpix
         self.ypix = ypix

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -154,7 +154,7 @@ class WCUSource(TERCurve):
                                              header=hole_hdu.header)
             hole_src = Source(field=hole_fld)
         else:
-            hole_src = Source(image_hdu=self.fpmask.holehdu, spectra=bb_flux)
+            hole_src = Source(image_hdu=self.fpmask.holehdu, spectra=[bb_flux])
 
         self._background_source.append(hole_src)
 
@@ -170,7 +170,7 @@ class WCUSource(TERCurve):
                 opaque_src = Source(field=opaque_fld)
             else:
                 opaque_src = Source(image_hdu=self.fpmask.opaquehdu,
-                                    spectra=mask_flux)
+                                    spectra=[mask_flux])
             self._background_source.append(opaque_src)
 
         return self._background_source
@@ -423,13 +423,17 @@ class WCUSource(TERCurve):
         lam = self.wavelength
         dlam = lam[1] - lam[0]
 
+        mult_is = self.is_multiplication(lam)
+
         # Laser 1 (L band)  # TODO move to yaml
         lamc_l = 3.39 * u.um
         power_l = 5e-3 * u.W / (c.c * c.h / lamc_l) * u.ph
+
         # Laser 2 (tunable), power divided among multiple lines
         lam_t = seq(4.68, 4.78, 0.01) * u.um
         nline = len(lam_t)
         power_t = 70e-3 * u.W / (c.c * c.h / lam) * u.ph / nline
+
         # Laser 3 (M band)
         lamc_m = 5.26 * u.um
         power_m = 20e-3 * u.W / (c.c * c.h / lamc_m) * u.ph
@@ -441,9 +445,12 @@ class WCUSource(TERCurve):
         line_m = Gaussian1D(amplitude=amp, mean=lamc_m, stddev=sigma)
         list_t = [Gaussian1D(amplitude=amp, mean=ll, stddev=sigma) for ll in lam_t]
         line_t = sum(list_t[1:], start=list_t[0])
+
         flux = ((power_l * line_l(lam) + power_m * line_m(lam) + power_t
-                 * line_t(lam)) / (np.pi * self.d_is_in**2 / 4))
-        intens = flux / (np.pi * u.sr)
+                 * line_t(lam)) / (np.pi * self.d_is**2 / 4))
+
+        intens = mult_is * flux / (np.pi * u.sr)
+
         return intens.to(self.bb_scale)
 
     def compute_fp_emission(self):

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -3,8 +3,8 @@
 # pylint: disable=missing-class-docstring
 # pylint: disable=missing-function-docstring
 
-import pytest
 from unittest.mock import patch
+import pytest
 
 import numpy as np
 from astropy import units as u
@@ -240,8 +240,9 @@ class TestFPMask:
 
     def test_data_correct(self, fpmask):
         assert fpmask.holehdu.data[241, 1943] == 0
-        assert fpmask.holehdu.data[1023, 1023] < np.pi * (0.007532**2) / 4
-        assert fpmask.holehdu.data[1021:1025, 1021:1025].sum() == np.pi * (0.007532**2) / 4
+        assert fpmask.holehdu.data[1023, 1023] < 1
+        assert fpmask.holehdu.data[1021:1025, 1021:1025].sum() == pytest.approx(
+            np.pi * (0.007532**2) / 4 / fpmask.pixarea.value)
         assert (fpmask.opaquehdu.data[1023, 1023] + fpmask.holehdu.data[1023, 1023]
-                == fpmask.pixarea.value)
-        assert fpmask.opaquehdu.data[748, 1308] == fpmask.pixarea.value
+                == 1)
+        assert fpmask.opaquehdu.data[748, 1308] == 1.


### PR DESCRIPTION
This started out with the observation that the flux of the laser lamps through the pinhole mask of the METIS WCU was too low (#850). While looking into this it was noticed that the background flux (with lamp off) without and with a focal-plane mask inserted was not identical. The expected ratio is 0.95, which is the emissivity of the integrating sphere, whereas the emissivity of the (opaque parts of the) focal-plane mask is taken to be 1. The observed ratio was more like 20. This PR makes these values consistent by setting the values of the `holehdu` and `opaquehdu`, which define the FPMask, in terms of pixels rather than solid angles as before. 

While consistent, it is currently not clear that it is also correct. Running the `METIS_WCU.ipynb` notebook shows that the signal from the black-body source through the open FPMask  is lower than it used to be. If that is true, then the problem may  be not with the FPMask but with the black-body source (which is a `TERCurve` without an hdu). **Update:** The difference can be explained through the new pupil mask (PPS-LM instead  of open) and averaging and gain of the detector readouts. The notebook still needs to be updated.

Closes #850 