### PR TITLE
Refactor `TERCurve.apply_to()`

### DIFF
--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -4,26 +4,38 @@
 import warnings
 from typing import ClassVar
 from collections.abc import Collection, Iterable
-from pooch import retrieve
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 from scipy import integrate
 from astropy import units as u
 from astropy.io import fits
 from astropy.table import Table
+from synphot import SpectralElement, SourceSpectrum
 
 import skycalc_ipy
 
 from .effects import Effect
-from .ter_curves_utils import (add_edge_zeros, combine_two_spectra,
-                               apply_throughput_to_cube, download_svo_filter,
-                               download_svo_filter_list)
+from .ter_curves_utils import (
+    add_edge_zeros,
+    download_svo_filter,
+    download_svo_filter_list,
+)
 from ..optics.fov_volume_list import FovVolumeList
 from ..optics.surface import SpectralSurface
 from ..source.source import Source
-from ..source.source_fields import (CubeSourceField, SpectrumSourceField,
-                                    BackgroundSourceField)
-from ..utils import (from_currsys, quantify, check_keys, find_file,
-                     figure_factory, get_logger)
+from ..source.source_fields import (
+    CubeSourceField,
+    SpectrumSourceField,
+    BackgroundSourceField,
+)
+from ..utils import (
+    from_currsys,
+    quantify,
+    check_keys,
+    find_file,
+    figure_factory,
+    get_logger,
+)
 from ..server.download_utils import create_retriever
 
 logger = get_logger(__name__)
@@ -109,53 +121,64 @@ class TERCurve(Effect):
             self.surface.table = data
             self.surface.table.meta.update(self.meta)
 
+    def __call__(self, data: ArrayLike, waveset: u.Quantity[u.um]) -> NDArray:
+        return data * self.throughput(waveset).value[:, None, None]
+
+    def _apply_to_fvl(self, fvl: FovVolumeList) -> None:
+        logger.debug("Apply %s, FoV setup", self.display_name)
+
+        wave = self.surface.throughput.waveset
+        thru = self.surface.throughput(wave)
+        valid_waves = np.argwhere(thru > 0)
+        wave_min = wave[max(0, valid_waves[0][0] - 1)]
+        wave_max = wave[min(len(wave) - 1, valid_waves[-1][0] + 1)]
+
+        fvl.shrink("wave", [wave_min.to_value(u.um), wave_max.to_value(u.um)])
+
+    def _apply_to_src(self, src: Source) -> None:
+        logger.debug("Apply %s, Source spectra", self.display_name)
+
+        self.meta = from_currsys(self.meta, self.cmds)
+        wave_min = quantify(self.meta["wave_min"], u.um).to(u.AA)
+        wave_max = quantify(self.meta["wave_max"], u.um).to(u.AA)
+
+        thru = self.throughput
+
+        # apply transmission to source spectra
+        for fld in src.fields:
+            if isinstance(fld, CubeSourceField):
+                fld.field.data = self(fld.field.data, fld.waveset)
+            elif isinstance(fld, SpectrumSourceField):
+                fld.spectra = {
+                    isp: spec * thru  # This works because synphot!
+                    for isp, spec in fld.spectra.items()
+                }
+            else:
+                # Rather log than raise here, can still move on
+                logger.error(
+                    "Source field is neither Cube nor has spectra, this "
+                    "should not happen, but moving on.")
+
+        # add the effect background to the source background field
+        if self.background_source is not None:
+            for bgs in self.background_source:
+                src.append(bgs)
+
     def apply_to(self, obj, **kwargs):
         if isinstance(obj, Source):
