### PR TITLE
Rectify now accepts `str` and `HDUList` + stop mangling `METISLMSSPectralTrace` params dict

### DIFF
--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -235,7 +235,7 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
         for i, spt in enumerate(self.spectral_traces.values()):
             spt.wave_min = wave_min
             spt.wave_max = wave_max
-            result = spt.rectify(hdulist, interps=interps,
+            result = spt.rectify(inhdul, interps=interps,
                                  wave_min=wave_min, wave_max=wave_max,
                                  xi_min=xi_min, xi_max=xi_max,
                                  bin_width=dwave,

--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -301,6 +301,7 @@ class MetisLMSSpectralTrace(SpectralTrace):
 
     def __init__(self, hdulist, spslice, params, **kwargs):
         polyhdu = hdulist["Polynomial coefficients"]
+        params = dict(params)   # do not modify the caller's dictionary
         params.update(kwargs)
         params["aperture_id"] = spslice
         params["slice"] = spslice

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -348,7 +348,7 @@ class SpectralTraceList(Effect):
 
         if interps is None:
             logger.debug("Computing interpolation functions")
-            interps = make_image_interpolations(hdulist)
+            interps = make_image_interpolations(inhdul)
 
         pdu = fits.PrimaryHDU()
         pdu.header["FILETYPE"] = "Rectified spectra"
@@ -358,7 +358,7 @@ class SpectralTraceList(Effect):
 
         for i, trace_id in tqdm(enumerate(self.spectral_traces, start=1),
                                 desc=" Traces", total=len(self.spectral_traces)):
-            hdu = self[trace_id].rectify(hdulist,
+            hdu = self[trace_id].rectify(inhdul,
                                          interps=interps,
                                          bin_width=bin_width,
                                          xi_min=xi_min, xi_max=xi_max,

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -230,6 +230,7 @@ class SpectralTrace:
             self._xilamimg = xilam   # ..todo: remove or make available with a debug flag?
         except ValueError:
             logger.warning(" ---> %s gave ValueError", self.trace_id)
+            return None
 
         npix_xi, npix_lam = xilam.npix_xi, xilam.npix_lam
         xilam_wcs = xilam.wcs

--- a/scopesim/tests/tests_effects/test_MetisLMSTraceList.py
+++ b/scopesim/tests/tests_effects/test_MetisLMSTraceList.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 import pytest
 from numpy.testing import assert_allclose
 from astropy.io import fits
-from scopesim.effects.metis_lms_trace_list import predisperser_angle
+from scopesim.effects.metis_lms_trace_list import (predisperser_angle,
+                                                   echelle_setting,
+                                                   MetisLMSSpectralTrace)
 
 
 # pylint: disable=missing-class-docstring
@@ -38,6 +40,26 @@ class TestDetectorLayoutCache:
         assert first is second
         mlt._read_detector_layout.cache_clear()
 
+class TestMetisLMSSpectralTraceInit:
+    def test_does_not_mutate_caller_params(self, mock_dir, monkeypatch):
+        """The params dict is passed by reference from the trace list's
+        self.meta; the trace previously wrote its slice-specific values
+        (slice, aperture_id, ...) back into it."""
+        monkeypatch.setattr(MetisLMSSpectralTrace, "fov_grid",
+                            lambda self: {})
+
+        with fits.open(mock_dir / "METIS_LMS/TRACE_LMS.fits") as hdul:
+            ech = echelle_setting(4.2, 18.2, hdul["WCAL"].data)
+            params = {"order": ech["Ord"], "echelle": ech["Echelle"],
+                      "wavelen": 4.2}
+            snapshot = dict(params)
+
+            trace = MetisLMSSpectralTrace(hdul, spslice=0, params=params)
+
+            assert params == snapshot, \
+                "constructor modified the caller's params dict"
+            assert trace.meta["slice"] == 0
+            assert trace.meta["aperture_id"] == 0
 
 
 @pytest.mark.usefixtures("patch_mock_path_metis")

--- a/scopesim/tests/tests_effects/test_SpectralTraceList.py
+++ b/scopesim/tests/tests_effects/test_SpectralTraceList.py
@@ -80,6 +80,49 @@ def fixture_spectral_trace_list():
     #        spectral_trace_list.rectify_traces(hdulist)
 
 
+class TestRectifyTracesInput:
+    def test_rectify_traces_opens_filename_before_use(
+            self, spectral_trace_list, tmp_path, monkeypatch):
+        """rectify_traces accepts a filename, but passed the raw string on
+        to make_image_interpolations and SpectralTrace.rectify instead of
+        the opened HDUList."""
+        import numpy as np
+        from astropy.table import Table
+        from scopesim.effects import spectral_trace_list as stl_mod
+
+        readout = tmp_path / "readout.fits"
+        fits.HDUList([fits.PrimaryHDU(),
+                      fits.ImageHDU(data=np.zeros((10, 10)))]
+                     ).writeto(readout)
+
+        # Stub the filter lookup; it needs a fully configured instrument
+        class FakeFilterCurve:
+            table = Table(data=[[1.0, 2.0], [1.0, 1.0]],
+                          names=["wavelength", "transmission"])
+
+        monkeypatch.setattr(stl_mod, "FilterCurve",
+                            lambda **kwargs: FakeFilterCurve())
+        monkeypatch.setattr(stl_mod, "from_currsys",
+                            lambda *args, **kwargs: "J")
+
+        # Record what object each trace's rectify() receives
+        received = []
+
+        def fake_rectify(self, hdulist, **kwargs):
+            received.append(hdulist)
+            return None
+
+        monkeypatch.setattr(SpectralTrace, "rectify", fake_rectify)
+
+        result = spectral_trace_list.rectify_traces(
+            str(readout), xi_min=-1, xi_max=1)
+
+        assert isinstance(result, fits.HDUList)
+        assert received, "rectify() was never called"
+        assert all(isinstance(hdul, fits.HDUList) for hdul in received), \
+            "traces received the filename string, not the opened HDUList"
+
+
 class TestSpectralTraceListWheel:
     @pytest.mark.usefixtures("no_file_error")
     def test_basic_init(self):

--- a/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
+++ b/scopesim/tests/tests_effects/test_SpectralTraceListUtils.py
@@ -159,6 +159,32 @@ class TestTransform2D:
         assert res.shape == (n_y, n_x)
 
 
+class TestMapSpectraErrorPath:
+    def test_returns_none_when_xilamimage_fails(self, monkeypatch):
+        """A ValueError from XiLamImage was logged but then the unbound
+        variable was used anyway, raising NameError instead."""
+        from scopesim.effects import spectral_trace_list_utils as stlu_mod
+        from scopesim.tests.mocks.py_objects import header_objects as ho
+
+        class FailingXiLamImage:
+            def __init__(self, *args, **kwargs):
+                raise ValueError("simulated failure")
+
+        monkeypatch.setattr(stlu_mod, "XiLamImage", FailingXiLamImage)
+
+        spt = SpectralTrace(tlo.trace_1(), trace_id="TRACE_1",
+                            pixel_scale=0.004, plate_scale=0.266)
+
+        class FakeFov:
+            header = ho._basic_fov_header()
+            detector_header = header
+            trace_id = "TRACE_1"
+            meta = {"wave_min": 1.2 * u.um, "wave_max": 2.4 * u.um,
+                    "xi_min": -1.5 * u.arcsec, "xi_max": 1.5 * u.arcsec}
+
+        assert spt.map_spectra_to_focal_plane(FakeFov()) is None
+
+
 class MockCubeFov:
     """Minimal stand-in for a FieldOfView carrying a spectral cube."""
     def __init__(self, n_lam=20, n_eta=3, n_xi=11):


### PR DESCRIPTION
Human-readbale summary:

Bug 1: `rectify_cube()` and `traces()` ignore their own checks for `filename `or `HDUList` at the top of the functions. 
Bug 2: `map_spectra_to_focal_plane` continues even when chucking an error on a `XiLamImage `call. Fails again two lines later (line 235) on `xilam_wcs = xilam.wcs`
Bug 3: Copy of params dict, to avoid altering the original contents of the dict being passed to the function

For more information, see the toaster's explanation below the line. But I think the code changes are more informative anyway

---




Three independent, few-line fixes, kept as separate commits for review:

## 1. `rectify_traces` / `rectify_cube` crash when given a filename

Both methods document accepting *"str or fits.HDUList"* and open the file into `inhdul` — but then passed the **original argument** on to `make_image_interpolations()` and `SpectralTrace.rectify()`. With a filename this raised `AttributeError: 'str' object has no attribute 'header'`; with an in-memory HDUList it happened to work, masking the bug. Now `inhdul` is used consistently after opening.

## 2. `map_spectra_to_focal_plane` turned a handled error into a NameError

A `ValueError` raised while building the `XiLamImage` was caught and logged, but execution then continued with the unbound local variable:

```
NameError: name 'xilam' is not defined
```

The method now returns `None` — the same "no contribution from this trace" contract as the footprint-outside-FoV and empty-footprint paths, which all callers already handle.

## 3. `MetisLMSSpectralTrace` wrote into the trace list's meta dict

`MetisLMSSpectralTraceList.make_spectral_traces` passes `params=self.meta` by reference to each of the 28 slice traces; each trace then updated that shared dict with its slice-specific values (`slice`, `aperture_id`, plus construction kwargs). After building all traces the *list's* meta carried whichever slice came last. The constructor now copies the dict at the boundary.

## Testing

One regression test per fix:
- `TestRectifyTracesInput::test_rectify_traces_opens_filename_before_use`
- `TestMapSpectraErrorPath::test_returns_none_when_xilamimage_fails`
- `TestMetisLMSSpectralTraceInit::test_does_not_mutate_caller_params`

Notebooks demonstrating each fix on the METIS IRDB (including the full LSS observe→readout→rectify-from-file chain for fix 1) are attached below.