### PR TITLE
Use exceptions instead of return None

### DIFF
--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -17,9 +17,12 @@ from astropy import units as u
 
 from ..utils import from_currsys, find_file, quantify, get_logger
 from .spectral_trace_list import SpectralTraceList
-from .spectral_trace_list_utils import SpectralTrace
-from .spectral_trace_list_utils import Transform2D
-from .spectral_trace_list_utils import make_image_interpolations
+from .spectral_trace_list_utils import (
+    SpectralTrace,
+    Transform2D,
+    make_image_interpolations,
+    SpecTraceError,
+)
 from .apertures import ApertureMask
 from .ter_curves import TERCurve
 from ..optics.fov import FieldOfView, FieldOfView3D
@@ -141,13 +144,22 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
                 slicefov.cube = fits.ImageHDU(header=slicewcs.to_header(),
                                               data=slicecube)
                 # slicefov.cube.writeto(f"slicefov_{sptid}.fits", overwrite=True)
-                slicefov.hdu = spt.map_spectra_to_focal_plane(slicefov)
-                if slicefov.hdu is not None:
-                    sxmin = slicefov.hdu.header["XMIN"]
-                    sxmax = slicefov.hdu.header["XMAX"]
-                    symin = slicefov.hdu.header["YMIN"]
-                    symax = slicefov.hdu.header["YMAX"]
-                    fovimage[symin:symax, sxmin:sxmax] += slicefov.hdu.data
+                try:
+                    slicefov.hdu = spt.map_spectra_to_focal_plane(slicefov)
+                except (KeyError, ValueError) as err:
+                    # Should also match NoXlimError, KwNotFound
+                    logger.error(err)
+                except SpecTraceError as err:
+                    # If we need specific behavior for any of these, we can
+                    # import the subclass and deal with it separately.
+                    logger.info(err)
+                    continue
+
+                sxmin = slicefov.hdu.header["XMIN"]
+                sxmax = slicefov.hdu.header["XMAX"]
+                symin = slicefov.hdu.header["YMIN"]
+                symax = slicefov.hdu.header["YMAX"]
+                fovimage[symin:symax, sxmin:sxmax] += slicefov.hdu.data
 
             obj.hdu = fits.ImageHDU(data=fovimage, header=obj.detector_header)
 
@@ -163,11 +175,13 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
         self.meta["predisperser"] = tempres["Predisperser"]
 
         spec_traces = {}
-        for sli in np.arange(self.meta["nslice"]):
-            slicename = "Slice " + str(sli + 1)
+        for sli in range(self.meta["nslice"]):
+            slicename = f"Slice {sli + 1}"
             spec_traces[slicename] = MetisLMSSpectralTrace(
                 self._file,
-                spslice=sli, params=self.meta)
+                spslice=sli,
+                params=self.meta,
+            )
 
         self.spectral_traces = spec_traces
 
@@ -235,11 +249,27 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
         for i, spt in enumerate(self.spectral_traces.values()):
             spt.wave_min = wave_min
             spt.wave_max = wave_max
-            result = spt.rectify(hdulist, interps=interps,
-                                 wave_min=wave_min, wave_max=wave_max,
-                                 xi_min=xi_min, xi_max=xi_max,
-                                 bin_width=dwave,
-                                 fit_inverse=fit_inverse)
+
+            try:
+                result = spt.rectify(
+                    hdulist,
+                    interps=interps,
+                    wave_min=wave_min,
+                    wave_max=wave_max,
+                    xi_min=xi_min,
+                    xi_max=xi_max,
+                    bin_width=dwave,
+                    fit_inverse=fit_inverse,
+                )
+            except (KeyError, ValueError) as err:
+                # Should also match NoXlimError, KwNotFound
+                logger.error(err)
+            except SpecTraceError as err:
+                # If we need specific behavior for any of these, we can
+                # import the subclass and deal with it separately.
+                logger.info(err)
+                continue
+
             cube[:, i, :] = result.data.T
 
         # FIXME: use wcs object here
@@ -307,7 +337,7 @@ class MetisLMSSpectralTrace(SpectralTrace):
         super().__init__(polyhdu, **params)
 
         self._file = hdulist
-        self.meta["description"] = "Slice " + str(spslice + 1)
+        self.meta["description"] = f"Slice {spslice + 1}"
         self.meta["trace_id"] = f"Slice {spslice + 1}"
         self.meta.update(params)
         # Provisional:

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -14,14 +14,17 @@ from tqdm.auto import tqdm
 from astropy.io import fits
 from astropy.table import Table
 
-from .effects import Effect
-from .ter_curves import FilterCurve
-from .spectral_trace_list_utils import SpectralTrace, make_image_interpolations
+from ..utils import from_currsys, check_keys, figure_factory, get_logger
 from ..optics.image_plane_utils import header_from_list_of_xy
 from ..optics.fov import FieldOfView
 from ..optics.fov_volume_list import FovVolumeList
