### PR TITLE
Refactor `PSF.apply_to()`

### DIFF
--- a/scopesim/effects/psfs/discrete.py
+++ b/scopesim/effects/psfs/discrete.py
@@ -7,8 +7,7 @@ from pathlib import Path
 import numpy as np
 from tqdm.auto import tqdm
 from scipy.signal import convolve
-from scipy.ndimage import zoom
-from scipy.interpolate import griddata, RectBivariateSpline, RegularGridInterpolator
+from scipy.interpolate import RectBivariateSpline, griddata
 
 from astropy import units as u
 from astropy.io import fits

--- a/scopesim/effects/psfs/psf_base.py
+++ b/scopesim/effects/psfs/psf_base.py
@@ -57,98 +57,104 @@ class PSF(Effect):
         self.meta = from_currsys(self.meta, self.cmds)
         self.convolution_classes = (FieldOfView, ImagePlane)
 
+    def __call__(self, data: np.ndarray, kernel: np.ndarray) -> np.ndarray:
+        # subtract background level before convolving, re-add afterwards
+        bkg_level = get_bkg_level(data, self.meta["bkg_width"])
+
+        if data.ndim == 3:
+            bkg_level = bkg_level[:, None, None]
+
+        image = np.asarray(data - bkg_level)
+
+        # Shortcut for flat images, which wouldn't change with convolution
+        if image.sum() == 0.:
+            logger.debug(
+                "%s: uniform field, convolution skipped", self.meta["name"])
+            return data  # return unchanged
+
+        mode = from_currsys(self.meta["convolve_mode"], self.cmds)
+
+        match image.ndim, kernel.ndim:
+            case 2, 2:
+                return convolve(image, kernel, mode=mode) + bkg_level
+
+            case 3, 2:
+                kernel = kernel[None, ...]
+                return convolve(image, kernel, mode=mode) + bkg_level
+
+            case 3, 3:
+                if mode != "same":
+                    logger.warning(
+                        "cube-cube convolution assumes mode='same', but mode "
+                        "is %s, result may be inconsistent.", mode)
+
+                convolved = np.zeros(data.shape)  # assumes mode="same"
+                for iplane in range(data.shape[0]):
+                    convolved[iplane,] = convolve(
+                        image[iplane,],
+                        kernel[iplane,],
+                        mode=mode,
+                    )
+                return convolved + bkg_level
+
+            case _:
+                raise ValueError("Image and Kernel shape mismatch.")
+
+    def _apply_to_fvl(self, fvl: FovVolumeList) -> None:
+        logger.debug("Executing %s, FoV setup", self.meta["name"])
+        if len(self._waveset) != 0:
+            waveset_edges = 0.5 * (self._waveset[:-1] + self._waveset[1:])
+            fvl.split("wave", quantify(waveset_edges, u.um).value)
+
+    def _apply_convolution(self, obj) -> None:
+        logger.debug("Executing %s, convolution", self.meta["name"])
+        if ((hasattr(obj, "fields") and len(obj.fields) > 0) or
+                (obj.hdu is not None)):
+            kernel = self.get_kernel(obj).astype(float)
+
+            # This doesn't work because of a "Delta PSF" in some mocks...
+            # if kernel.size == 1:  # only 1 pixel
+            #     raise ValueError("Cannot convolve single pixel PSF.")
+
+            # apply rotational blur for field-tracking observations
+            rot_blur_angle = self.meta["rotational_blur_angle"]
+            if abs(rot_blur_angle << u.deg) > 0*u.deg:
+                # makes a copy of kernel
+                kernel = rotational_blur(kernel, rot_blur_angle)
+
+            # Round the edges of kernels so that the silly square stars
+            # don't appear anymore
+            if self.meta.get("rounded_edges", False) and kernel.ndim == 2:
+                kernel = self._round_kernel_edges(kernel)
+
+            # normalise psf kernel      KERNEL SHOULD BE normalised within get_kernel()
+            # if from_currsys(self.meta["normalise_kernel"], self.cmds):
+            #    kernel /= np.sum(kernel)
+            #    kernel[kernel < 0.] = 0.
+
+            orig_shape = obj.hdu.data.shape
+
+            logger.debug("PSF convolution start")
+            obj.hdu.data = self(obj.hdu.data.astype(float), kernel)
+            logger.debug("PSF convolution done")
+
+            # TODO: careful with which dimensions mean what
+            d_x = obj.hdu.data.shape[-1] - orig_shape[-1]
+            d_y = obj.hdu.data.shape[-2] - orig_shape[-2]
+            for wcsid in ["", "D"]:
+                if "CRPIX1" + wcsid in obj.hdu.header:
+                    obj.hdu.header["CRPIX1" + wcsid] += d_x / 2
+                    obj.hdu.header["CRPIX2" + wcsid] += d_y / 2
+
     def apply_to(self, obj, **kwargs):
         """Apply the PSF."""
         # 1. During setup of the FieldOfViews
         if isinstance(obj, FovVolumeList) and self._waveset is not None:
-            logger.debug("Executing %s, FoV setup", self.meta['name'])
-            waveset = self._waveset
-            if len(waveset) != 0:
-                waveset_edges = 0.5 * (waveset[:-1] + waveset[1:])
-                obj.split("wave", quantify(waveset_edges, u.um).value)
+            self._apply_to_fvl(obj)
 
         # 2. During observe: convolution
         elif isinstance(obj, self.convolution_classes):
