### PR TITLE
Read fp_mask_{}.dat explicitely as float

### DIFF
--- a/scopesim/effects/metis_wcu/fpmask.py
+++ b/scopesim/effects/metis_wcu/fpmask.py
@@ -52,7 +52,7 @@ class FPMask:
         maskname: Path | str | None = None,
         fpmask_filename_format: str | None = None,
         angle: float = 0,
-        shift: tuple[float, float] = (0, 0),
+        shift: tuple[float, float] = (0., 0.),
         **kwargs
     ):
         logger.debug("Initialising FPMask with %s", maskname)
@@ -99,9 +99,9 @@ class FPMask:
 
         # Hole locations
         tab = self.data_container.table
-        xhole = tab["x"].data
-        yhole = tab["y"].data
-        diam = tab["diam"].data
+        xhole = tab["x"].data.astype(float)
+        yhole = tab["y"].data.astype(float)
+        diam = tab["diam"].data.astype(float)
 
         if self.angle != 0:
             rangle = np.deg2rad(self.angle)

--- a/scopesim/tests/mocks/files/fp_mask_pinhole_int.dat
+++ b/scopesim/tests/mocks/files/fp_mask_pinhole_int.dat
@@ -1,0 +1,18 @@
+# description : WCU focal plane mask, pinhole
+# author : Oliver Czoske
+# source : ...
+# date_created : 2024-11-06
+# date_modified : 2024-11-06
+# status : preliminary fantasy values
+# type : aperture:aperture_mask
+# x_unit : arcsec
+# y_unit : arcsec
+# diam_unit : arcsec
+# notes : use plate scale 3.319 mm / arcsec
+# changes :
+#     - 2025-01-09 :  (OC) change format
+#     - 2026-01-23 :  (OC) initialise as int to test Scopesim#868
+#
+ x   y    diam
+ 0   0    0.007532
+ 1   1    0.007532

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -209,6 +209,12 @@ def fixture_pinholemask(mock_path):
     return FPMask(maskname="pinhole",
                   fpmask_filename_format=str(mock_path / "fp_mask_{}.dat"))
 
+@pytest.fixture(name="pinholemask_int", scope="function")
+def fixture_pinholemask_int(mock_path):
+    return FPMask(
+        maskname=str(mock_path / "fp_mask_pinhole_int.dat"),
+        shift=(0.4,-0.3))
+
 class TestFPMask:
     def test_fpmask_initialises_correctly(self, fpmask):
         assert isinstance(fpmask, FPMask)
@@ -246,3 +252,7 @@ class TestFPMask:
         assert (fpmask.opaquehdu.data[1023, 1023] + fpmask.holehdu.data[1023, 1023]
                 == 1)
         assert fpmask.opaquehdu.data[748, 1308] == 1.
+
+    def test_no_error_with_integer_positions(self, pinholemask_int):
+        """Tests that the bug in Scopesim#868 does not occur"""
+        assert isinstance(pinholemask_int, FPMask)


### PR DESCRIPTION
Positions for the pinhole in the METIS WCU focal-plane mask were given as `(0, 0)` in e.g. `fp_mask_pinhole_lm.dat` (in the irdb). The hole positions were then initialised as `int`. In combination with a `shift` argument given as `float` (e.g. 0.5) this caused an error since the shift is applied in-place via `+=`.  This PR converts the entries in the mask table explicitely to `float` since that is the assumed data type for hole positions anyway.  

Closes #868 