### PR TITLE
Improve handling of spectral trace mapping and rectification

### DIFF
--- a/scopesim/effects/metis_lms_trace_list.py
+++ b/scopesim/effects/metis_lms_trace_list.py
@@ -17,9 +17,11 @@ from astropy import units as u
 
 from ..utils import from_currsys, find_file, quantify, get_logger
 from .spectral_trace_list import SpectralTraceList
-from .spectral_trace_list_utils import SpectralTrace
-from .spectral_trace_list_utils import Transform2D
-from .spectral_trace_list_utils import make_image_interpolations
+from .spectral_trace_list_utils import (
+    SpectralTrace,
+    Transform2D,
+    make_image_interpolations,
+)
 from .apertures import ApertureMask
 from .ter_curves import TERCurve
 from ..optics.fov import FieldOfView, FieldOfView3D
@@ -126,28 +128,44 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
 
                 slicecube = np.zeros((n_z, ny_slice, n_x))
                 for islice in range(n_z):
-                    ifov = RectBivariateSpline(np.arange(n_y),
-                                               np.arange(n_x),
-                                               fovcube[islice], kx=1, ky=1)
+                    ifov = RectBivariateSpline(
+                        np.arange(n_y),
+                        np.arange(n_x),
+                        fovcube[islice],
+                        kx=1,
+                        ky=1,
+                    )
                     slicecube[islice] = ifov(yfov, xfov, grid=False)
 
-                slicefov = FieldOfView3D(obj.header,
-                                         [obj.meta["wave_min"],
-                                          obj.meta["wave_max"]])
+                slicefov = FieldOfView3D(
+                    obj.header,
+                    [obj.meta["wave_min"], obj.meta["wave_max"]],
+                )
                 slicefov.detector_header = obj.detector_header
                 slicefov.meta["xi_min"] = obj.meta["xi_min"]
                 slicefov.meta["xi_max"] = obj.meta["xi_max"]
                 slicefov.meta["trace_id"] = sptid
-                slicefov.cube = fits.ImageHDU(header=slicewcs.to_header(),
-                                              data=slicecube)
+                slicefov.cube = fits.ImageHDU(
+                    header=slicewcs.to_header(),
+                    data=slicecube,
+                )
                 # slicefov.cube.writeto(f"slicefov_{sptid}.fits", overwrite=True)
-                slicefov.hdu = spt.map_spectra_to_focal_plane(slicefov)
-                if slicefov.hdu is not None:
-                    sxmin = slicefov.hdu.header["XMIN"]
-                    sxmax = slicefov.hdu.header["XMAX"]
-                    symin = slicefov.hdu.header["YMIN"]
-                    symax = slicefov.hdu.header["YMAX"]
-                    fovimage[symin:symax, sxmin:sxmax] += slicefov.hdu.data
+
+                try:
+                    # If footprint is outside FOV, this will assign None to the hdu
+                    slicefov.hdu = spt.map_spectra_to_focal_plane(slicefov)
+                except ValueError as err:  # xlim_mm is None
+                    logger.error(err)
+                    continue
+
+                if slicefov.hdu is None:  # footprint outside FOV
+                    continue
+
+                sxmin = slicefov.hdu.header["XMIN"]
+                sxmax = slicefov.hdu.header["XMAX"]
+                symin = slicefov.hdu.header["YMIN"]
+                symax = slicefov.hdu.header["YMAX"]
+                fovimage[symin:symax, sxmin:sxmax] += slicefov.hdu.data
 
             obj.hdu = fits.ImageHDU(data=fovimage, header=obj.detector_header)
 
@@ -163,11 +181,13 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
         self.meta["predisperser"] = tempres["Predisperser"]
 
         spec_traces = {}
-        for sli in np.arange(self.meta["nslice"]):
-            slicename = "Slice " + str(sli + 1)
+        for sli in range(self.meta["nslice"]):
+            slicename = f"Slice {sli + 1}"
             spec_traces[slicename] = MetisLMSSpectralTrace(
                 self._file,
-                spslice=sli, params=self.meta)
+                spslice=sli,
+                params=self.meta,
+            )
 
         self.spectral_traces = spec_traces
 
@@ -235,11 +255,25 @@ class MetisLMSSpectralTraceList(SpectralTraceList):
         for i, spt in enumerate(self.spectral_traces.values()):
             spt.wave_min = wave_min
             spt.wave_max = wave_max
