### PR TITLE
Pixel area must be positive

### DIFF
--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -358,6 +358,7 @@ class OpticalTrain:
                 # ..todo: lower needed because "DEG" is not understood, this is ugly
                 pixarea = (header["CDELT1"] * u.Unit(header["CUNIT1"].lower()) *
                            header["CDELT2"] * u.Unit(header["CUNIT2"].lower())).to(u.arcsec**2)
+                pixarea = np.abs(pixarea)     # CDELTi can be negative, pixarea cannot
                 data = data / pixarea.value    # cube is per arcsec2
 
             data = (data * factor).value


### PR DESCRIPTION
The METIS/IFU notebook used an input cube in which `CDELT1` was negative. This resulted in a *negative* source trace imprinted on positive background. The reason is that `OpticalTrain.prepare_source()` divides the cube data by the pixel area (solid angle), which was computed from `CDELT1` and `CDELT2` and came out negative. This PR uses the absolute value of the pixel area so that the cube data remain positive.  