-            self.meta = from_currsys(self.meta, self.cmds)
-            wave_min = quantify(self.meta["wave_min"], u.um).to(u.AA)
-            wave_max = quantify(self.meta["wave_max"], u.um).to(u.AA)
-
-            thru = self.throughput
-
-            # apply transmission to source spectra
-            for fld in obj.fields:
-                if isinstance(fld, CubeSourceField):
-                    fld.field = apply_throughput_to_cube(
-                        fld.field, thru, fld.waveset)
-                elif isinstance(fld, SpectrumSourceField):
-                    fld.spectra = {
-                        isp: combine_two_spectra(spec, thru, "multiply",
-                                                 wave_min, wave_max)
-                        for isp, spec in fld.spectra.items()
-                    }
-                else:
-                    # Rather log than raise here, can still move on
-                    logger.error("Source field is neither Cube nor has "
-                                 "spectra, this shouldn't occur...")
-
-            # add the effect background to the source background field
-            if self.background_source is not None:
-                for bgs in self.background_source:
-                    obj.append(bgs)
+            self._apply_to_src(obj)
 
         if isinstance(obj, FovVolumeList):
-            wave = self.surface.throughput.waveset
-            thru = self.surface.throughput(wave)
-            valid_waves = np.argwhere(thru > 0)
-            wave_min = wave[max(0, valid_waves[0][0] - 1)]
-            wave_max = wave[min(len(wave) - 1, valid_waves[-1][0] + 1)]
-
-            obj.shrink("wave", [wave_min.to_value(u.um),
-                                wave_max.to_value(u.um)])
+            self._apply_to_fvl(obj)
 
         return obj
 
     @property
-    def emission(self):
+    def emission(self) -> SourceSpectrum:
         return self.surface.emission
 
     @property
-    def throughput(self):
+    def throughput(self) -> SpectralElement:
         return self.surface.throughput
 
     @property
@@ -166,23 +189,16 @@ class TERCurve(Effect):
             bkg_hdr = fits.Header()
 
             bkg_hdr.update({
+                "ROLE": "background",  # not used yet
                 "BG_SRC": True,
                 "BG_SURF": self.display_name,
                 "SPEC_REF": 0,
-                # Seem those are not needed...
-                # "CUNIT1": "ARCSEC",
-                # "CUNIT2": "ARCSEC",
-                # "CDELT1": 0,
-                # "CDELT2": 0,
                 "BUNIT": "photlam arcsec-2",
                 "SOLIDANG": "arcsec-2",
             })
             bkg_fld = BackgroundSourceField(field=None, spectra=bkg_spec, header=bkg_hdr)
             bkg_src = Source(field=bkg_fld)
 
-            # Before BackgroundSourceField:
-            # bkg_hdu = fits.ImageHDU(header=bkg_hdr)
-            # bkg_src = Source(image_hdu=bkg_hdu, spectra=flux)
             self._background_source = bkg_src
 
         return [self._background_source]
@@ -604,34 +620,6 @@ class FilterCurve(TERCurve):
         # TODO: maybe use actually masked table here?
         self.table["transmission"][mask] = 0
 
-    def fov_grid(self, which="waveset", **kwargs):
-        warnings.warn("The fov_grid method is deprecated and will be removed "
-                      "in a future release.", DeprecationWarning, stacklevel=2)
-        if which == "waveset":
-            self.meta.update(kwargs)
-            self.meta = from_currsys(self.meta, self.cmds)
-            # ..todo:: replace the 101 with a variable in !SIM
-            wave = np.linspace(self.meta["wave_min"],
-                               self.meta["wave_max"], 101)
-            wave = quantify(wave, u.um)
-            throughput = self.surface.transmission(wave)
-            min_thru = self.meta["minimum_throughput"]
-            valid_waves = np.where(throughput.value > min_thru)[0]
-            if len(valid_waves) > 0:
-                wave_edges = [min(wave[valid_waves].value),
-                              max(wave[valid_waves].value)] * u.um
-            else:
-                raise ValueError("No transmission found above the threshold {}"
-                                 " in this wavelength range {}. Did you open "
-                                 "the shutter?"
-                                 "".format(self.meta["minimum_throughput"],
-                                           [self.meta["wave_min"],
-                                            self.meta["wave_max"]]))
-        else:
-            wave_edges = []
-
-        return wave_edges
-
     @property
     def fwhm(self):
         wave = self.surface.wavelength
