### PR TITLE
Stop `SpectralTraceList.meta` dict overwriting individual `SPectralTrace.meta` dicts

### DIFF
--- a/scopesim/effects/mosaic_trace_list.py
+++ b/scopesim/effects/mosaic_trace_list.py
@@ -135,8 +135,10 @@ class MosaicSpectralTraceList(SpectralTraceList):
             # a possibility to "mask" traces.
             if row["image_plane_id"] == -1:
                 continue
-            params = {col: row[col] for col in row.colnames}
-            params.update(self.meta)
+            # list-level meta provides defaults, the trace-specific values
+            # from the catalogue row (description, extension_id, ...) win
+            params = dict(self.meta)
+            params.update({col: row[col] for col in row.colnames})
             hdu = self._file[row["extension_id"]]
             spec_traces[row["description"]] = MosaicSpectralTrace(hdu, **params)
 

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -149,8 +149,10 @@ class SpectralTraceList(Effect):
         self.catalog = Table(self._file[self.ext_cat].data)
         spec_traces = {}
         for row in self.catalog:
-            params = {col: row[col] for col in row.colnames}
-            params.update(self.meta)
+            # list-level meta provides defaults, the trace-specific values
+            # from the catalogue row (description, extension_id, ...) win
+            params = dict(self.meta)
+            params.update({col: row[col] for col in row.colnames})
             hdu = self._file[row["extension_id"]]
             spec_traces[row["description"]] = SpectralTrace(hdu, **params)
 

--- a/scopesim/tests/tests_effects/test_SpectralTraceList.py
+++ b/scopesim/tests/tests_effects/test_SpectralTraceList.py
@@ -59,6 +59,14 @@ class TestInit:
         slist = SpectralTraceList(hdulist=full_trace_list)
         assert isinstance(slist['Sheared'], SpectralTrace)
 
+    def test_trace_values_win_over_list_meta(self, full_trace_list):
+        # The effect-level meta (e.g. the YAML description of the whole
+        # list) previously clobbered the per-trace catalogue columns
+        slist = SpectralTraceList(hdulist=full_trace_list,
+                                  description="list-level description")
+        for key, trace in slist.spectral_traces.items():
+            assert trace.meta["description"] == key
+
     def test_setitem_appends_correctly(self, full_trace_list):
         slist = SpectralTraceList(hdulist=full_trace_list)
         n_trace = len(slist.spectral_traces)


### PR DESCRIPTION
The Toaster-generated description is actually pretty ok for this one - summarised with the problem statement:

```
most instrument YAMLs give the effect a `description`, every individual `SpectralTrace` had its catalogue 
description replaced by the list-level one (e.g. all eight MICADO traces described as 
*"list of spectral order trace geometry on the focal plane"* instead of `ORDER_3_1` etc.)
```

This PR swaps the `params.update(self.meta)` to `dict(self.meta).update(params)` to preserve individual `SpectralTrace `meta info

It seems fine and the tests bare it out. In practice it seems it's limited to the "description" key, but in general, we want each individual `SpectralTrace` to retain it's own settings. So this seems to, in the words of Martin, "reduce the future bug cross-section"

--- 

## What

`make_spectral_traces` built each trace's parameters as *catalogue row columns, then overwritten by the list's meta*:

```python
params = {col: row[col] for col in row.colnames}
params.update(self.meta)          # meta clobbers the row on any collision
```

Since most instrument YAMLs give the effect a `description`, every individual `SpectralTrace` had its catalogue description replaced by the list-level one (e.g. all eight MICADO traces described as *"list of spectral order trace geometry on the focal plane"* instead of `ORDER_3_1` etc.). The same applies to any future collision between effect kwargs and the per-trace catalogue columns (`description`, `extension_id`, `aperture_id`, `image_plane_id`).

Precedence is now: list meta provides the defaults, the trace-specific catalogue values win. Applied to `SpectralTraceList` and the same pattern in `MosaicSpectralTraceList`.

## Behaviour note

This is a (mild) behaviour change by design: previously, an effect kwarg colliding with a catalogue column silently overrode it per trace. No instrument package in the IRDB relies on that — the colliding key in practice is only `description` — and the full basic_instrument spectroscopy/IFU end-to-end suite passes unchanged.

## Testing

- New test `TestInit::test_trace_values_win_over_list_meta`: per-trace descriptions survive a list-level `description` kwarg.
- Notebook demonstrating the effect on the MICADO trace catalogue is attached below.