### PR TITLE
Fix scalar Quantity pattern matching

### DIFF
--- a/scopesim/effects/fits_headers.py
+++ b/scopesim/effects/fits_headers.py
@@ -402,6 +402,10 @@ def flatten_dict(
 
         # Catch any value+comments lists/tuples
         match val:
+            # This became necessary in numpy 2.5, to avoid tripping on scalar quantities
+            case u.Quantity() as value:
+                # value get bound to variable anyway
+                comment = ""
             case [value, str(comment)]:
                 pass  # values get bound to variables anyway
             case value:


### PR DESCRIPTION
This started occurring in the updated dependency tests today (which is good in a way, that's exactly why we run those tests!!) after skycalc_ipy 0.7.1 started allowing NumPy > 2.4. I traced it down to the structural pattern matching, which was [changed in NumPy 2.5](https://numpy.org/doc/stable/release/2.5.0-notes.html#numpy-ndarray-now-supports-structural-pattern-matching), and is now causing a scalar `u.Quantity` to fail matching for a 2-tuple. This used to work, because the structured pattern matching treated the `u.Quantity` as a single object, so didn't match the 2-tuple and went instead to the single `value` case. Flipping the `case` statements around won't work, because then an actual 2-tuple would match the single object already (actually Python is smart enough to raise a `SyntaxError` in tht case). The fix now checks for the single `u.Quantity` before, which seems to work.

I have some hope that Astropy 8.x will fix that again, we'll see...