-            logger.debug("Executing %s, convolution", self.meta['name'])
-            if ((hasattr(obj, "fields") and len(obj.fields) > 0) or
-                    (obj.hdu is not None)):
-                image = obj.hdu.data.astype(float)
-
-                # subtract background level before convolving, re-add afterwards
-                bkg_level = get_bkg_level(image, self.meta["bkg_width"])
-
-                # Short-circuit for spatially uniform fields (e.g. darks and
-                # closed-shutter calibration frames): the background is
-                # subtracted before the convolution below and re-added after,
-                # so for a uniform image the convolution input is identically
-                # zero and the output is bit-for-bit the input. Skip the
-                # (expensive) kernel interpolation/rescale and FFT entirely.
-                # This is exact, not approximate: it only fires when the
-                # residual is exactly zero everywhere.
-                # np.asarray: the FOV data can be an astropy Quantity, whose
-                # truthiness/.any() raises TypeError; we only need the values
-                if image.ndim == 3:
-                    residual = np.asarray(
-                        image - np.asarray(bkg_level)[:, None, None])
-                else:
-                    residual = np.asarray(image - bkg_level)
-                if not residual.any():
-                    logger.debug(
-                        "%s: uniform field, convolution skipped",
-                        self.meta["name"])
-                    obj.hdu.data = image
-                    return obj
-
-                kernel = self.get_kernel(obj).astype(float)
-
-                # This doesn't work because of a "Delta PSF" in some mocks...
-                # if kernel.size == 1:  # only 1 pixel
-                #     raise ValueError("Cannot convolve single pixel PSF.")
-
-                # apply rotational blur for field-tracking observations
-                rot_blur_angle = self.meta["rotational_blur_angle"]
-                if abs(rot_blur_angle << u.deg) > 0*u.deg:
-                    # makes a copy of kernel
-                    kernel = rotational_blur(kernel, rot_blur_angle)
-
-                # Round the edges of kernels so that the silly square stars
-                # don't appear anymore
-                if self.meta.get("rounded_edges", False) and kernel.ndim == 2:
-                    kernel = self._round_kernel_edges(kernel)
-
-                # normalise psf kernel      KERNEL SHOULD BE normalised within get_kernel()
-                # if from_currsys(self.meta["normalise_kernel"], self.cmds):
-                #    kernel /= np.sum(kernel)
-                #    kernel[kernel < 0.] = 0.
-
-                # do the convolution
-                mode = from_currsys(self.meta["convolve_mode"], self.cmds)
-
-                logger.debug("PSF convolution start")
-                if image.ndim == 2 and kernel.ndim == 2:
-                    new_image = convolve(image - bkg_level, kernel, mode=mode)
-                elif image.ndim == 3 and kernel.ndim == 2:
-                    kernel = kernel[None, :, :]
-                    bkg_level = bkg_level[:, None, None]
-                    new_image = convolve(image - bkg_level, kernel, mode=mode)
-                elif image.ndim == 3 and kernel.ndim == 3:
-                    bkg_level = bkg_level[:, None, None]
-                    new_image = np.zeros(image.shape)  # assumes mode="same"
-                    for iplane in range(image.shape[0]):
-                        new_image[iplane,] = convolve(
-                            image[iplane,] - bkg_level[iplane,],
-                            kernel[iplane,], mode=mode)
-
-                obj.hdu.data = new_image + bkg_level
-                logger.debug("PSF convolution done")
-
-                # TODO: careful with which dimensions mean what
-                d_x = new_image.shape[-1] - image.shape[-1]
-                d_y = new_image.shape[-2] - image.shape[-2]
-                for wcsid in ["", "D"]:
-                    if "CRPIX1" + wcsid in obj.hdu.header:
-                        obj.hdu.header["CRPIX1" + wcsid] += d_x / 2
-                        obj.hdu.header["CRPIX2" + wcsid] += d_y / 2
+            self._apply_convolution(obj)
 
         return obj
 


### PR DESCRIPTION
## Context

This was pulled from a (local) branch with more changes like this, but it's easier to review if done piece-by-piece.

Eventually, (all??) effects will become Callables (and maybe also dataclasses, see #387, but that's somewhat orthogonal), which enables two things:

1. Pulling individual effects out of the optical train to apply just that one effect directly.
2. Injecting simple functions into the optical train for custom effects, that don't need to become a full subclass upstream.

The conceptual split is that the `.__call__()` should act _directly on the data array_ (if applicable, e.g. the FITS header effects work differently), whereas the `.apply_to()` _delegates_ based on the type of object it receives. The latter is not new, that's how `.apply_to()` always worked. Some effects (like the `PSF` in this case) also act on a "meta level", i.e. they don't just affect the photons passing through the optical train, but also the optical train itself. That behavior will _not_ move to the `.__call__()`. I realize this sounds a bit like going back to `.fov_grid`, but it's not.

In the future, we might replace the (broken, see #696 an others) `z_order` with mixin classes (or intermediate subclasses to `Effect`), which cleverly handle the delegation. In that scenario, the `.apply_to()` method might only actually exist in the base `Effect` in the end. That's why I created `._apply_to_fvl()` and `._apply_convolution()` to work towards that. Even if we end up deciding against that, splitting the `.apply_to()` into individual methods which get delegated makes everything a bit cleaner.

### A small but important difference

The `.apply_to()` always returns the object it was handed (that's fundamental to ScopeSim). The new `._apply_*()` methods modify the object in-place. Not sure if that design decision is final, but for now I think that's better. If not, that's a cheap change. Much more importantly, the new `.__call__()` _accepts and array and returns an array_, without and in-place modifications of the original array. This is in vaguely working towards making (some parts of) ScopeSim compatible with J-UBIK and JAX. There's much more to do for that, but the effects that came up as "most relevant" in our last collaboration are a good place to start, and those are the PSF and TER curves.

## Changes

No (intentional) functional change, just refactored.

- Extract actual array operation (useful for JAX in the future)
- Make actual apply_to easier to read (will be called by Effect mixins in the future)
- Slightly refactor toaster's shortcut from #973