### PR TITLE
Remove reflectance factor from integrating sphere background

### DIFF
--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -402,7 +402,7 @@ class WCUSource(TERCurve):
 
         # background emission from integrating sphere
         self.is_bg = BlackBody(self.is_temp, scale=self.bb_scale)
-        self.intens_bg = self.rho_is(lam) * self.is_bg(lam)
+        self.intens_bg = self.is_bg(lam)
 
         self.intensity = self.intens_lamp + self.intens_bg
 


### PR DESCRIPTION
Quote from an email by RvB:

> The problem was in the thermal self-emission of the integrating sphere (IS),
> described in section 2.3.1 of the WCU flux model document
> and was the following: the sphere multiplication factor M implicitly
> accounts for an initial reflection of the signal off the IS inner surface.
> This is appropriate for signal from an actively injected external source,
> but not for the thermal self-emission. This lead to our expression for the
> emergent intensity from the IS self emission to have a factor rho_nu
> (reflectance) too many, and therefore to an expression of this intensity
> 
> I_IS = rho_nu * B_nu(T_IS)     (wrong formula used so far)
>
> This factor rho_nu had bothered me from the beginning but I could not find
> its cause back then, but now it is clear. So the proper intensity is 
>
> I_IS =  B_nu(T_IS)     (correct formula to be used)

This PR implements the requested change. 