-            result = spt.rectify(hdulist, interps=interps,
-                                 wave_min=wave_min, wave_max=wave_max,
-                                 xi_min=xi_min, xi_max=xi_max,
-                                 bin_width=dwave,
-                                 fit_inverse=fit_inverse)
+
+            try:
+                result = spt.rectify(
+                    hdulist,
+                    interps=interps,
+                    wave_min=wave_min,
+                    wave_max=wave_max,
+                    xi_min=xi_min,
+                    xi_max=xi_max,
+                    bin_width=dwave,
+                    fit_inverse=fit_inverse,
+                )
+            except (KeyError, ValueError) as err:
+                logger.error(err)
+                continue
+
+            if result is None:  # Outside filter range
+                continue
+
             cube[:, i, :] = result.data.T
 
         # FIXME: use wcs object here
@@ -307,7 +341,7 @@ class MetisLMSSpectralTrace(SpectralTrace):
         super().__init__(polyhdu, **params)
 
         self._file = hdulist
-        self.meta["description"] = "Slice " + str(spslice + 1)
+        self.meta["description"] = f"Slice {spslice + 1}"
         self.meta["trace_id"] = f"Slice {spslice + 1}"
         self.meta.update(params)
         # Provisional:

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -14,13 +14,13 @@ from tqdm.auto import tqdm
 from astropy.io import fits
 from astropy.table import Table
 
-from .effects import Effect
-from .ter_curves import FilterCurve
-from .spectral_trace_list_utils import SpectralTrace, make_image_interpolations
+from ..utils import from_currsys, check_keys, figure_factory, get_logger
 from ..optics.image_plane_utils import header_from_list_of_xy
 from ..optics.fov import FieldOfView
 from ..optics.fov_volume_list import FovVolumeList
-from ..utils import from_currsys, check_keys, figure_factory, get_logger
+from .effects import Effect
+from .ter_curves import FilterCurve
+from .spectral_trace_list_utils import SpectralTrace, make_image_interpolations
 
 
 logger = get_logger(__name__)
@@ -257,7 +257,11 @@ class SpectralTraceList(Effect):
                 self.update_meta()
 
             spt = self.spectral_traces[obj.trace_id]
-            obj.hdu = spt.map_spectra_to_focal_plane(obj)
+            try:
+                # If footprint is outside FOV, this will assign None to the hdu
+                obj.hdu = spt.map_spectra_to_focal_plane(obj)
+            except ValueError as err:  # xlim_mm is None
+                logger.error(err)
 
         logger.debug("%s done", self.display_name)
         return obj
@@ -358,14 +362,25 @@ class SpectralTraceList(Effect):
 
         for i, trace_id in tqdm(enumerate(self.spectral_traces, start=1),
                                 desc=" Traces", total=len(self.spectral_traces)):
-            hdu = self[trace_id].rectify(hdulist,
-                                         interps=interps,
-                                         bin_width=bin_width,
-                                         xi_min=xi_min, xi_max=xi_max,
-                                         wave_min=wave_min, wave_max=wave_max)
-            if hdu is not None:   # ..todo: rectify does not do that yet
-                outhdul.append(hdu)
-                outhdul[0].header[f"EXTNAME{i}"] = trace_id
+            try:
+                hdu = self[trace_id].rectify(
+                    hdulist,
+                    interps=interps,
+                    bin_width=bin_width,
+                    xi_min=xi_min,
+                    xi_max=xi_max,
+                    wave_min=wave_min,
+                    wave_max=wave_max,
+                )
+            except (KeyError, ValueError) as err:
+                logger.error(err)
+                continue
+
+            if hdu is None:   # TODO: rectify does not do that yet
+                continue
+
+            outhdul.append(hdu)
+            outhdul[0].header[f"EXTNAME{i}"] = trace_id
 
         outhdul[0].header.update(inhdul[0].header)
 

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -24,8 +24,14 @@ from astropy import units as u
 from astropy.wcs import WCS
 from astropy.modeling.models import Polynomial2D
 
-from ..utils import (power_vector, quantify, from_currsys, close_loop,
-                     figure_factory, get_logger)
+from ..utils import (
+    power_vector,
+    quantify,
+    from_currsys,
+    close_loop,
+    figure_factory,
+    get_logger,
+)
 
 
 logger = get_logger(__name__)
@@ -154,7 +160,8 @@ class SpectralTrace:
             logger.info(
                 "Dispersion axis determined to be %s", self.dispersion_axis)
 
