### PR TITLE
Document system transmission plot in getting_started

### DIFF
--- a/docs/source/getting_started.ipynb
+++ b/docs/source/getting_started.ipynb
@@ -318,6 +318,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "15efee46-576f-4aee-9dd9-3ab2fe68ba14",
+   "metadata": {},
+   "source": [
+    "### Inspecting the system transmission\n",
+    "\n",
+    "The total system transmission and the contribution from the individual elements in the optical train can be visualised as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80c0c1cd-cc6c-4015-9c7c-ed0bc5479c98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "simulation.optical_train.optics_manager.system_transmission(plot=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "labeled-railway",
    "metadata": {},
    "source": [
@@ -354,7 +374,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
#894 seems sufficiently useful to warrant inclusion in `getting_started.ipynb`. 