### PR TITLE
Make laser parameters configurable; utility function for tunable laser

### DIFF
--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -477,29 +477,45 @@ class WCUSource(TERCurve):
         # Laser 2 (tunable), power divided among multiple lines
         if not isinstance(self.meta['laser_t_wave'], Iterable):
             self.meta['laser_t_wave'] = [self.meta['laser_t_wave']]
-        lam_t = self.meta["laser_t_wave"] * u.um
-        nline = len(lam_t)
-        power_t = self.meta["laser_t_power"] * u.W / (c.c * c.h / lam) * u.ph / nline
+        lamc_t = self.meta["laser_t_wave"] * u.um
+        nline_t = len(lamc_t)
+        power_t = self.meta["laser_t_power"] * u.W / (c.c * c.h / lam) * u.ph / nline_t
 
         # Laser 3 (M band)
         lamc_m = self.meta["laser_m_wave"] * u.um
         power_m = self.meta["laser_m_power"] * u.W / (c.c * c.h / lamc_m) * u.ph
 
+        # N-band lasers
+        if not isinstance(self.meta['laser_n_wave'], Iterable):
+            self.meta['laser_n_wave'] = [self.meta['laser_n_wave']]
+        if not isinstance(self.meta['laser_n_power'], Iterable):
+            self.meta['laser_n_power'] = [self.meta['laser_n_power']]
+        print(self.meta['laser_n_wave'])
+        lamc_n = self.meta["laser_n_wave"] * u.um
+        print(self.meta['laser_n_power'])
+        power_n = self.meta["laser_n_power"] * u.W / (c.c * c.h / lamc_n) * u.ph
+
+
         # Apply fibre transmission
         power_l *= self.fibre_trans
         power_t *= self.fibre_trans
         power_m *= self.fibre_trans
+        power_n *= self.fibre_trans
 
         sigma = 2 * dlam
+        print(sigma)
         amp = 1/(sigma * np.sqrt(2 * np.pi))
 
         line_l = Gaussian1D(amplitude=amp, mean=lamc_l, stddev=sigma)
         line_m = Gaussian1D(amplitude=amp, mean=lamc_m, stddev=sigma)
-        list_t = [Gaussian1D(amplitude=amp, mean=ll, stddev=sigma) for ll in lam_t]
+        list_t = [Gaussian1D(amplitude=amp, mean=ll, stddev=sigma) for ll in lamc_t]
         line_t = sum(list_t[1:], start=list_t[0])
+        list_n = [Gaussian1D(amplitude=pp*amp, mean=ll, stddev=sigma) for (ll,pp) in
+                  zip(lamc_n, power_n)]
+        line_n = sum(list_n[1:], start=list_n[0])
 
         flux = ((power_l * line_l(lam) + power_m * line_m(lam) + power_t
-                 * line_t(lam)) / (np.pi * self.d_is**2))
+                 * line_t(lam) + line_n(lam)) / (np.pi * self.d_is**2))
 
         # emergent intensity from the IS output port
         intens = mult_is * flux / (np.pi * u.sr)

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -6,6 +6,7 @@
 """
 
 from typing import ClassVar
+from collections.abc import Iterable
 
 import numpy as np
 from astropy.table import Table
@@ -211,7 +212,7 @@ class WCUSource(TERCurve):
             If True bypass the validation for the lasers available
             wavelength range.
         """
-        if not hasattr(wavelength, "__len__"):
+        if not isinstance(wavelength, Iterable):
             wavelength = [wavelength]
         if not force:
             wavelength = self._validate_tunable(wavelength)
