### PR TITLE
Vectorise matrix extraction in MetisLMSSpectralTrace.get_matrices

### DIFF
--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -417,24 +417,22 @@ class MetisLMSSpectralTrace(SpectralTrace):
         matrices = {}
 
         poly = self.table
-        for matid in range(4):
-            select = ((poly["Ord"] == order) *
-                      (poly["Sli"] == spslice) *
-                      (poly["Mat"] == matid))
-            if not np.any(select):
+        select = (poly["Ord"] == order) & (poly["Sli"] == spslice)
+        subpoly = poly[select]
+
+        # Evaluate the angle polynomial for all rows of the four matrices
+        values = (subpoly["P3"] * angle**3 + subpoly["P2"] * angle**2 +
+                  subpoly["P1"] * angle + subpoly["P0"])
+
+        for matid, matname in enumerate(matnames):
+            sel_mat = subpoly["Mat"] == matid
+            if not np.any(sel_mat):
                 raise KeyError("Combination of Order, Slice not found")
 
-            subpoly = poly[select]
             thematrix = np.zeros((4, 4))
-            for i in range(4):
-                for j in range(4):
-                    sel_ij = (subpoly["Row"] == i) * (subpoly["Col"] == j)
-                    thematrix[i, j] = (subpoly["P3"][sel_ij][0] * angle**3 +
-                                       subpoly["P2"][sel_ij][0] * angle**2 +
-                                       subpoly["P1"][sel_ij][0] * angle +
-                                       subpoly["P0"][sel_ij][0])
-
-            matrices[matnames[matid]] = thematrix
+            thematrix[subpoly["Row"][sel_mat],
+                      subpoly["Col"][sel_mat]] = values[sel_mat]
+            matrices[matname] = thematrix
 
         return matrices
 

--- a/scopesim/tests/tests_effects/test_MetisLMSTraceList.py
+++ b/scopesim/tests/tests_effects/test_MetisLMSTraceList.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 import pytest
 from numpy.testing import assert_allclose
 from astropy.io import fits
-from scopesim.effects.metis_lms_trace_list import predisperser_angle
+from scopesim.effects.metis_lms_trace_list import (predisperser_angle,
+                                                   echelle_setting,
+                                                   MetisLMSSpectralTrace)
 
 
 # pylint: disable=missing-class-docstring
@@ -38,6 +40,51 @@ class TestDetectorLayoutCache:
         assert first is second
         mlt._read_detector_layout.cache_clear()
 
+
+class TestGetMatrices:
+    def test_matches_elementwise_reference(self, mock_dir, monkeypatch):
+        """get_matrices must reproduce the element-by-element evaluation of
+        the angle polynomial exactly."""
+        import numpy as np
+
+        monkeypatch.setattr(MetisLMSSpectralTrace, "fov_grid",
+                            lambda self: {})
+
+        with fits.open(mock_dir / "METIS_LMS/TRACE_LMS.fits") as hdul:
+            ech = echelle_setting(4.2, 18.2, hdul["WCAL"].data)
+            order, angle = ech["Ord"], ech["Echelle"]
+
+            for spslice in (0, 13, 27):
+                trace = MetisLMSSpectralTrace(
+                    hdul, spslice=spslice,
+                    params={"order": order, "echelle": angle, "wavelen": 4.2})
+                matrices = trace.get_matrices()
+
+                poly = trace.table
+                for matid, name in enumerate(["A", "B", "AI", "BI"]):
+                    reference = np.zeros((4, 4))
+                    sel = ((poly["Ord"] == order) & (poly["Sli"] == spslice)
+                           & (poly["Mat"] == matid))
+                    sub = poly[sel]
+                    for i in range(4):
+                        for j in range(4):
+                            s_ij = (sub["Row"] == i) & (sub["Col"] == j)
+                            reference[i, j] = (
+                                sub["P3"][s_ij][0] * angle**3
+                                + sub["P2"][s_ij][0] * angle**2
+                                + sub["P1"][s_ij][0] * angle
+                                + sub["P0"][s_ij][0])
+                    assert_allclose(matrices[name], reference, rtol=0,
+                                    atol=0)
+
+    def test_raises_for_unknown_order(self, mock_dir, monkeypatch):
+        monkeypatch.setattr(MetisLMSSpectralTrace, "fov_grid",
+                            lambda self: {})
+        with fits.open(mock_dir / "METIS_LMS/TRACE_LMS.fits") as hdul:
+            with pytest.raises(KeyError):
+                MetisLMSSpectralTrace(
+                    hdul, spslice=0,
+                    params={"order": -1, "echelle": 0., "wavelen": 4.2})
 
 
 @pytest.mark.usefixtures("patch_mock_path_metis")


