### PR TITLE
Catch wrong inputs to `UserCommands`

### DIFF
--- a/scopesim/commands/user_commands.py
+++ b/scopesim/commands/user_commands.py
@@ -163,6 +163,11 @@ class UserCommands(NestedChainMap):
             # Don't add another layer when .new_child() is called.
             maps = [RecursiveNestedMapping(title="CurrSys"), *maps]
 
+        # Guard against wrong args to avoid cryptical error downstream.
+        if not all(isinstance(m, Mapping) for m in maps):
+                raise TypeError(
+                    "Non-keyword args to UserCommands must be dict-like.")
+
         super().__init__(*maps)
 
         self.yaml_dicts = []

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -163,6 +163,10 @@ class OpticalTrain:
         if all(len(m) == 0 for m in self.cmds.maps):
             raise ValueError("Empty cmds, cannot construct OpticalTrain.")
 
+        # Guard against empty yamls to avoid cryptical error downstream.
+        if not self.cmds.yaml_dicts:
+            raise ValueError("No YAMLS found, cannot construct OpticalTrain.")
+
         self.yaml_dicts = self.cmds.yaml_dicts
         self.optics_manager = OpticsManager(self.yaml_dicts, self.cmds)
         self.update()

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -158,6 +158,11 @@ class OpticalTrain:
         #       Nevertheless, I'm a bit reluctant to removing this code just
         #       yet. So it is commented out.
         # rc.__currsys__ = user_commands
+
+        # Guard against all-empty cmds to avoid cryptical error downstream.
+        if all(len(m) == 0 for m in self.cmds.maps):
+            raise ValueError("Empty cmds, cannot construct OpticalTrain.")
+
         self.yaml_dicts = self.cmds.yaml_dicts
         self.optics_manager = OpticsManager(self.yaml_dicts, self.cmds)
         self.update()


### PR DESCRIPTION
Also applies to `Simulation`. Should avoid the kind of cryptical error messages that confused @astronomyk in AstarVienna/IRDB#352 etc.