### PR TITLE
Fibre transmission for WCU lasers

### DIFF
--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -18,7 +18,7 @@ from scipy.interpolate import interp1d
 import yaml
 
 from .fpmask import FPMask
-from ..ter_curves import TERCurve, FilterCurve
+from ..ter_curves import TERCurve
 from ...utils import get_logger, seq, find_file, from_currsys
 from ...source.source import Source
 from ...source.source_fields import BackgroundSourceField
@@ -124,6 +124,7 @@ class WCUSource(TERCurve):
         self.rho_tube = get_reflectivity(self.meta["rho_tube"])
         self.rho_is = get_reflectivity(self.meta["rho_is"])
         self.emiss_mask = self.meta["emiss_mask"]
+        self.fibre_trans = self.meta["fibre_transmission"]
 
         # Compute the emission components
         self.compute_lamp_emission()
@@ -419,9 +420,10 @@ class WCUSource(TERCurve):
         """
         Compute the intensity for the single-line lasers.
 
-        The function computes both lasers at once. This is possible because the
-        lines are so far apart that there is no band that sees them both.
+        The function computes all three lasers at once. This is possible because
+        the lines are so far apart that there is no band that sees them both.
         """
+        print("Computing laser intensity")
         lam = self.wavelength
         dlam = lam[1] - lam[0]
 
@@ -440,6 +442,11 @@ class WCUSource(TERCurve):
         lamc_m = 5.26 * u.um
         power_m = 20e-3 * u.W / (c.c * c.h / lamc_m) * u.ph
 
+        # Apply fibre transmission
+        power_l *= self.fibre_trans
+        power_t *= self.fibre_trans
+        power_m *= self.fibre_trans
+
         sigma = 2 * dlam
         amp = 1/(sigma * np.sqrt(2 * np.pi))
 
@@ -449,8 +456,9 @@ class WCUSource(TERCurve):
         line_t = sum(list_t[1:], start=list_t[0])
 
         flux = ((power_l * line_l(lam) + power_m * line_m(lam) + power_t
-                 * line_t(lam)) / (np.pi * self.d_is**2 / 4))
+                 * line_t(lam)) / (np.pi * self.d_is**2))
 
+        # emergent intensity from the IS output port
         intens = mult_is * flux / (np.pi * u.sr)
 
         return intens.to(self.bb_scale)

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -36,6 +36,7 @@ def _patched_cmds_lss(mode="wcu_lss", filtername="J", bin_width=0.002):
 @pytest.fixture(name="bbsource", scope="function")
 def fixture_bbsource():
     return WCUSource(current_lamp="bb",
+                     lamps=["bb", "laser", "off"],
                      bb_temp=1000*u.K,
                      is_temp=300*u.K,
                      wcu_temp=300*u.K,
@@ -48,6 +49,7 @@ def fixture_bbsource():
                      diam_is_in=25.4,
                      diam_is_out=100.,
                      emiss_bb=0.98,
+                     fibre_transmission=0.1,
                      current_fpmask="open",
                      fpmask_angle=0,
                      fpmask_shift=(0, 0),
@@ -199,6 +201,17 @@ class TestWCUSource:
         ref_bg = bbsource.intens_bg
         bbsource.set_bb_aperture(newvalue)
         npt.assert_equal(bbsource.intens_bg, ref_bg)
+
+    def test_laser_brighter_with_fibre_transmission(self, bbsource):
+        bbsource.set_lamp("laser")
+        ft_1 = bbsource.fibre_trans
+        intens_1 = np.sum(bbsource.intens_lamp)
+        bbsource.fibre_trans = 0.853
+        ft_2 = bbsource.fibre_trans
+        bbsource.set_lamp("laser")
+        intens_2 = np.sum(bbsource.intens_lamp)
+
+        assert intens_2 / intens_1 == ft_2 / ft_1
 
 
 @pytest.fixture(name="fpmask", scope="function")


### PR DESCRIPTION
Add fibre transmission for the METIS WCU lasers. The value is defined in https://github.com/AstarVienna/irdb/pull/334

If needed, it can be changed with
```wcu = metis['wcu_source']
wcu.fibre_trans = 0.5
wcu.set_lamp("laser")    # needed to recompute the emergent intensity
metis.observe()
```
The figure shows the effect for five different values on the ImagePlane, where the thermal background has been subtracted. 
<img width="587" height="426" alt="fibre_trans_test" src="https://github.com/user-attachments/assets/dc81ac78-af8b-4485-b5b4-b909f72f97b2" />