-    def map_spectra_to_focal_plane(self, fov):
+    # TODO: add typing to fov: FieldOfView, but that creates a circular import
+    def map_spectra_to_focal_plane(self, fov) -> fits.ImageHDU:
         """
         Apply the spectral trace mapping to a spectral cube.
 
@@ -171,12 +178,15 @@ class SpectralTrace:
         wave_max = fov.meta["wave_max"].value       # [um]
         xi_min = fov.meta["xi_min"].value           # [arcsec]
         xi_max = fov.meta["xi_max"].value           # [arcsec]
-        xlim_mm, ylim_mm = self.footprint(wave_min=wave_min, wave_max=wave_max,
-                                          xi_min=xi_min, xi_max=xi_max)
+        xlim_mm, ylim_mm = self.footprint(
+            wave_min=wave_min,
+            wave_max=wave_max,
+            xi_min=xi_min,
+            xi_max=xi_max,
+        )
 
         if xlim_mm is None:
-            logger.warning("xlim_mm is None")
-            return None
+            raise ValueError("xlim_mm is None")
 
         fov_header = fov.header
         det_header = fov.detector_header
@@ -235,12 +245,10 @@ class SpectralTrace:
         xilam_wcs = xilam.wcs
 
         # focal-plane coordinate images
-        ximg_fpa, yimg_fpa = np.meshgrid(np.linspace(xmin_mm, xmax_mm,
-                                                     sub_naxis1,
-                                                     dtype=np.float32),
-                                         np.linspace(ymin_mm, ymax_mm,
-                                                     sub_naxis2,
-                                                     dtype=np.float32))
+        ximg_fpa, yimg_fpa = np.meshgrid(
+            np.linspace(xmin_mm, xmax_mm, sub_naxis1, dtype=np.float32),
+            np.linspace(ymin_mm, ymax_mm, sub_naxis2, dtype=np.float32),
+        )
 
         # Image mapping (xi, lambda) on the focal plane
         xi_fpa = self.xy2xi(ximg_fpa, yimg_fpa).astype(np.float32)
@@ -276,8 +284,9 @@ class SpectralTrace:
 
         # Scale to ph / s / pixel
         dlam_by_dx, dlam_by_dy = self.xy2lam.gradient()
-        dlam_per_pix = pixsize * np.sqrt(dlam_by_dx(ximg_fpa, yimg_fpa)**2 +
-                                         dlam_by_dy(ximg_fpa, yimg_fpa)**2)
+        dlam_per_pix = pixsize * np.sqrt(
+            dlam_by_dx(ximg_fpa, yimg_fpa)**2 +
+            dlam_by_dy(ximg_fpa, yimg_fpa)**2)
         image *= pixscale * dlam_per_pix        # [arcsec/pix] * [um/pix]
 
         # img_header = sub_wcs.to_header()
@@ -289,14 +298,34 @@ class SpectralTrace:
         img_header["YMAX"] = ymax
 
         if np.any(image < 0):
-            logger.warning("map_spectra_to_focal_plane: %d negative pixels",
-                           np.sum(image < 0))
+            logger.warning(
+                "map_spectra_to_focal_plane: %d negative pixels",
+                np.sum(image < 0))
 
         image_hdu = fits.ImageHDU(header=img_header, data=image)
         return image_hdu
 
-    def rectify(self, hdulist, interps=None, wcs=None, **kwargs):
+    def rectify(
+        self,
+        hdulist: fits.HDUList,
+        interps: list | None = None,
+        wcs: WCS | None = None,
+        fit_inverse: bool = True,
+        bin_width: float | None = None,
+        wave_min: float | None = None,
+        wave_max: float | None = None,
+        xi_min: float | None = None,
+        xi_max: float | None = None,
+    ) -> fits.ImageHDU | None:
         """Create 2D spectrum for a trace.
+
+        .. todo: Consider turning `interps` into a dict keyed on extname.
+
+        .. todo: Proper typing on `interps`.
+
+        .. todo: Rewrite and expand docstring (FH).
+
+        .. todo: Consider using quantities for float parameters.
 
         Parameters
         ----------