@@ -788,11 +776,6 @@ class FilterWheelBase(Effect):
     @property
     def throughput(self):
         return self.current_filter.throughput
-
-    def fov_grid(self, which="waveset", **kwargs):
-        warnings.warn("The fov_grid method is deprecated and will be removed "
-                      "in a future release.", DeprecationWarning, stacklevel=2)
-        return self.current_filter.fov_grid(which=which, **kwargs)
 
     def change_filter(self, filtername=None):
         """Change the current filter."""

--- a/scopesim/effects/ter_curves_utils.py
+++ b/scopesim/effects/ter_curves_utils.py
@@ -389,55 +389,6 @@ def apply_throughput_to_cube(
     return cube
 
 
-def combine_two_spectra(spec_a, spec_b, action, wave_min, wave_max):
-    """
-    Combine transmission and/or emission spectrum with a common waverange.
-
-    Spec_A is the source spectrum
-    Spec_B is either the transmission or emission that should be applied
-
-    Parameters
-    ----------
-    spec_a : synphot.SourceSpectrum
-    spec_b : synphot.SpectralElement, synphot.SourceSpectrum
-    action: {"multiply", "add"}
-    wave_min, wave_max : quantity
-        [Angstrom]
-
-    Returns
-    -------
-    new_source : synphot.SourceSpectrum
-
-    """
-    if spec_a.waveset is None:
-        wave_val = spec_b.waveset.value
-    else:
-        wave_val = spec_a.waveset.value
-    mask = (wave_val > wave_min.value) * (wave_val < wave_max.value)
-
-    wave = ([wave_min.value] + list(wave_val[mask]) + [wave_max.value]) * u.AA
-    if "mult" in action.lower():
-        spec_c = spec_a(wave) * spec_b(wave)
-        # Diagnostic plots - not for general use
-        # from matplotlib import pyplot as plt
-        # plt.plot(wave, spec_a(wave), label="spec_a")
-        # plt.plot(wave, spec_b(wave), label="spec_b")
-        # plt.plot(wave, spec_c, label="spec_c")
-        # plt.xlim(2.9e4, 4.2e4)
-        # plt.legend()
-        # plt.show()
-    elif "add" in action.lower():
-        spec_c = spec_a(wave) + spec_b(wave)
-    else:
-        raise ValueError(f"action {action} unknown")
-
-    new_source = SourceSpectrum(Empirical1D, points=wave, lookup_table=spec_c)
-    new_source.meta.update(spec_b.meta)
-    new_source.meta.update(spec_a.meta)
-
-    return new_source
-
-
 def add_edge_zeros(tbl, wave_colname):
     if isinstance(tbl, Table):
         vals = np.zeros(len(tbl.colnames))

--- a/scopesim/tests/tests_effects/test_TERCurve.py
+++ b/scopesim/tests/tests_effects/test_TERCurve.py
@@ -112,9 +112,6 @@ class TestFilterWheelInit:
     def test_current_filter_is_filter(self, fwheel):
         assert isinstance(fwheel.current_filter, tc.FilterCurve)
 
-    def test_current_filter_has_fov_grid_method(self, fwheel):
-        assert hasattr(fwheel.current_filter, "fov_grid")
-
     def test_change_to_known_filter(self, fwheel):
         fwheel.change_filter('Ks')
         assert fwheel.current_filter.meta["name"] == "Ks"


### PR DESCRIPTION
For detailed explanation see #1002, this is basically the same but for `TERCurve`. The new `.__call__()` in this case is exclusively for cubes, because 1D spectra work differently. But those could be simplified as well, and as a result the `combine_two_spectra` function was no longer needed.

Also finally remove the long-deprecated `.fov_grid()` methods that were still here. Everything passes without them. Well, except of course `test_current_filter_has_fov_grid_method`...