-from ..utils import from_currsys, check_keys, figure_factory, get_logger
-
+from .effects import Effect
+from .ter_curves import FilterCurve
+from .spectral_trace_list_utils import (
+    SpectralTrace,
+    make_image_interpolations,
+    SpecTraceError,
+)
 
 logger = get_logger(__name__)
 
@@ -257,7 +260,15 @@ class SpectralTraceList(Effect):
                 self.update_meta()
 
             spt = self.spectral_traces[obj.trace_id]
-            obj.hdu = spt.map_spectra_to_focal_plane(obj)
+            try:
+                obj.hdu = spt.map_spectra_to_focal_plane(obj)
+            except ValueError as err:
+                # Should also match NoXlimError
+                logger.error(err)
+            except SpecTraceError as err:
+                # If we need specific behavior for any of these, we can
+                # import the subclass and deal with it separately.
+                logger.info(err)
 
         logger.debug("%s done", self.display_name)
         return obj
@@ -358,12 +369,26 @@ class SpectralTraceList(Effect):
 
         for i, trace_id in tqdm(enumerate(self.spectral_traces, start=1),
                                 desc=" Traces", total=len(self.spectral_traces)):
-            hdu = self[trace_id].rectify(hdulist,
-                                         interps=interps,
-                                         bin_width=bin_width,
-                                         xi_min=xi_min, xi_max=xi_max,
-                                         wave_min=wave_min, wave_max=wave_max)
-            if hdu is not None:   # ..todo: rectify does not do that yet
+            try:
+                hdu = self[trace_id].rectify(
+                    hdulist,
+                    interps=interps,
+                    bin_width=bin_width,
+                    xi_min=xi_min,
+                    xi_max=xi_max,
+                    wave_min=wave_min,
+                    wave_max=wave_max,
+                )
+            except (KeyError, ValueError) as err:
+                # Should also match NoXlimError, KwNotFound
+                logger.error(err)
+            except SpecTraceError as err:
+                # If we need specific behavior for any of these, we can
+                # import the subclass and deal with it separately.
+                logger.info(err)
+                continue
+
+            if hdu is not None:   # TODO: rectify does not do that yet
                 outhdul.append(hdu)
                 outhdul[0].header[f"EXTNAME{i}"] = trace_id
 

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -31,6 +31,26 @@ from ..utils import (power_vector, quantify, from_currsys, close_loop,
 logger = get_logger(__name__)
 
 
+class SpecTraceError(Exception):
+    """Base class for exceptions in this module."""
+
+
+class NoXlimError(SpecTraceError, ValueError):
+    """Dunno."""
+
+
+class KwNotFound(SpecTraceError, KeyError):
+    """Required keyword for rectification was not found."""
+
+
+class TraceOutsideFov(SpecTraceError):
+    """The spectral trace falls outside the given FOV."""
+
+
+class OutsideFilterRange(SpecTraceError):
+    """Trace wavelength is not within filter waverange."""
+
+
 class SpectralTrace:
     """Definition of one spectral trace.
 
@@ -175,8 +195,7 @@ class SpectralTrace:
                                           xi_min=xi_min, xi_max=xi_max)
 
         if xlim_mm is None:
-            logger.warning("xlim_mm is None")
-            return None
+            raise NoXlimError("xlim_mm is None")
 
         fov_header = fov.header
         det_header = fov.detector_header
@@ -197,9 +216,8 @@ class SpectralTrace:
 
         # Check if spectral trace footprint is outside FoV
         if xmax < 0 or xmin > naxis1d or ymax < 0 or ymin > naxis2d:
-            logger.info(
-                "Spectral trace %s: footprint is outside FoV", fov.trace_id)
-            return None
+            raise TraceOutsideFov(
+                f"Spectral trace {fov.trace_id}: footprint is outside FoV")
 
         # Only work on parts within the FoV
         xmin = max(xmin, 0)
@@ -329,8 +347,8 @@ class SpectralTrace:
         wave_max = kwargs.get("wave_max",
                               self.wave_max)
         if wave_max < self.wave_min or wave_min > self.wave_max:
-            logger.debug("   Outside filter range")
-            return None
+            raise OutsideFilterRange("   Outside filter range")
+
         wave_min = max(wave_min, self.wave_min)
         wave_max = min(wave_max, self.wave_max)
         logger.info("Rectifying %s (%.02f .. %.02f um)",
@@ -352,15 +370,14 @@ class SpectralTrace:
             try:
                 xi_min = hdulist[0].header["HIERARCH INS SLIT XIMIN"]
             except KeyError:
-                logger.error("xi_min not found")
-                return None
+                raise KwNotFound("xi_min not found")
+
         xi_max = kwargs.get("xi_max", None)
         if xi_max is None:
             try:
                 xi_max = hdulist[0].header["HIERARCH INS SLIT XIMAX"]
             except KeyError:
-                logger.error("xi_max not found")
-                return None
+                raise KwNotFound("xi_max not found")
 
         if wcs is None:
             wcs = WCS(naxis=2)


### PR DESCRIPTION
Fairly minimal, we'll see if that does anything about #991. Either way, I think this is better because the previous implementation broke the "a function should not return different things" principle by returning `None` in some cases.