@@ -323,22 +352,21 @@ class SpectralTrace:
            Spatial limits of the slit on the sky. This should be taken from
            the header of the hdulist, but this is not yet provided by scopesim
         """
-        self.fit_inverse = kwargs.get("fit_inverse", True)
-        wave_min = kwargs.get("wave_min",
-                              self.wave_min)
-        wave_max = kwargs.get("wave_max",
-                              self.wave_max)
+        # Note: fit_inverse used to be self.fit_inverse, but wasn't used
+        #       outside this function.
+        wave_min = wave_min if wave_min is not None else self.wave_min
+        wave_max = wave_max if wave_max is not None else self.wave_max
         if wave_max < self.wave_min or wave_min > self.wave_max:
             logger.debug("   Outside filter range")
             return None
+
         wave_min = max(wave_min, self.wave_min)
         wave_max = min(wave_max, self.wave_max)
         logger.info("Rectifying %s (%.02f .. %.02f um)",
                     self.trace_id, wave_min, wave_max)
 
         # bin_width is taken as the minimum dispersion of the trace
-        # ..todo: if wcs is given take bin width from cdelt1
-        bin_width = kwargs.get("bin_width", None)
+        # TODO: if wcs is given take bin width from cdelt1
         if bin_width is None:
             self._set_dispersion(wave_min, wave_max)
             bin_width = np.abs(self.dlam_per_pix.y).min()
@@ -347,20 +375,23 @@ class SpectralTrace:
         pixscale = from_currsys(self.meta["pixel_scale"], self.cmds)
 
         # Temporary solution to get slit length
-        xi_min = kwargs.get("xi_min", None)
         if xi_min is None:
             try:
                 xi_min = hdulist[0].header["HIERARCH INS SLIT XIMIN"]
-            except KeyError:
-                logger.error("xi_min not found")
-                return None
-        xi_max = kwargs.get("xi_max", None)
+            except KeyError as err:
+                raise KeyError(
+                    "xi_min must be in header as 'INS SLIT XIMIN' or provided "
+                    "directly as an argument."
+                ) from err
+
         if xi_max is None:
             try:
                 xi_max = hdulist[0].header["HIERARCH INS SLIT XIMAX"]
-            except KeyError:
-                logger.error("xi_max not found")
-                return None
+            except KeyError as err:
+                raise KeyError(
+                    "xi_max must be in header as 'INS SLIT XIMAX' or provided "
+                    "directly as an argument."
+                ) from err
 
         if wcs is None:
             wcs = WCS(naxis=2)
@@ -381,20 +412,26 @@ class SpectralTrace:
             interps = make_image_interpolations(hdulist, kx=1, ky=1)
 
         # Create Xi, Lam images (do I need Iarr and Jarr or can I build Xi, Lam directly?)
-        Iarr, Jarr = np.meshgrid(np.arange(nlam, dtype=np.float32),
-                                 np.arange(nxi, dtype=np.float32))
+        Iarr, Jarr = np.meshgrid(
+            np.arange(nlam, dtype=np.float32),
+            np.arange(nxi, dtype=np.float32),
+        )
         Lam, Xi = wcs.all_pix2world(Iarr, Jarr, 0)
 
         # Make sure that we do have microns
         Lam = Lam * u.Unit(wcs.wcs.cunit[0]).to(u.um)
 
-        ## TODO: Replace self.xilam2x and self.xilam2y by fitted
-        ##       functions fit_xilam2x and fit_xilam2y, which need
-        ##       to be determined by mapping a grid of (xi, lam) to (x,y)
-        ##       and back to (xip, lamp); then fit (x,y)(xip, lamp).
-        if self.fit_inverse:
-            fit_xilam2x, fit_xilam2y = self._fit_transform(xi_min, xi_max,
-                                                           wave_min, wave_max)
+        # TODO: Replace self.xilam2x and self.xilam2y by fitted
+        #       functions fit_xilam2x and fit_xilam2y, which need
+        #       to be determined by mapping a grid of (xi, lam) to (x,y)
+        #       and back to (xip, lamp); then fit (x,y)(xip, lamp).
+        if fit_inverse:
+            fit_xilam2x, fit_xilam2y = self._fit_transform(
+                xi_min,
+                xi_max,
+                wave_min,
+                wave_max,
+            )
         else:
             logger.debug("Using matrix transform")
             fit_xilam2x, fit_xilam2y = self.xilam2x, self.xilam2y
@@ -527,14 +564,18 @@ class SpectralTrace:
 
         # Map the edges of xi/lam to the focal plance
         n_edge = 512
-        wave_edge = np.concatenate((np.linspace(wave_min, wave_max, n_edge),
-                                    [wave_max] * n_edge,
-                                    np.linspace(wave_min, wave_max, n_edge),
-                                    [wave_min] * n_edge))
-        xi_edge = np.concatenate(([xi_min] * n_edge,
-                                  np.linspace(xi_min, xi_max, n_edge),
-                                  [xi_max] * n_edge,
-                                  np.linspace(xi_min, xi_max, n_edge)))
+        wave_edge = np.concatenate((
+            np.linspace(wave_min, wave_max, n_edge),
+            [wave_max] * n_edge,
+            np.linspace(wave_min, wave_max, n_edge),
+            [wave_min] * n_edge,
+        ))
+        xi_edge = np.concatenate((
+            [xi_min] * n_edge,
+            np.linspace(xi_min, xi_max, n_edge),
+            [xi_max] * n_edge,
+            np.linspace(xi_min, xi_max, n_edge),
+        ))
 
         x_edge = self.xilam2x(xi_edge, wave_edge)
         y_edge = self.xilam2y(xi_edge, wave_edge)


### PR DESCRIPTION
- raise `ValueError` when `xlim_mm` is None (`footprint` could be improved)
- remove `kwargs` from `.rectify()`, make all args explicit
- raise `KeyError` when `xi_min` or `xi_max` are neither in args nor header
- some typing and formatting along the way (yeah that could have been separate...)

Alternative to #996.