### PR TITLE
Make `Transform2D` per-call transform overrides non-persistent

### DIFF
--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -848,7 +848,8 @@ class Transform2D():
         this case, x and y must be of the same length).
 
         Functions `pretransform_x`, `pretransform_y` and `posttransform`
-        can be supplied to override the instance values.
+        can be supplied to override the instance values for this call only;
+        the instance itself is not modified.
 
         Parameters
         ----------
@@ -863,12 +864,16 @@ class Transform2D():
         in x and y. When grid=False, a vector. In this case, x and y must
         have the same length.
         """
+        # Per-call overrides must not modify the instance
+        pretransform_x = self.pretransform_x
+        pretransform_y = self.pretransform_y
+        posttransform = self.posttransform
         if "pretransform_x" in kwargs:
-            self.pretransform_x = self._repackage(kwargs["pretransform_x"])
+            pretransform_x = self._repackage(kwargs["pretransform_x"])
         if "pretransform_y" in kwargs:
-            self.pretransform_y = self._repackage(kwargs["pretransform_y"])
+            pretransform_y = self._repackage(kwargs["pretransform_y"])
         if "posttransform" in kwargs:
-            self.posttransform = self._repackage(kwargs["posttransform"])
+            posttransform = self._repackage(kwargs["posttransform"])
 
         x = np.array(x)
         y = np.array(y)
@@ -879,10 +884,10 @@ class Transform2D():
                              "is False")
 
         # Apply pre transforms
-        if self.pretransform_x is not None:
-            x = self.pretransform_x[0](x, **self.pretransform_x[1])
-        if self.pretransform_y is not None:
-            y = self.pretransform_y[0](y, **self.pretransform_y[1])
+        if pretransform_x is not None:
+            x = pretransform_x[0](x, **pretransform_x[1])
+        if pretransform_y is not None:
+            y = pretransform_y[0](y, **pretransform_y[1])
 
         xvec = power_vector(x.flatten(), self.nx - 1)
         yvec = power_vector(y.flatten(), self.ny - 1)
@@ -902,8 +907,8 @@ class Transform2D():
                 result = result.reshape(orig_shape)
 
         # Apply posttransform
-        if self.posttransform is not None:
-            result = self.posttransform[0](result, **self.posttransform[1])
+        if posttransform is not None:
+            result = posttransform[0](result, **posttransform[1])
 
         return result
 

--- a/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
+++ b/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
@@ -139,6 +139,17 @@ class TestTransform2D:
 
         assert tf2d.matrix == pytest.approx(matrix)
 
+    def test_call_kwargs_do_not_modify_instance(self, quadratic):
+        # pre/posttransform overrides passed to __call__ previously
+        # rewired the instance for all subsequent calls
+        tf2d = Transform2D(quadratic['matrix'])
+        x, y = 0.7, -0.3
+        plain = tf2d(x, y)
+        shifted = tf2d(x, y, posttransform=lambda z: z + 100)
+        assert shifted == pytest.approx(plain + 100)
+        assert tf2d.posttransform is None
+        assert tf2d(x, y) == pytest.approx(plain)
+
     def test_grid_false_shape_is_preserved(self, tf2d):
         n_x, n_y = 4, 2
         res = tf2d(np.ones((n_y, n_x)), np.ones((n_y, n_x)), grid=False)


### PR DESCRIPTION
As you can see, I'm taking this slow ;) Checking things locally before I ask for the LLM to make the PR. Then I re-write the PR ;)


## What

`Transform2D.__call__` accepts `pretransform_x` / `pretransform_y` / `posttransform` keyword arguments as per-call overrides (used e.g. by the METIS LMS traces, where the polynomial matrices act on grating phase while ScopeSim works in wavelength). The overrides were assigned to `self.*`, so a single overridden call permanently rewired the transform for every later caller — a silent state trap in shared `SpectralTrace` objects.

The overrides are now resolved into local variables; the instance is never modified. The documented per-call override behaviour is unchanged, and the docstring now says so explicitly.

## Testing

- New test `TestTransform2D::test_call_kwargs_do_not_modify_instance`: an overridden call applies the override, and both the instance state and subsequent plain calls are unchanged (previously the plain call returned the overridden value).