### PR TITLE
Fix PupilTransmission emission after update

### DIFF
--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -1065,7 +1065,7 @@ class PupilTransmission(TERCurve):
         """Set a new transmission value"""
         self.surface = SpectralSurface(wavelength=self.meta['wavelength'],
                                        transmission=[transmission, transmission],
-                                       emission=[0, 0])
+                                       emissivity=[0., 0.], **kwargs)
         self.meta.update(self.surface.meta)
 
 

--- a/scopesim/tests/tests_effects/test_PupilTransmission.py
+++ b/scopesim/tests/tests_effects/test_PupilTransmission.py
@@ -1,5 +1,7 @@
-import pytest
+"""Tests for PupilTransmission"""
+
 from unittest.mock import patch
+import pytest
 
 from astropy import units as u
 
@@ -8,7 +10,7 @@ from synphot.units import PHOTLAM
 from scopesim.effects.ter_curves import TERCurve
 from scopesim.effects.ter_curves import PupilTransmission
 
-# pylint: disable=no-self-use, missing-class-docstring
+# pylint: disable=missing-class-docstring
 # pylint: disable=missing-function-docstring
 
 THROUGHPUT = 0.764      # random value
@@ -35,7 +37,9 @@ class TestPupilTransmission:
     def test_has_zero_emission(self, pupilmask):
         assert pupilmask.emission(3.5 * u.um) == 0 * PHOTLAM
 
-    def test_update_transmission_works(self, pupilmask):
+    @pytest.mark.parametrize("newtrans", (0., 0.5))
+    def test_update_transmission_works(self, pupilmask, newtrans):
         assert pupilmask.throughput(3.5 * u.um) == THROUGHPUT
-        pupilmask.update_transmission(0.5)
-        assert pupilmask.throughput(3.5 * u.um) == 0.5
+        pupilmask.update_transmission(newtrans)
+        assert pupilmask.throughput(3.5 * u.um) == newtrans
+        assert pupilmask.emission(3.5 * u.um).unit == PHOTLAM


### PR DESCRIPTION
`PupilTransmission().update_transmission` used to reinstantiate `SpectralSurface` with `emission` without units, which caused `apply_to` to fail.  This was not unit tested, hence went unnoticed.  The PR reinstantiates `SpectralSurface` with `emissivity`, which is used to construct `emission`. A new test checks that `emission` now has correct units; this fails with the old  and passes with the new code.