### PR TITLE
Fix NameError in `SpectralTrace.plot` when `plot_trace_id` is used without `plot_outline`

### DIFF
--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -626,7 +626,7 @@ class SpectralTrace:
         if plot_ctrlpnts:
             axes.plot(x, y, "o", c=c)
 
-        if plot_outline:
+        if plot_outline or plot_trace_id:
             blue_end = self.table[mask][w == w.min()]
             red_end = self.table[mask][w == w.max()]
             blue_end.sort(sname)
@@ -634,6 +634,8 @@ class SpectralTrace:
             corners = vstack([blue_end[[0, -1]][xname, yname],
                               red_end[[-1, 0]][xname, yname],
                               blue_end[0][xname, yname]])
+
+        if plot_outline:
             axes.plot(corners[xname], corners[yname], c=c)
 
         if plot_trace_id:

--- a/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
+++ b/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
@@ -36,6 +36,17 @@ class TestSpectralTrace:
         spt = SpectralTrace(trace_tbl)
         assert spt.dispersion_axis == 'y'
 
+class TestSpectralTracePlot:
+    """Tests for SpectralTrace.plot()"""
+    @pytest.mark.parametrize("plot_outline", [True, False])
+    def test_plot_trace_id_works_without_outline(self, plot_outline):
+        # plot_trace_id previously relied on corners, which was only
+        # computed when plot_outline was True
+        spt = SpectralTrace(tlo.trace_1(), trace_id="TRACE_1")
+        axes = spt.plot(plot_trace_id=True, plot_outline=plot_outline)
+        assert any(txt.get_text() == spt.trace_id for txt in axes.texts)
+
+
 class TestPowerVec:
     """Test function power_vector()"""
     def test_gives_correct_result(self):


### PR DESCRIPTION
A minor bug, caught by claude. Trivial, but shows the usefulness of using an LLM ;) 