### PR TITLE
Skip PSF convolution for exactly-uniform fields

### DIFF
--- a/scopesim/effects/psfs/psf_base.py
+++ b/scopesim/effects/psfs/psf_base.py
@@ -72,6 +72,33 @@ class PSF(Effect):
             logger.debug("Executing %s, convolution", self.meta['name'])
             if ((hasattr(obj, "fields") and len(obj.fields) > 0) or
                     (obj.hdu is not None)):
+                image = obj.hdu.data.astype(float)
+
+                # subtract background level before convolving, re-add afterwards
+                bkg_level = get_bkg_level(image, self.meta["bkg_width"])
+
+                # Short-circuit for spatially uniform fields (e.g. darks and
+                # closed-shutter calibration frames): the background is
+                # subtracted before the convolution below and re-added after,
+                # so for a uniform image the convolution input is identically
+                # zero and the output is bit-for-bit the input. Skip the
+                # (expensive) kernel interpolation/rescale and FFT entirely.
+                # This is exact, not approximate: it only fires when the
+                # residual is exactly zero everywhere.
+                # np.asarray: the FOV data can be an astropy Quantity, whose
+                # truthiness/.any() raises TypeError; we only need the values
+                if image.ndim == 3:
+                    residual = np.asarray(
+                        image - np.asarray(bkg_level)[:, None, None])
+                else:
+                    residual = np.asarray(image - bkg_level)
+                if not residual.any():
+                    logger.debug(
+                        "%s: uniform field, convolution skipped",
+                        self.meta["name"])
+                    obj.hdu.data = image
+                    return obj
+
                 kernel = self.get_kernel(obj).astype(float)
 
                 # This doesn't work because of a "Delta PSF" in some mocks...
@@ -93,11 +120,6 @@ class PSF(Effect):
                 # if from_currsys(self.meta["normalise_kernel"], self.cmds):
                 #    kernel /= np.sum(kernel)
                 #    kernel[kernel < 0.] = 0.
-
-                image = obj.hdu.data.astype(float)
-
-                # subtract background level before convolving, re-add afterwards
-                bkg_level = get_bkg_level(image, self.meta["bkg_width"])
 
                 # do the convolution
                 mode = from_currsys(self.meta["convolve_mode"], self.cmds)


### PR DESCRIPTION
## What

`PSF.apply_to` subtracts the background level before convolving and re-adds it afterwards (`psf_base.py`). For a **spatially uniform field** the convolution input is therefore identically zero — the operation provably cannot change the image — yet the kernel interpolation/rescale and the padded-grid FFT were still executed every time.

This PR checks the residual (`image − bkg_level`) *before* `get_kernel` and skips the convolution when it is exactly zero everywhere.

## Why it matters (measured, METIS)

Uniform fields are the *most expensive* frames METIS generates, because a closed light path implies the full thermal waveset and the largest FOV chunks:

- an `img_lm` dark spends **57 s of a 75 s frame (76%)** in `PSF.apply_to` — kernel rescale + FFT at up to 4639² — convolving a field the operation cannot change;
- the IFU (`lms`/`wcu_lms`) pays the same pattern per (n_wave, x, y) **cube** (observed up to 6383 planes, ~1.6 GB per padded copy), where the FFT copies have also intermittently exhausted memory and killed generation with no traceback;
- for zero-flux IFU darks, skipping the PSF was measured **exactly lossless**: frames with and without it are identical at rtol 1e-9 on every header card and every data statistic (measured downstream via `metis["psf"].include = False`, the manual equivalent of this shortcut — see AstarVienna/METIS_Simulations#212).

## Why it is safe

- The check is **exact, not a tolerance**: any structure at all takes the unchanged full path. When it fires, the output equals the input *by the function's own algebra*: `convolve(0, kernel) + bkg == bkg`.
- The `FovVolumeList` waveset handling earlier in `apply_to` is untouched, so FOV chunking is identical whether or not the shortcut fires. (This matters: disabling the whole `psf` *effect* — the manual workaround — changes FOV chunking and shifts imaging-dark statistics at the 1e-5 level. This shortcut has no such side effect, which is why it is bit-exact where the workaround is only approximately equivalent.)
- The FOV data can be an astropy `Quantity`; the residual test goes through `np.asarray` for that reason.
- The only code motion is computing `image`/`bkg_level` before `get_kernel` instead of after; neither depends on the kernel.

## Validation

Run downstream through METIS_Simulations with the differential harness (per-pixel comparison of every frame, matched by DO.CATG + MJD-OBS, all 4,194,304 px each):

| Case | Wall time (main → patched) | Pixel verdict vs unpatched main |
|---|---|---|
| `darkLM.yaml` (3 frames, H2RG) | 162 s → **23 s (7×)** | **3/3 frames BITWISE IDENTICAL** |
| `darkN.yaml` (3 frames, GeoSnap) | 110 s → **20 s (5.5×)** | **3/3 frames BITWISE IDENTICAL** |

The per-FOV fields of METIS imaging darks are exactly uniform, so the shortcut fires on every dark/closed-shutter FOV and the frames are unchanged to the bit. The IFU cube case (where the skipped work is largest, and where the padded-FFT copies have intermittently exhausted memory) gains proportionally more; zero-flux IFU skips were independently measured exactly lossless via the manual route (AstarVienna/METIS_Simulations#212).

(Full harness and measurement log: `METIS_Simulations_Deux`, findings F-D8/F-D9/F-D24/F-D30/F-D38.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
