### PR TITLE
Resolve !SIM.random.seed per apply_to call, not once

### DIFF
--- a/scopesim/effects/electronic/noise.py
+++ b/scopesim/effects/electronic/noise.py
@@ -59,20 +59,23 @@ class PoorMansHxRGReadoutNoise(Effect):
         if not isinstance(det, Detector):
             return det
 
-        self.meta["random_seed"] = from_currsys(self.meta["random_seed"],
-                                                self.cmds)
-        if self.meta["random_seed"] is not None:
-            np.random.seed(self.meta["random_seed"])
+        # Resolve into locals rather than back into self.meta: writing the
+        # resolved value over the "!SIM.random.seed" reference froze the
+        # first frame's seed into the effect, so repeated readouts from a
+        # reused OpticalTrain could never be reseeded per exposure.
+        random_seed = from_currsys(self.meta["random_seed"], self.cmds)
+        if random_seed is not None:
+            np.random.seed(random_seed)
 
-        self.meta = from_currsys(self.meta, self.cmds)
         ron_keys = ["noise_std", "n_channels", "channel_fraction",
                     "line_fraction", "pedestal_fraction", "read_fraction"]
-        ron_kwargs = {key: self.meta[key] for key in ron_keys}
+        ron_kwargs = {key: from_currsys(self.meta[key], self.cmds)
+                      for key in ron_keys}
         ron_kwargs["image_shape"] = det._hdu.data.shape
 
         ron_frame = _make_ron_frame(**ron_kwargs)
         stacked_ron_frame = np.zeros_like(ron_frame)
-        for i in range(self.meta["ndit"]):
+        for i in range(from_currsys(self.meta["ndit"], self.cmds)):
             dx = np.random.randint(0, ron_frame.shape[1])
             dy = np.random.randint(0, ron_frame.shape[0])
             stacked_ron_frame += np.roll(ron_frame, (dy, dx), axis=(0, 1))
@@ -240,9 +243,10 @@ class ShotNoise(Effect):
         if not isinstance(det, Detector):
             return det
 
-        self.meta["random_seed"] = from_currsys(self.meta["random_seed"],
-                                                self.cmds)
-        rng = np.random.default_rng(self.meta["random_seed"])
+        # Local resolution (see PoorMansHxRGReadoutNoise.apply_to): keep the
+        # "!SIM.random.seed" reference intact so every readout re-resolves it.
+        random_seed = from_currsys(self.meta["random_seed"], self.cmds)
+        rng = np.random.default_rng(random_seed)
 
         # numpy has a problem with generating Poisson distributions above
         # certain values. E.g. on linux, numpy.random.poisson(1e20) raises


### PR DESCRIPTION
## What

Two noise effects resolved `!SIM.random.seed` in a way that **destroys the reference on first use**:

- `ShotNoise.apply_to` wrote the resolved integer back into `self.meta["random_seed"]`;
- `PoorMansHxRGReadoutNoise.apply_to` did the same, and additionally rebaked its whole `self.meta` through `from_currsys`.

After the first readout, the effect's meta holds a frozen integer instead of `"!SIM.random.seed"`, so **any later readout from a reused `OpticalTrain` re-seeds with the first exposure's seed**, regardless of what `!SIM.random.seed` was updated to in `cmds`.

This PR resolves into locals instead — exactly the pattern `BasicReadoutNoise` and `PixelResponseNonUniformity` already use. First-call behaviour, resolution order and generated values are unchanged; only repeated `apply_to` calls now honour a per-readout seed.

## Why it matters

`readout()` deliberately supports repeated calls (it deep-copies results so "subsequent readouts" don't clobber earlier ones — `optical_train.py`), and repeated readout from one `observe()` is the natural way to generate N darks or a detector-linearity DIT ramp: measured on METIS, ~1–2 s per additional frame instead of ~60 s for a full rebuild+observe.

Today that pattern is *statistically* correct but impossible to make **reproducible**: readouts 2..N carry the frame-1 readout-noise pattern rolled to random offsets (measured: σ agrees with independent simulation to 4×10⁻⁷, but ~92% of pixels differ and reruns don't reproduce). With this fix, one-observe/N-readouts at per-frame seeds is bit-for-bit identical to N independent simulations.

## Validation (METIS_Simulations differential harness, per-pixel comparison)

| Check | Result |
|---|---|
| Single-frame no-regression: `darkLM.yaml` ×3 frames, patched vs unpatched main | **3/3 frames BITWISE IDENTICAL** (all 4,194,304 px each) |
| One observe + 3 readouts at per-frame seeds vs 3 independently simulated frames (patched) | **3/3 frames BITWISE IDENTICAL** — repeated readout is now exactly reproducible |

Notes:
- `np.random.seed` (process-global, legacy RNG) is untouched here — moving to per-effect `Generator`s spawned from a `SeedSequence` would be the fuller modernisation, but is a behaviour-changing refactor best done separately. This PR is the minimal fix that makes repeated readout deterministic.
- Full measurement log: `METIS_Simulations_Deux` findings F-D18/F-D24/F-D34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
