### PR TITLE
Cache the detector layout file in `MetisLMSSpectralTraceList` to avoid reading the file N*28 times for every `OpticalTrain` usage

### DIFF
--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -3,6 +3,7 @@
 
 import copy
 import warnings
+from functools import lru_cache
 
 from tqdm.auto import tqdm
 import numpy as np
@@ -26,6 +27,17 @@ from ..optics.fov_volume_list import FovVolumeList
 
 
 logger = get_logger(__name__)
+
+
+@lru_cache(maxsize=8)
+def _read_detector_layout(filename):
+    """Read (and cache) a detector layout file.
+
+    The layout is required by ``MetisLMSSpectralTrace.fov_grid``, which is
+    called several times for each of the 28 slices; without the cache the
+    same file is read and parsed from disk on every call.
+    """
+    return ioascii.read(find_file(filename))
 
 
 class MetisLMSSpectralTraceList(SpectralTraceList):
@@ -323,7 +335,7 @@ class MetisLMSSpectralTrace(SpectralTrace):
         y_max = aperture["top"]
 
         filename_det_layout = from_currsys("!DET.layout.file_name", cmds=self.cmds)
-        layout = ioascii.read(find_file(filename_det_layout))
+        layout = _read_detector_layout(filename_det_layout)
         det_lims = {}
         xhw = layout["pixel_size"] * layout["x_size"] / 2
         yhw = layout["pixel_size"] * layout["y_size"] / 2

--- a/scopesim/tests/tests_effects/test_MetisLMSTraceList.py
+++ b/scopesim/tests/tests_effects/test_MetisLMSTraceList.py
@@ -16,6 +16,30 @@ def patch_mock_path_metis(mock_dir):
     with patch("scopesim.rc.__search_path__", [metis_dir]):
         yield
 
+class TestDetectorLayoutCache:
+    def test_layout_file_is_read_only_once(self, mock_dir, monkeypatch):
+        from scopesim.effects import metis_lms_trace_list as mlt
+
+        mlt._read_detector_layout.cache_clear()
+        calls = []
+        real_read = mlt.ioascii.read
+
+        def counting_read(*args, **kwargs):
+            calls.append(args)
+            return real_read(*args, **kwargs)
+
+        monkeypatch.setattr(mlt.ioascii, "read", counting_read)
+
+        path = str(mock_dir / "files" / "LIST_detector_layout.dat")
+        first = mlt._read_detector_layout(path)
+        second = mlt._read_detector_layout(path)
+
+        assert len(calls) == 1
+        assert first is second
+        mlt._read_detector_layout.cache_clear()
+
+
+
 @pytest.mark.usefixtures("patch_mock_path_metis")
 class TestPredisperserAngle:
     @pytest.mark.parametrize("coeffs,wavelen,expected",


### PR DESCRIPTION
TL;DR - tiny efficiency speed up to avoid excessive disk reads of the DetectorLayout file
@teutoburg requesting your review for this one as it's more about ScopeSim mehcanics, rather than METIS mechanics

---

## What

`MetisLMSSpectralTrace.fov_grid` needs the detector limits and read + parsed the layout file (`!DET.layout.file_name`) from disk on **every call**. Building an LMS trace list calls it several times for each of the 28 slices (trace construction, `update_meta`, volume setup), so the same small file was read dozens of times per `OpticalTrain` — more during `observe()`.

The read is wrapped in a small `lru_cache`'d module function (`maxsize=8`, keyed on the filename), so each layout file is read once per session.

## Testing

- New test `TestDetectorLayoutCache::test_layout_file_is_read_only_once` counts the actual `ascii.read` calls for repeated lookups.
- A notebook counting the file reads while building the real METIS LMS trace list (lookups vs actual reads) is attached below.