### PR TITLE
Extrapolate all transmissions with 0

### DIFF
--- a/scopesim/optics/surface.py
+++ b/scopesim/optics/surface.py
@@ -194,9 +194,12 @@ class SpectralSurface:
         if value_arr is None:
             value_arr = self._complement_array(*complement_names)
 
+        fill_value = 0. if ter_property == "transmission" else None
+
         if value_arr is not None and wave is not None and fmt == "synphot":
             response_curve = SpectralElement(Empirical1D, points=wave,
-                                             lookup_table=value_arr)
+                                             lookup_table=value_arr,
+                                             fill_value=fill_value)
         elif fmt == "array":
             response_curve = value_arr
         else:

--- a/scopesim/optics/surface.py
+++ b/scopesim/optics/surface.py
@@ -194,7 +194,7 @@ class SpectralSurface:
         if value_arr is None:
             value_arr = self._complement_array(*complement_names)
 
-        fill_value = 0. if ter_property == "transmission" else None
+        fill_value = 0. if ter_property == "transmission" else np.nan
 
         if value_arr is not None and wave is not None and fmt == "synphot":
             response_curve = SpectralElement(Empirical1D, points=wave,

--- a/scopesim/tests/tests_effects/test_MetisLMSEfficiency.py
+++ b/scopesim/tests/tests_effects/test_MetisLMSEfficiency.py
@@ -41,7 +41,7 @@ class TestMetisLMSEfficiency:
     @pytest.mark.parametrize("lam0, lam, expected",
                              [(3.65, 3.60, 0.127914),
                               (4.80, 4.83, 0.578098),
-                              (4.10, 4.30, 0.023711)])
+                              (4.10, 4.299999, 0.023711)])
     def test_gives_correct_throughput(self, lam0, lam, expected):
         eff = MetisLMSEfficiency(wavelen=lam0, filename="TRACE_LMS.fits")
         eff_trans = eff.surface.transmission(lam * 1e4).value


### PR DESCRIPTION
Following report on Slack, explicitely extrapolate filter curves with zero transmission outside of definition wavelength range.