@@ -231,17 +232,13 @@ class WCUSource(TERCurve):
         This is currently not used as there is no reliable
         information on the tuning range of the QCL.
         """
-        reject = []
-        accept = []
-        lam_min = 1.
-        lam_max = 30.
-        for lam in wave:
-            if lam < lam_min or lam > lam_max:
-                reject.append(lam)
-            else:
-                accept.append(lam)
-        if len(reject) > 0:
-            logger.warning("Removed %d wavelengths outside allowed range (%f, %f) um", len(reject), lam_min, lam_max)
+        lam_min, lam_max = self.meta["laser_t_wave_limits"]
+
+        accept = [w for w in wave if (w >= lam_min) & (w <= lam_max)]
+        n_rejected = len(wave) - len(accept)
+        if n_rejected > 0:
+            logger.warning("Removed %d wavelengths outside allowed range (%.2f, %.2f) um",
+                           n_rejected, lam_min, lam_max)
         return accept
 
     def get_wavelength(self):
@@ -478,7 +475,7 @@ class WCUSource(TERCurve):
         power_l = self.meta["laser_l_power"] * u.W / (c.c * c.h / lamc_l) * u.ph
 
         # Laser 2 (tunable), power divided among multiple lines
-        if not hasattr(self.meta['laser_t_wave'], "__len__"):
+        if not isinstance(self.meta['laser_t_wave'], Iterable):
             self.meta['laser_t_wave'] = [self.meta['laser_t_wave']]
         lam_t = self.meta["laser_t_wave"] * u.um
         nline = len(lam_t)

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -200,6 +200,50 @@ class WCUSource(TERCurve):
         self.compute_lamp_emission()
         self.compute_fp_emission()
 
+    def tune_laser(self, wavelength, force=False):
+        """Set the wavelength(s) of the tunable laser
+
+        Parameters
+        ==========
+        wavelength : float, list, array [um]
+            The wavelength(s) at which the laser emits
+        force: boolean [True] <- currently not used
+            If True bypass the validation for the lasers available
+            wavelength range.
+        """
+        if not hasattr(wavelength, "__len__"):
+            wavelength = [wavelength]
+        if not force:
+            wavelength = self._validate_tunable(wavelength)
+
+        # if nothing's there use a dummy value outside any range
+        # to prevent division by zero
+        if len(wavelength) == 0:
+            wavelength = [0.001]
+
+        self.meta["laser_t_wave"] = wavelength
+        self.compute_lamp_emission()
+        self.compute_fp_emission()
+
+    def _validate_tunable(self, wave):
+        """Validate wave against a wavelength range
+
+        This is currently not used as there is no reliable
+        information on the tuning range of the QCL.
+        """
+        reject = []
+        accept = []
+        lam_min = 1.
+        lam_max = 30.
+        for lam in wave:
+            if lam < lam_min or lam > lam_max:
+                reject.append(lam)
+            else:
+                accept.append(lam)
+        if len(reject) > 0:
+            logger.warning("Removed %d wavelengths outside allowed range (%f, %f) um", len(reject), lam_min, lam_max)
+        return accept
+
     def get_wavelength(self):
         """Try to set the appropriate wavelength vector for mode and filter."""
         # Need to provide for wcu_lms_extended
@@ -423,24 +467,26 @@ class WCUSource(TERCurve):
         The function computes all three lasers at once. This is possible because
         the lines are so far apart that there is no band that sees them both.
         """
-        print("Computing laser intensity")
+        logger.info("Computing laser intensity")
         lam = self.wavelength
         dlam = lam[1] - lam[0]
 
         mult_is = self.is_multiplication(lam)
 
         # Laser 1 (L band)  # TODO move to yaml
-        lamc_l = 3.39 * u.um
-        power_l = 5e-3 * u.W / (c.c * c.h / lamc_l) * u.ph
+        lamc_l = self.meta["laser_l_wave"] * u.um
+        power_l = self.meta["laser_l_power"] * u.W / (c.c * c.h / lamc_l) * u.ph
 
         # Laser 2 (tunable), power divided among multiple lines
-        lam_t = seq(4.68, 4.78, 0.01) * u.um
+        if not hasattr(self.meta['laser_t_wave'], "__len__"):
+            self.meta['laser_t_wave'] = [self.meta['laser_t_wave']]
+        lam_t = self.meta["laser_t_wave"] * u.um
         nline = len(lam_t)
-        power_t = 70e-3 * u.W / (c.c * c.h / lam) * u.ph / nline
+        power_t = self.meta["laser_t_power"] * u.W / (c.c * c.h / lam) * u.ph / nline
 
         # Laser 3 (M band)
-        lamc_m = 5.26 * u.um
-        power_m = 20e-3 * u.W / (c.c * c.h / lamc_m) * u.ph
+        lamc_m = self.meta["laser_m_wave"] * u.um
+        power_m = self.meta["laser_m_power"] * u.W / (c.c * c.h / lamc_m) * u.ph
 
         # Apply fibre transmission
         power_l *= self.fibre_trans

--- a/scopesim/effects/metis_wcu/metis_wcu.py
+++ b/scopesim/effects/metis_wcu/metis_wcu.py
@@ -490,9 +490,7 @@ class WCUSource(TERCurve):
             self.meta['laser_n_wave'] = [self.meta['laser_n_wave']]
         if not isinstance(self.meta['laser_n_power'], Iterable):
             self.meta['laser_n_power'] = [self.meta['laser_n_power']]
