### PR TITLE
Use scopesim-specific PendingDeprecationWarning

### DIFF
--- a/scopesim/__init__.py
+++ b/scopesim/__init__.py
@@ -21,6 +21,8 @@ import warnings
 import yaml
 from astropy.utils.exceptions import AstropyWarning
 
+from .utils import ScopesimPendingDeprecationWarning
+
 warnings.simplefilter('ignore', UserWarning)
 warnings.simplefilter('ignore', RuntimeWarning)  # warnings for the developer
 
@@ -28,7 +30,7 @@ try:
     if __version__.is_prerelease or __version__.is_devrelease:
         # Those are usually ignored, but in development we should see them.
         warnings.simplefilter("default", DeprecationWarning)
-        warnings.simplefilter("default", PendingDeprecationWarning)
+        warnings.simplefilter("default", ScopesimPendingDeprecationWarning)
 except AttributeError:  # catch __version__ = "undetermined"
     pass
 

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -81,8 +81,8 @@ from ..utils import (
     convert_table_comments_to_dict,
     unit_includes_per_physical_type,
     pixel_area,
+    ScopesimPendingDeprecationWarning,
 )
-from ..warnings import ScopesimPendingDeprecationWarning
 
 
 logger = get_logger(__name__)

--- a/scopesim/source/source_fields.py
+++ b/scopesim/source/source_fields.py
@@ -82,6 +82,7 @@ from ..utils import (
     unit_includes_per_physical_type,
     pixel_area,
 )
+from ..warnings import ScopesimPendingDeprecationWarning
 
 
 logger = get_logger(__name__)
@@ -109,7 +110,7 @@ class SourceField:
         # this and force the use of .field...
         warn("Direct item access for source fields may become deprecated "
              "in the future. Use the .field attribute instead.",
-             PendingDeprecationWarning, stacklevel=2)
+             ScopesimPendingDeprecationWarning, stacklevel=2)
         return self.field.__getitem__(key)
 
     def __setitem__(self, key, value):
@@ -118,7 +119,7 @@ class SourceField:
         # this and force the use of .field...
         warn("Direct item assignment for source fields may become deprecated "
              "in the future. Use the .field attribute instead.",
-             PendingDeprecationWarning, stacklevel=2)
+             ScopesimPendingDeprecationWarning, stacklevel=2)
         self.field.__setitem__(key, value)
 
     @property

--- a/scopesim/utils.py
+++ b/scopesim/utils.py
@@ -30,6 +30,9 @@ from . import rc
 logger = get_logger(__name__)
 bug_logger = get_logger("bug_report")
 
+class ScopesimPendingDeprecationWarning(PendingDeprecationWarning):
+    """A scopesim-specific subclass of PendingDeprecationWarning"""
+
 
 def parallactic_angle(ha, de, lat=-24.589167):
     r"""


### PR DESCRIPTION
`warnings.simplefilter` shows `PendingDeprecationWarning` to developers. This includes warnings from other packages. In my case, a warning from `ipykernel` completely messes up my `jupyter qtconsole`. The solution proposed here is to define a subclass `ScopesimPendingDeprecationWarning` that we use for our internal warnings, and which we display by default (only development versions). Users who want to see warnings from other packages should set their own `simplefilter` accordingly. 