### PR TITLE
Fix `XiLamImage` overwriting the cunit of its primary WCS

### DIFF
--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -767,7 +767,7 @@ class XiLamImage():
         self.wcsa.wcs.cdelt = [d_lam, 1./n_xi]
         self.wcsa.wcs.ctype = ["LINEAR", "LINEAR"]
         self.wcsa.wcs.cname = ["WAVELEN", "SLITPOS"]
-        self.wcs.wcs.cunit = ["um", ""]
+        self.wcsa.wcs.cunit = ["um", ""]
 
         self.xi = self.wcs.all_pix2world(self.lam[0], np.arange(n_xi), 0)[1]
         self.npix_xi = n_xi

--- a/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
+++ b/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
@@ -9,9 +9,12 @@ import numpy as np
 
 from astropy.io import fits
 
+from astropy import units as u
+
 from scopesim.effects.spectral_trace_list_utils import SpectralTrace
 from scopesim.effects.spectral_trace_list_utils import Transform2D, power_vector
 from scopesim.effects.spectral_trace_list_utils import make_image_interpolations
+from scopesim.effects.spectral_trace_list_utils import XiLamImage
 from scopesim.tests.mocks.py_objects import trace_list_objects as tlo
 
 class TestSpectralTrace:
@@ -143,6 +146,30 @@ class TestTransform2D:
         n_x, n_y = 4, 2
         res = tf2d(np.ones((n_y, n_x)), np.ones((n_y, n_x)), grid=False)
         assert res.shape == (n_y, n_x)
+
+
+class MockCubeFov:
+    """Minimal stand-in for a FieldOfView carrying a spectral cube."""
+    def __init__(self, n_lam=20, n_eta=3, n_xi=11):
+        hdr = fits.Header()
+        hdr["NAXIS"] = 3
+        hdr["NAXIS1"], hdr["NAXIS2"], hdr["NAXIS3"] = n_xi, n_eta, n_lam
+        hdr["CTYPE1"], hdr["CTYPE2"], hdr["CTYPE3"] = "LINEAR", "LINEAR", "WAVE"
+        hdr["CRPIX1"], hdr["CRPIX2"], hdr["CRPIX3"] = 1, 1, 1
+        hdr["CRVAL1"], hdr["CRVAL2"], hdr["CRVAL3"] = 0., 0., 2.0
+        hdr["CDELT1"], hdr["CDELT2"], hdr["CDELT3"] = 0.1, 0.1, 0.001
+        hdr["CUNIT1"], hdr["CUNIT2"], hdr["CUNIT3"] = "arcsec", "arcsec", "um"
+        self.cube = fits.ImageHDU(
+            data=np.ones((n_lam, n_eta, n_xi)), header=hdr)
+        self.meta = {"xi_min": -0.5 * u.arcsec, "xi_max": 0.5 * u.arcsec}
+
+
+class TestXiLamImage:
+    def test_primary_wcs_keeps_arcsec_cunit(self):
+        # The wcsa block previously overwrote self.wcs.wcs.cunit
+        xilam = XiLamImage(MockCubeFov(), dlam_per_pix=0.001)
+        assert list(xilam.wcs.wcs.cunit) == [u.um, u.arcsec]
+        assert list(xilam.wcsa.wcs.cunit) == [u.um, u.dimensionless_unscaled]
 
 
 class TestImageInterpolations:


### PR DESCRIPTION
Was this intentional, or a typo?

Also happy to delete the test, as it seems unnecessary and will clutter up the test suite, if you agree

----

## What

`XiLamImage` carries two WCS objects for the rectified (xi, lambda) spectrum: `self.wcs` (slit position in arcsec) and `self.wcsa` (slit position normalised to [0, 1]). The last line of the `wcsa` set-up block assigned to `self.wcs.wcs.cunit` instead of `self.wcsa.wcs.cunit`, so the *primary* WCS ended up with `cunit = ["um", ""]` — the arcsec unit set five lines earlier was silently discarded.

One-line fix. Silent unit corruption rather than a crash, which is presumably why it survived unnoticed; any unit-aware consumer of `xilam.wcs` got a dimensionless slit axis.