### PR DESCRIPTION
Adding both @oczoske and @teutoburg as it's more a mechanics issue, than an instrument specific one. 
Local tests produce identical results.

TL;DR - A speed boost for SpectralTraceList

From the testing notebook, removing these nested loops results in a 10x speed boost for extracting the polynomial coefficients

Not that impressive on a single run, but when we have to run this hundreds of times for METIS_Simulations, it all adds up.

```
import time
from astropy.io import fits
from scopesim.effects.metis_lms_trace_list import (MetisLMSSpectralTraceList,
                                                   echelle_setting)

cmd = scopesim.UserCommands(use_instrument="METIS", set_modes=["lms"])
lms = MetisLMSSpectralTraceList(
    filename="TRACE_LMS.fits", wavelen=4.2, cmds=cmd,
    wave_colname="wavelength", s_colname="xi", slice_samples=5)
trace = lms.spectral_traces["Slice 1"]
order, angle = trace.meta["order"], trace.meta["echelle"]
print(f"order {order}, echelle angle {angle:.3f} deg")

# Reference: the removed per-element implementation
def get_matrices_reference(trace):
    poly = trace.table
    order = trace.meta["order"]; spslice = trace.meta["slice"]
    angle = trace.meta["echelle"]
    out = {}
    for matid, name in enumerate(["A", "B", "AI", "BI"]):
        sel = ((poly["Ord"] == order) & (poly["Sli"] == spslice)
               & (poly["Mat"] == matid))
        sub = poly[sel]
        mat = np.zeros((4, 4))
        for i in range(4):
            for j in range(4):
                s = (sub["Row"] == i) & (sub["Col"] == j)
                mat[i, j] = (sub["P3"][s][0]*angle**3 + sub["P2"][s][0]*angle**2
                             + sub["P1"][s][0]*angle + sub["P0"][s][0])
        out[name] = mat
    return out

t0 = time.perf_counter()
ref = {sid: get_matrices_reference(spt) for sid, spt in lms.spectral_traces.items()}
t1 = time.perf_counter()
new = {sid: spt.get_matrices() for sid, spt in lms.spectral_traces.items()}
t2 = time.perf_counter()

worst = max(np.abs(new[sid][m] - ref[sid][m]).max()
            for sid in ref for m in ref[sid])
print(f"per-element loops (28 slices): {t1-t0:.3f} s")
print(f"vectorised       (28 slices): {t2-t1:.3f} s   ({(t1-t0)/(t2-t1):.0f}x)")
print(f"max |difference| over all 28 x 4 matrices: {worst}")
assert worst == 0.0
```

Resulting in 
```
per-element loops (28 slices): 0.356 s
vectorised       (28 slices): 0.037 s   (10x)
max |difference| over all 28 x 4 matrices: 0.0
```

Toaster description below:

-----

## What

The A/B/AI/BI matrices are polynomial evaluations at the echelle angle, with coefficients selected from the `Polynomial coefficients` table (37,632 rows in `TRACE_LMS.fits`). The old loop ran one boolean mask over the full table per matrix, plus one mask per matrix element on the sub-table — (4 + 64) table scans for each of the 28 slices, on every trace-list construction.

The new code selects the (order, slice) block once, evaluates the angle polynomial on whole columns, and scatters the values into the 4x4 matrices via their Row/Col index columns. **The resulting matrices are exactly identical** (same additions in the same order — unit-tested element-by-element with zero tolerance); the KeyError for an unknown order/slice combination is kept.

## Testing

- `TestGetMatrices::test_matches_elementwise_reference` — exact equality against the previous per-element evaluation for slices 1, 14 and 28 of the real coefficient table.
- `TestGetMatrices::test_raises_for_unknown_order` — KeyError behaviour preserved.
- A notebook with the equivalence check and timing on the full 28-slice TRACE_LMS is attached below.