-        print(self.meta['laser_n_wave'])
         lamc_n = self.meta["laser_n_wave"] * u.um
-        print(self.meta['laser_n_power'])
         power_n = self.meta["laser_n_power"] * u.W / (c.c * c.h / lamc_n) * u.ph
 
 
@@ -503,7 +501,6 @@ class WCUSource(TERCurve):
         power_n *= self.fibre_trans
 
         sigma = 2 * dlam
-        print(sigma)
         amp = 1/(sigma * np.sqrt(2 * np.pi))
 
         line_l = Gaussian1D(amplitude=amp, mean=lamc_l, stddev=sigma)

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -43,6 +43,7 @@ def fixture_bbsource():
                      laser_l_wave=3.39,    # [um]
                      laser_l_power=5e-3,   # [W]
                      laser_t_wave=[4.70],  # [um], array
+                     laser_t_wave_limits=[1., 30.],  # [um]
                      laser_t_power=70e-3,  # [W]
                      laser_m_wave=5.26,    # [um]
                      laser_m_power=20e-3,  # [W]

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -47,6 +47,8 @@ def fixture_bbsource():
                      laser_t_power=70e-3,  # [W]
                      laser_m_wave=5.26,    # [um]
                      laser_m_power=20e-3,  # [W]
+                     laser_n_wave=10.4,    # [um]
+                     laser_n_power=2.e-3,  # [W]
                      bb_aperture=1.,
                      bb_to_is=None,
                      rho_tube=0.95,

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -218,7 +218,7 @@ class TestWCUSource:
         bbsource.set_lamp("laser")
         intens_2 = np.sum(bbsource.intens_lamp)
 
-        assert np.allclose(intens_2 / intens_1, ft_2 / ft_1)
+        npt.assert_allclose(intens_2 / intens_1, ft_2 / ft_1)
 
 
     def test_can_tune_laser(self, bbsource):

--- a/scopesim/tests/tests_effects/test_MetisWCU.py
+++ b/scopesim/tests/tests_effects/test_MetisWCU.py
@@ -40,6 +40,12 @@ def fixture_bbsource():
                      bb_temp=1000*u.K,
                      is_temp=300*u.K,
                      wcu_temp=300*u.K,
+                     laser_l_wave=3.39,    # [um]
+                     laser_l_power=5e-3,   # [W]
+                     laser_t_wave=[4.70],  # [um], array
+                     laser_t_power=70e-3,  # [W]
+                     laser_m_wave=5.26,    # [um]
+                     laser_m_power=20e-3,  # [W]
                      bb_aperture=1.,
                      bb_to_is=None,
                      rho_tube=0.95,
@@ -211,7 +217,18 @@ class TestWCUSource:
         bbsource.set_lamp("laser")
         intens_2 = np.sum(bbsource.intens_lamp)
 
-        assert intens_2 / intens_1 == ft_2 / ft_1
+        assert np.allclose(intens_2 / intens_1, ft_2 / ft_1)
+
+
+    def test_can_tune_laser(self, bbsource):
+        bbsource.set_lamp("laser")
+        assert bbsource.meta["laser_t_wave"] == [4.70]
+        bbsource.tune_laser(4.72)
+        assert bbsource.meta["laser_t_wave"] == [4.72]
+        bbsource.tune_laser(np.linspace(4.68, 4.72, 10))
+        assert len(bbsource.meta["laser_t_wave"]) == 10
+        bbsource.tune_laser([])
+        assert bbsource.meta["laser_t_wave"] == [0.001]
 
 
 @pytest.fixture(name="fpmask", scope="function")


### PR DESCRIPTION
The laser parameters (wavelength, power) are now taken from `wcu.meta`, i.e. from a config file or from kwargs. 
All parameters can be changed by doing, e.g.
```
wcu = metis['wcu_source']
wcu.meta['laser_l_wave'] = 3.15
wcu.set_lamp("laser")
```
`set_lamp` is necessary to recompute the lamp emission.

The wavelengths of the tunable laser should be more easily accessible to the user, therefore a utility method is offered (this recomputes the emission automatically): 
```
wcu.tune_laser(wavelength=np.linspace(4.68, 4.78, 10))
```
A validation method for the wavelengths has been implemented but is not yet used as we do not have reliable information on the actually available wavelength range. 