### PR TITLE
Refactor `.apply_to()` in electronic effects

### DIFF
--- a/scopesim/detector/detector.py
+++ b/scopesim/detector/detector.py
@@ -1,4 +1,7 @@
+# -*- coding: utf-8 -*-
+
 import numpy as np
+from numpy.typing import ArrayLike
 
 from astropy.io.fits import ImageHDU
 from astropy.wcs import WCS
@@ -71,6 +74,10 @@ class Detector:
     def data(self):
         """Return data from internal HDU."""
         return self._hdu.data
+
+    @data.setter
+    def data(self, data: ArrayLike):
+        self._hdu.data = data
 
     @property
     def image(self):

--- a/scopesim/effects/electronic/electrons.py
+++ b/scopesim/effects/electronic/electrons.py
@@ -189,8 +189,7 @@ class InterPixelCapacitance(Effect):
                          det.__class__.__name__)
             return det
 
-        newdata = oaconvolve(det._hdu.data, self.kernel, mode="same")
-        det._hdu.data = newdata
+        det.data = oaconvolve(det.data, self.kernel, mode="same")
         return det
 
     def update(self, **kwargs):

--- a/scopesim/effects/electronic/electrons.py
+++ b/scopesim/effects/electronic/electrons.py
@@ -9,17 +9,18 @@ Related effects:
 """
 
 from typing import ClassVar
+from numbers import Real  # matches int, float and all the numpy scalars
 
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 from scipy.signal import oaconvolve
 
 from .. import Effect
 from ...detector import Detector
 from ...utils import figure_factory, check_keys
-from ...utils import from_currsys, real_colname, get_logger
+from ...utils import from_currsys, real_colname
 from . import logger
 
-logger = get_logger(__name__)
 
 class LinearityCurve(Effect):
     """
@@ -62,21 +63,29 @@ class LinearityCurve(Effect):
 
         check_keys(self.meta, self.required_keys, action="error")
 
+    def __call__(self, data: ArrayLike, ndit: int = 1) -> NDArray:
+        incident = self.incident * ndit
+        measured = self.measured * ndit
+        return np.interp(data, incident, measured)
+
+    @property
+    def incident(self) -> NDArray:
+        if self.table is not None:
+            return self.table["incident"]
+        return np.asarray(from_currsys(self.meta["incident"], self.cmds))
+
+    @property
+    def measured(self) -> NDArray:
+        if self.table is not None:
+            return self.table["measured"]
+        return np.asarray(from_currsys(self.meta["measured"], self.cmds))
+
     def apply_to(self, obj, **kwargs):
         if not isinstance(obj, Detector):
             return obj
 
         ndit = from_currsys(self.meta["ndit"], self.cmds)
-        if self.table is not None:
-            incident = self.table["incident"] * ndit
-            measured = self.table["measured"] * ndit
-        else:
-            incident = np.asarray(from_currsys(self.meta["incident"],
-                                               self.cmds)) * ndit
-            measured = np.asarray(from_currsys(self.meta["measured"],
-                                               self.cmds)) * ndit
-        obj._hdu.data = np.interp(obj._hdu.data, incident, measured)
-
+        obj.data = self(obj.data, ndit)
         return obj
 
     def plot(self, **kwargs):
@@ -298,28 +307,34 @@ class ADConversion(Effect):
 
         return True
 
+    def __call__(self, data: ArrayLike, gain: Real) -> NDArray:
+        return data / gain
+
+    def _get_gain(self, det_meta) -> Real:
+        # Apply the gain value (copy from DarkCurrent)
+        # Note that this does not cater for the case where the gain is given
+        # as a plain dictionary. Should we implement that?
+        if hasattr(self.cmds["!DET.gain"], "dic"):
+            dtcr_id = det_meta[real_colname("id", det_meta)]
+            gain = self.cmds["!DET.gain"].dic[dtcr_id]
+            logger.info(f"Detector {dtcr_id}: applying gain {gain}")
+            return gain
+        if isinstance(self.cmds["!DET.gain"], Real):
+            gain = self.cmds["!DET.gain"]
+            logger.info(f"Applying gain {gain}")
+            return gain
+        raise ValueError(
+            f"{self.__class__.__name__}.meta['gain'] must be either "
+            f"dict or float, but is {self.cmds['!DET.gain']}")
+
     def apply_to(self, obj, **kwargs):
         if not isinstance(obj, Detector):
             return obj
 
         new_dtype = self.meta["dtype"]
 
-        # Apply the gain value (copy from DarkCurrent)
-        # Note that this does not cater for the case where the gain is given
-        # as a plain dictionary. Should we implement that?
-        if hasattr(self.cmds["!DET.gain"], "dic"):
-            dtcr_id = obj.meta[real_colname("id", obj.meta)]
-            gain = self.cmds["!DET.gain"].dic[dtcr_id]
-            logger.info(f"Detector {dtcr_id}: applying gain {gain}")
-        elif isinstance(self.cmds["!DET.gain"], (float, int)):
-            gain = self.cmds["!DET.gain"]
-            logger.info(f"Applying gain {gain}")
-        else:
-            raise ValueError("<ADConversion>.meta['gain'] must be either "
-                             f"dict or float, but is {self.cmds['!DET.gain']}")
-
         # Apply gain
-        obj._hdu.data /= gain
+        obj.data = self(obj.data, self._get_gain(obj.meta))
 
         # Type-conversion wraps around input values that are higher or lower than
         # the respective maximum and minimum values of the new data type. Before
@@ -328,14 +343,14 @@ class ADConversion(Effect):
         if np.issubdtype(new_dtype, np.integer):
             minval = np.iinfo(new_dtype).min
             maxval = np.iinfo(new_dtype).max
-            minvals_mask = obj._hdu.data < minval
-            maxvals_mask = obj._hdu.data > maxval
+            minvals_mask = obj.data < minval
+            maxvals_mask = obj.data > maxval
             if minvals_mask.any():
-                obj._hdu.data[minvals_mask] = minval
+                obj.data[minvals_mask] = minval
                 logger.warning(
                     f"Effect ADConversion: {minvals_mask.sum()} negative pixels")
             if maxvals_mask.any():
-                obj._hdu.data[maxvals_mask] = maxval
+                obj.data[maxvals_mask] = maxval
                 logger.warning(
                     f"Effect ADConversion: {maxvals_mask.sum()} saturated pixels")
 
@@ -343,6 +358,6 @@ class ADConversion(Effect):
         # set to the modified data. It should be fine to simply re-assign the
         # data attribute, but just in case it's not...
         logger.debug("Applying digitization to dtype %s.", new_dtype)
-        obj._hdu.data = obj._hdu.data.astype(new_dtype)
+        obj.data = obj.data.astype(new_dtype)
 
         return obj

--- a/scopesim/effects/electronic/exposure.py
+++ b/scopesim/effects/electronic/exposure.py
@@ -217,7 +217,7 @@ class ExposureOutput(Effect):
         logger.debug("Exposure: DIT = %s s, NDIT = %s", dit, ndit)
 
         if self.current_mode == "average":
-            obj._hdu.data /= ndit
+            obj.data = obj.data / ndit
 
         return obj
 
@@ -276,6 +276,6 @@ class ExposureIntegration(Effect):
                 "readout call."
             )
 
-        obj._hdu.data *= dit * ndit
+        obj.data = obj.data * dit * ndit
 
         return obj

--- a/scopesim/effects/electronic/noise.py
+++ b/scopesim/effects/electronic/noise.py
@@ -143,7 +143,7 @@ class PoorMansHxRGReadoutNoise(Effect):
             return det
 
         ndit = from_currsys(self.meta["ndit"], self.cmds)
-        det._hdu.data = self(det._hdu.data, ndit)
+        det.data = self(det.data, ndit)
         return det
 
     def plot(self, det, **kwargs):
@@ -190,7 +190,7 @@ class BasicReadoutNoise(Effect):
             return det
 
         ndit = from_currsys(self.meta["ndit"], self.cmds)
-        det._hdu.data = self(det._hdu.data, ndit)
+        det.data = self(det.data, ndit)
         return det
 
     def plot(self, det):
@@ -354,12 +354,7 @@ class ShotNoise(Effect):
         # - numpy.nan are implicitly passed through the normal distribution;
         #   because the Poisson distribution cannot handle them.
 
-        new_imagehdu = fits.ImageHDU(
-            data=self(det._hdu.data),
-            header=det._hdu.header,
-        )
-
-        det._hdu = new_imagehdu
+        det._hdu = fits.ImageHDU(header=det.header, data=self(det.data))
         return det
 
     def plot(self, det):

--- a/scopesim/effects/electronic/noise.py
+++ b/scopesim/effects/electronic/noise.py
@@ -2,9 +2,11 @@
 """Any kinds of electronic or photonic noise."""
 
 from typing import ClassVar
-from numbers import Real
+from collections.abc import Mapping
+from numbers import Real  # matches int, float and all the numpy scalars
 
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 from astropy.io import fits
 
 from .. import Effect
@@ -24,14 +26,18 @@ class Bias(Effect):
         self.meta.update(kwargs)
         check_keys(self.meta, self.required_keys, action="error")
 
+    def __call__(self, data: ArrayLike) -> NDArray:
+        return data + self.bias_level
+
+    @property
+    def bias_level(self) -> float:
+        return from_currsys(self.meta["bias"], self.cmds)
+
     def apply_to(self, obj, **kwargs):
         if not isinstance(obj, Detector):
             return obj
 
-        biaslevel = from_currsys(self.meta["bias"], self.cmds)
-        # Can't do in-place because of Quantization data type conflicts.
-        obj._hdu.data = obj._hdu.data + biaslevel
-
+        obj.data = self(obj.data)
         return obj
 
 
@@ -55,32 +61,89 @@ class PoorMansHxRGReadoutNoise(Effect):
 
         check_keys(self.meta, self.required_keys, action="error")
 
-    def apply_to(self, det, **kwargs):
-        if not isinstance(det, Detector):
-            return det
-
-        self.meta["random_seed"] = from_currsys(self.meta["random_seed"],
-                                                self.cmds)
-        if self.meta["random_seed"] is not None:
-            np.random.seed(self.meta["random_seed"])
-
+    def __call__(self, data: ArrayLike, ndit: int = 1) -> NDArray:
         self.meta = from_currsys(self.meta, self.cmds)
-        ron_keys = ["noise_std", "n_channels", "channel_fraction",
-                    "line_fraction", "pedestal_fraction", "read_fraction"]
-        ron_kwargs = {key: self.meta[key] for key in ron_keys}
-        ron_kwargs["image_shape"] = det._hdu.data.shape
 
-        ron_frame = _make_ron_frame(**ron_kwargs)
+        ron_frame = self._make_ron_frame(data.shape)
+
         stacked_ron_frame = np.zeros_like(ron_frame)
-        for i in range(self.meta["ndit"]):
+        for i in range(ndit):
             dx = np.random.randint(0, ron_frame.shape[1])
             dy = np.random.randint(0, ron_frame.shape[0])
             stacked_ron_frame += np.roll(ron_frame, (dy, dx), axis=(0, 1))
 
         # TODO: this .T is ugly. Work out where things are getting switched and remove it!
-        # Can't do in-place because of Quantization data type conflicts.
-        det._hdu.data = det._hdu.data + stacked_ron_frame.T
+        return data + stacked_ron_frame.T
 
+    @property
+    def noise_std(self) -> int:
+        return from_currsys(self.meta["noise_std"], self.cmds)
+
+    @property
+    def n_channels(self) -> int:
+        return from_currsys(self.meta["n_channels"], self.cmds)
+
+    @property
+    def random_seed(self) -> int:
+        return from_currsys(self.meta["random_seed"], self.cmds)
+
+    @staticmethod
+    def _pseudo_random_field(
+        rng,
+        scale: float = 1.,
+        size: tuple[int, ...] = (1024, 1024),
+    ) -> NDArray:
+        n = 256
+        image = np.zeros(size)
+        batch = rng.normal(loc=0, scale=scale, size=(2*n, 2*n))
+        for y in range(0, size[1], n):
+            for x in range(0, size[0], n):
+                i, j = rng.integers(n, size=2)
+                dx, dy = min(size[0]-x, n), min(size[1]-y, n)
+                image[x:x+dx, y:y+dy] = batch[i:i+dx, j:j+dy]
+
+        return image
+
+    def _make_ron_frame(self, shape: tuple[int, ...]) -> NDArray:
+        # TODO: Add yaml-settable seed here
+        rng = np.random.default_rng(self.random_seed)
+
+        channel_fraction = self.meta["channel_fraction"]
+        line_fraction = self.meta["line_fraction"]
+        pedestal_fraction = self.meta["pedestal_fraction"]
+        read_fraction = self.meta["read_fraction"]
+
+        pixel_std = self.noise_std * (pedestal_fraction + read_fraction)**0.5
+        if shape < (1024, 1024):
+            pixel = rng.normal(loc=0, scale=pixel_std, size=shape)
+            line = rng.normal(
+                loc=0,
+                scale=self.noise_std * line_fraction**0.5,
+                size=shape[1],
+            )
+        else:
+            # TODO: Why bother with this pseudo random function?
+            pixel = self._pseudo_random_field(rng, scale=pixel_std, size=shape)
+            line = pixel[0]
+
+        channel = np.repeat(
+            rng.normal(
+                loc=0,
+                scale=self.noise_std * channel_fraction**0.5,
+                size=self.n_channels,
+            ),
+            max(1, shape[0] // self.n_channels) + 1,
+            axis=0,
+        )
+
+        return (pixel + line).T + channel[:shape[0]]
+
+    def apply_to(self, det, **kwargs):
+        if not isinstance(det, Detector):
+            return det
+
+        ndit = from_currsys(self.meta["ndit"], self.cmds)
+        det._hdu.data = self(det._hdu.data, ndit)
         return det
 
     def plot(self, det, **kwargs):
@@ -109,21 +172,25 @@ class BasicReadoutNoise(Effect):
 
         check_keys(self.meta, self.required_keys, action="error")
 
+    def __call__(self, data: ArrayLike, ndit: int = 1) -> NDArray:
+        rng = np.random.default_rng(self.random_seed)
+        scale = self.noise_std * np.sqrt(float(ndit))
+        return data + rng.normal(loc=0, scale=scale, size=data.shape)
+
+    @property
+    def noise_std(self) -> float:
+        return from_currsys(self.meta["noise_std"], self.cmds)
+
+    @property
+    def random_seed(self) -> int:
+        return from_currsys(self.meta["random_seed"], self.cmds)
+
     def apply_to(self, det, **kwargs):
         if not isinstance(det, Detector):
             return det
 
         ndit = from_currsys(self.meta["ndit"], self.cmds)
-        ron = from_currsys(self.meta["noise_std"], self.cmds)
-        noise_std = ron * np.sqrt(float(ndit))
-
-        random_seed = from_currsys(self.meta["random_seed"], self.cmds)
-        if random_seed is not None:
-            np.random.seed(random_seed)
-        # Can't do in-place because of Quantization data type conflicts.
-        det._hdu.data = det._hdu.data + np.random.normal(
-            loc=0, scale=noise_std, size=det._hdu.data.shape)
-
+        det._hdu.data = self(det._hdu.data, ndit)
         return det
 
     def plot(self, det):
@@ -191,7 +258,7 @@ class PixelResponseNonUniformity(Effect):
         dtcr_id = obj.meta[id_key] if id_key is not None else None
 
         prnu_std_meta = from_currsys(self.meta["prnu_std"], self.cmds)
-        if isinstance(prnu_std_meta, dict):
+        if isinstance(prnu_std_meta, Mapping):
             prnu_std = float(from_currsys(prnu_std_meta[dtcr_id], self.cmds))
         elif isinstance(prnu_std_meta, Real):
             prnu_std = float(prnu_std_meta)
@@ -201,7 +268,7 @@ class PixelResponseNonUniformity(Effect):
                 f"or a dict keyed by detector ID, got {type(prnu_std_meta)}"
             )
 
-        shape = obj._hdu.data.shape
+        shape = obj.data.shape
         if dtcr_id not in self._gain_maps:
             rng = np.random.default_rng(random_seed)
             self._gain_maps[dtcr_id] = rng.normal(
@@ -211,7 +278,7 @@ class PixelResponseNonUniformity(Effect):
         if self._gain_maps[dtcr_id].shape != shape:
             raise ValueError("gain map shape mismatch")
 
-        obj._hdu.data = obj._hdu.data * self._gain_maps[dtcr_id]
+        obj.data = obj.data * self._gain_maps[dtcr_id]
         return obj
 
     def plot(self, det_id=None):
@@ -236,13 +303,36 @@ class ShotNoise(Effect):
         self.meta["random_seed"] = "!SIM.random.seed"
         self.meta.update(kwargs)
 
+    def __call__(self, data: ArrayLike) -> NDArray:
+        rng = np.random.default_rng(self.random_seed)
+
+        # Check if there are negative values in the data.
+        values_negative = data < 0
+        if values_negative.any():
+            logger.warning(
+                "Effect ShotNoise: %d negative pixels", values_negative.sum())
+        data[values_negative] = 0
+
+        # Apply a Poisson distribution to the low values.
+        values_low = data < 1e7
+        data[values_low] = rng.poisson(data[values_low])
+
+        # Apply a normal distribution to the high values.
+        values_high = ~values_low
+        data[values_high] = rng.normal(data[values_high], np.sqrt(data[values_high]))
+
+        return data
+
+    @property
+    def random_seed(self) -> int:
+        return from_currsys(self.meta["random_seed"], self.cmds)
+
     def apply_to(self, det, **kwargs):
         if not isinstance(det, Detector):
             return det
 
-        self.meta["random_seed"] = from_currsys(self.meta["random_seed"],
-                                                self.cmds)
-        rng = np.random.default_rng(self.meta["random_seed"])
+        self.meta["random_seed"] = from_currsys(
+            self.meta["random_seed"], self.cmds)
 
         # numpy has a problem with generating Poisson distributions above
         # certain values. E.g. on linux, numpy.random.poisson(1e20) raises
@@ -264,25 +354,8 @@ class ShotNoise(Effect):
         # - numpy.nan are implicitly passed through the normal distribution;
         #   because the Poisson distribution cannot handle them.
 
-        data = det._hdu.data
-
-        # Check if there are negative values in the data.
-        values_negative = data < 0
-        if values_negative.any():
-            logger.warning(
-                "Effect ShotNoise: %d negative pixels", values_negative.sum())
-        data[values_negative] = 0
-
-        # Apply a Poisson distribution to the low values.
-        values_low = data < 1e7
-        data[values_low] = rng.poisson(data[values_low])
-
-        # Apply a normal distribution to the high values.
-        values_high = ~values_low
-        data[values_high] = rng.normal(data[values_high], np.sqrt(data[values_high]))
-
         new_imagehdu = fits.ImageHDU(
-            data=data,
+            data=self(det._hdu.data),
             header=det._hdu.header,
         )
 
@@ -314,25 +387,41 @@ class DarkCurrent(Effect):
         super().__init__(**kwargs)
         check_keys(self.meta, self.required_keys, action="error")
 
+    def __call__(
+        self,
+        data: np.ndarray,
+        dark_level: float,
+        dit: float,
+        ndit: int,
+    ) -> np.ndarray:
+        return data + dark_level * dit * ndit
+
+    @property
+    def random_seed(self) -> int:
+        return from_currsys(self.meta["random_seed"], self.cmds)
+
+    def _get_dark_level(self, det_meta) -> float:
+        dark_level = float(from_currsys(self.meta["value"], self.cmds))
+        if isinstance(dark_level, Real):
+            return dark_level
+        if isinstance(dark_level, Mapping):
+            dtcr_id = det_meta[real_colname("id", det_meta)]
+            return from_currsys(dark_level[dtcr_id], self.cmds)
+        raise ValueError(
+            f"<{self.__class__.__name__}>.meta['value'] must be either "
+            f"dict-like or scalar number, but is {dark_level}."
+        )
+
     def apply_to(self, obj, **kwargs):
         if not isinstance(obj, Detector):
             return obj
 
-        if isinstance(from_currsys(self.meta["value"], self.cmds), dict):
-            dtcr_id = obj.meta[real_colname("id", obj.meta)]
-            dark = from_currsys(self.meta["value"][dtcr_id], self.cmds)
-        elif isinstance(from_currsys(self.meta["value"], self.cmds), Real):
-            dark = float(from_currsys(self.meta["value"], self.cmds))
-        else:
-            raise ValueError("<DarkCurrent>.meta['value'] must be either "
-                             f"dict or float, but is {self.meta['value']}")
-
+        # Dark level needs detector meta so can't go into __call__()
+        dark_level = self._get_dark_level(obj.meta)
         dit = from_currsys(self.meta["dit"], self.cmds)
         ndit = from_currsys(self.meta["ndit"], self.cmds)
 
-        # Can't do in-place because of Quantization data type conflicts.
-        obj._hdu.data = obj._hdu.data + dark * dit * ndit
-
+        obj.data = self(obj.data, dark_level, dit, ndit)
         return obj
 
     def plot(self, det, **kwargs):
@@ -348,39 +437,3 @@ class DarkCurrent(Effect):
         ax.plot(times, levels, **kwargs)
         ax.set_xlabel("time")
         ax.set_ylabel("dark level")
-
-
-def _pseudo_random_field(scale=1, size=(1024, 1024)):
-    n = 256
-    image = np.zeros(size)
-    batch = np.random.normal(loc=0, scale=scale, size=(2*n, 2*n))
-    for y in range(0, size[1], n):
-        for x in range(0, size[0], n):
-            i, j = np.random.randint(n, size=2)
-            dx, dy = min(size[0]-x, n), min(size[1]-y, n)
-            image[x:x+dx, y:y+dy] = batch[i:i+dx, j:j+dy]
-
-    return image
-
-
-def _make_ron_frame(image_shape, noise_std, n_channels, channel_fraction,
-                   line_fraction, pedestal_fraction, read_fraction):
-    shape = image_shape
-    w_chan = max(1, shape[0] // n_channels)
-
-    pixel_std = noise_std * (pedestal_fraction + read_fraction)**0.5
-    line_std = noise_std * line_fraction**0.5
-    if shape < (1024, 1024):
-        pixel = np.random.normal(loc=0, scale=pixel_std, size=shape)
-        line = np.random.normal(loc=0, scale=line_std, size=shape[1])
-    else:
-        pixel = _pseudo_random_field(scale=pixel_std, size=shape)
-        line = pixel[0]
-
-    channel_std = noise_std * channel_fraction**0.5
-    channel = np.repeat(np.random.normal(loc=0, scale=channel_std,
-                                         size=n_channels), w_chan + 1, axis=0)
-
-    ron_frame = (pixel + line).T + channel[:shape[0]]
-
-    return ron_frame

--- a/scopesim/effects/electronic/noise.py
+++ b/scopesim/effects/electronic/noise.py
@@ -391,10 +391,6 @@ class DarkCurrent(Effect):
     ) -> np.ndarray:
         return data + dark_level * dit * ndit
 
-    @property
-    def random_seed(self) -> int:
-        return from_currsys(self.meta["random_seed"], self.cmds)
-
     def _get_dark_level(self, det_meta) -> float:
         dark_level = float(from_currsys(self.meta["value"], self.cmds))
         if isinstance(dark_level, Real):

--- a/scopesim/effects/electronic/pixels.py
+++ b/scopesim/effects/electronic/pixels.py
@@ -112,7 +112,7 @@ class BinnedImageBase(Effect):
         if not isinstance(det, Detector):
             return det
 
-        det._hdu.data = self(det._hdu.data)
+        det.data = self(det.data)
         return det
 
 

--- a/scopesim/effects/electronic/pixels.py
+++ b/scopesim/effects/electronic/pixels.py
@@ -3,6 +3,8 @@
 
 from typing import ClassVar
 
+from numpy.typing import ArrayLike, NDArray
+
 from .. import Effect
 from ...detector import Detector
 from ...utils import from_currsys, figure_factory, check_keys, real_colname
@@ -46,6 +48,27 @@ class ReferencePixelBorder(Effect):
                 raise ValueError(
                     "Parameter 'border' must have exactly four values.")
 
+    def __call__(self, data: ArrayLike, border: dict[int, int]) -> NDArray:
+        if border[0] > 0:
+            data[:border[0], :] = 0
+        if border[1] > 0:
+            data[:, :border[1]] = 0
+        if border[2] > 0:
+            data[-border[2]:, :] = 0
+        if border[3] > 0:
+            data[:, -border[3]:] = 0
+        return data
+
+    def _get_border(self, det_meta) -> dict[int, int]:
+        if hasattr(self.meta["border"], "dic"):
+            dtcr_id = det_meta[real_colname("id", det_meta)]
+            return self.meta["border"].dic[dtcr_id]
+        if isinstance(self.meta["border"], list):
+            return self.meta["border"]
+        raise ValueError(
+            f"{self.__class__.__name__}.meta['border'] must be either "
+            f"dict or list, but is {self.meta['border']}")
+
     def apply_to(self, obj, **kwargs):
         """Mask border pixels."""
         if not isinstance(obj, Detector):
@@ -54,24 +77,7 @@ class ReferencePixelBorder(Effect):
             return obj
 
         logger.info(f"Applying border {from_currsys(self.meta['border'])}")
-        if hasattr(self.meta["border"], "dic"):
-            dtcr_id = obj.meta[real_colname("id", obj.meta)]
-            border = self.meta["border"].dic[dtcr_id]
-        elif isinstance(self.meta["border"], list):
-            border = self.meta["border"]
-        else:
-            raise ValueError(
-                "<ReferenceBorderPixel>.meta['border'] must be either "
-                f"dict or list, but is {self.meta['border']}")
-
-        if border[0] > 0:
-            obj.data[:border[0], :] = 0
-        if border[1] > 0:
-            obj.data[:, :border[1]] = 0
-        if border[2] > 0:
-            obj.data[-border[2]:, :] = 0
-        if border[3] > 0:
-            obj.data[:, -border[3]:] = 0
+        obj.data = self(obj.data, self._get_border(obj.meta))
         return obj
 
     def plot(self, det, **kwargs):
@@ -90,44 +96,61 @@ class ReferencePixelBorder(Effect):
         return msg
 
 
-class BinnedImage(Effect):
+class BinnedImageBase(Effect):
+    """Base class for binning effects."""
+
+    z_order: ClassVar[tuple[int, ...]] = (870,)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        check_keys(self.meta, self.required_keys, action="error")
+
+    def __call__(self, data: ArrayLike) -> NDArray:
+        raise NotImplementedError("Subclasses must implement this.")
+
+    def apply_to(self, det, **kwargs):
+        if not isinstance(det, Detector):
+            return det
+
+        det._hdu.data = self(det._hdu.data)
+        return det
+
+
+class BinnedImage(BinnedImageBase):
     required_keys = {"bin_size"}
-    z_order: ClassVar[tuple[int, ...]] = (870,)
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        check_keys(self.meta, self.required_keys, action="error")
+    def __call__(self, data: ArrayLike) -> NDArray:
+        height, width = data.shape
+        binned_data = data.reshape((
+            height//self.bin_size,
+            self.bin_size,
+            width//self.bin_size,
+            self.bin_size
+        )).sum(axis=3).sum(axis=1)
+        return binned_data
 
-    def apply_to(self, det, **kwargs):
-        if not isinstance(det, Detector):
-            return det
-
-        bs = from_currsys(self.meta["bin_size"], self.cmds)
-        image = det._hdu.data
-        h, w = image.shape
-        new_image = image.reshape((h//bs, bs, w//bs, bs))
-        det._hdu.data = new_image.sum(axis=3).sum(axis=1)
-
-        return det
+    @property
+    def bin_size(self) -> int:
+        return from_currsys(self.meta["bin_size"], self.cmds)
 
 
-class UnequalBinnedImage(Effect):
+class UnequalBinnedImage(BinnedImageBase):
     required_keys = {"binx","biny"}
-    z_order: ClassVar[tuple[int, ...]] = (870,)
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        check_keys(self.meta, self.required_keys, action="error")
+    def __call__(self, data: ArrayLike) -> NDArray:
+        height, width = data.shape
+        binned_data = data.reshape((
+            height//self.binx,
+            self.binx,
+            width//self.biny,
+            self.binx
+        )).sum(axis=3).sum(axis=1)
+        return binned_data
 
-    def apply_to(self, det, **kwargs):
-        if not isinstance(det, Detector):
-            return det
+    @property
+    def binx(self) -> int:
+        return from_currsys(self.meta["binx"], self.cmds)
 
-        bx = from_currsys(self.meta["binx"], self.cmds)
-        by = from_currsys(self.meta["biny"], self.cmds)
-        image = det._hdu.data
-        h, w = image.shape
-        new_image = image.reshape((h//bx, bx, w//by, by))
-        det._hdu.data = new_image.sum(axis=3).sum(axis=1)
-
-        return det
+    @property
+    def biny(self) -> int:
+        return from_currsys(self.meta["biny"], self.cmds)

--- a/scopesim/effects/mosaic_trace_list.py
+++ b/scopesim/effects/mosaic_trace_list.py
@@ -253,8 +253,8 @@ class MosaicOutputFormat(MosaicSpectralTraceList):
                            type(det))
             return det
 
-        image = det._hdu.data
-        detwcs = WCS(det._hdu.header, key="D")
+        image = det.data
+        detwcs = WCS(det.header, key="D")
 
         output_format = from_currsys(self.meta["format"], self.cmds)
 

--- a/scopesim/effects/rotation.py
+++ b/scopesim/effects/rotation.py
@@ -40,5 +40,5 @@ class Rotate90CCD(Effect):
             return obj
 
         rotations = from_currsys(self.meta["rotations"], self.cmds)
-        obj._hdu.data = np.rot90(obj._hdu.data, rotations)
+        obj.data = np.rot90(obj.data, rotations)
         return obj

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -473,11 +473,12 @@ class OpticalTrain:
             self.cmds[f"!OBS.{key}"] = value
 
         hduls = []
-        for i, detector_array in enumerate(self.detector_managers):
-            array_effects = self.optics_manager.detector_array_effects
-            dtcr_effects = self.optics_manager.detector_effects
-            hdul = detector_array.readout(
-                self.image_planes, array_effects, dtcr_effects)
+        for i, detector_manager in enumerate(self.detector_managers):
+            hdul = detector_manager.readout(
+                self.image_planes,
+                self.optics_manager.detector_array_effects,
+                self.optics_manager.detector_effects,
+            )
 
             fits_effects = self.optics_manager.get_all(ExtraFitsKeywords)
             if len(fits_effects) > 0:

--- a/scopesim/tests/tests_effects/test_ADConversion.py
+++ b/scopesim/tests/tests_effects/test_ADConversion.py
@@ -32,9 +32,9 @@ def fixture_mock_detector():
 def fixture_detector_with_data(mock_detector):
     """Instantiate a Detector with some data"""
     det = mock_detector
-    width = det._hdu.data.shape[1]
-    det._hdu.data[:] = 1.2
-    det._hdu.data[:, width//2] = 1.99
+    width = det.data.shape[1]
+    det.data[:] = 1.2
+    det.data[:, width//2] = 1.99
     return det
 
 
@@ -73,11 +73,11 @@ class TestApplyTo:
     def test_applies_gain(self, mock_detector, gain):
         det = mock_detector
         data = np.random.randn(100, 100) * 100. + 1000.
-        det._hdu.data = 1. * data
+        det.data = 1. * data
         adconverter = ADConversion(gain=gain)
         adconverter.cmds = {"!DET.gain": gain, "!OBS.ndit": 1}
         adconverter.apply_to(det)
-        assert np.all((data/gain).astype(int) == det._hdu.data)
+        assert np.all((data/gain).astype(int) == det.data)
 
     @pytest.mark.usefixtures("patch_mock_path_micado")
     def test_applies_gain_list_to_detector_list(self):
@@ -104,10 +104,10 @@ class TestApplyTo:
         data = medval * np.ones((100, 100), dtype=np.float64)
         data[50, 50] = 1.e12
         data[60, 60] = -100000.
-        det._hdu.data = data
+        det.data = data
         adconverter = ADConversion(gain=gain, dtype=newtype)
         adconverter.cmds = {"!DET.gain": gain, "!OBS.ndit": 1}
         adconverter.apply_to(det)
-        assert(np.median(det._hdu.data) == newtype(medval/gain))
-        assert(np.max(det._hdu.data) == maxval)
-        assert(np.min(det._hdu.data) == minval)
+        assert(np.median(det.data) == newtype(medval/gain))
+        assert(np.max(det.data) == maxval)
+        assert(np.min(det.data) == minval)

--- a/scopesim/tests/tests_effects/test_BasicReadoutNoise.py
+++ b/scopesim/tests/tests_effects/test_BasicReadoutNoise.py
@@ -2,7 +2,7 @@ import pytest
 from pytest import approx
 import numpy as np
 
-from scopesim.effects.electronic.noise import PoorMansHxRGReadoutNoise, _make_ron_frame
+from scopesim.effects.electronic.noise import PoorMansHxRGReadoutNoise
 from scopesim.tests.mocks.py_objects.detector_objects import _basic_detector
 
 
@@ -39,12 +39,25 @@ class TestApplyTo:
 class TestMakeRonFrame:
     @pytest.mark.parametrize("n", (1, 4, 9, 25))
     def test_stdev_increase_with_square_of_n(self, n):
-        frames = np.array([_make_ron_frame((256, 256), 10, 2, 0.1, 0.2, 0.3, 0.4)
+        ron = PoorMansHxRGReadoutNoise(noise_std=10, n_channels=2, ndit=1)
+        ron.meta.update({
+            "channel_fraction": 0.1,
+            "line_fraction": 0.2,
+            "pedestal_fraction": 0.3,
+            "read_fraction": 0.4,
+        })
+        frames = np.array([ron._make_ron_frame((256, 256))
                            for _ in range(n)])
         assert np.std(np.sum(frames, axis=0)) == approx(10*n**0.5, rel=0.3)
 
     @pytest.mark.parametrize("shape", [(3, 7), (7, 3)])
     def test_makes_frame_sizes_for_non_integer_n_channels(self, shape):
-        n_channels = 2
-        frame = _make_ron_frame(shape, 5, n_channels, 0.25, 0.25, 0.25, 0.25)
+        ron = PoorMansHxRGReadoutNoise(noise_std=5, n_channels=2, ndit=1)
+        ron.meta.update({
+            "channel_fraction": 0.25,
+            "line_fraction": 0.25,
+            "pedestal_fraction": 0.25,
+            "read_fraction": 0.25,
+        })
+        frame = ron._make_ron_frame(shape)
         assert frame.shape > (0, 0)

--- a/scopesim/tests/tests_effects/test_BasicReadoutNoise.py
+++ b/scopesim/tests/tests_effects/test_BasicReadoutNoise.py
@@ -23,7 +23,7 @@ class TestApplyTo:
         ron = PoorMansHxRGReadoutNoise(noise_std=noise_std, n_channels=64, ndit=1)
         dtcr = ron.apply_to(dtcr)
 
-        assert np.std(dtcr._hdu.data) == approx(noise_std, rel=0.05)
+        assert np.std(dtcr.data) == approx(noise_std, rel=0.05)
 
     @pytest.mark.parametrize("noise_std", [1, 9, 100])
     @pytest.mark.parametrize("ndit", [1, 9, 100])
@@ -31,7 +31,7 @@ class TestApplyTo:
         dtcr = _basic_detector(width=256)
         ron = PoorMansHxRGReadoutNoise(noise_std=noise_std, n_channels=64, ndit=ndit)
         dtcr = ron.apply_to(dtcr)
-        noise_real = np.std(dtcr._hdu.data)
+        noise_real = np.std(dtcr.data)
 
         assert noise_real == approx(noise_std * ndit**0.5, rel=0.1)
 

--- a/scopesim/tests/tests_effects/test_InterPixelCapacitance.py
+++ b/scopesim/tests/tests_effects/test_InterPixelCapacitance.py
@@ -87,7 +87,7 @@ def fixture_detector():
     """Instantiate a random detector object"""
     hdu = fits.ImageHDU(data=np.random.randn(214, 333))
     det = Detector(hdu.header)
-    det._hdu.data = hdu.data
+    det.data = hdu.data
     return det
 
 class TestApply:
@@ -102,7 +102,7 @@ class TestApply:
                                            [0., 1., 0.],
                                            [0., 0., 0.]]))
         det = Detector(hdu.header)
-        det._hdu.data = hdu.data
+        det.data = hdu.data
         ipc = IPC(kernel=np.random.rand(3, 3))
         newdet = ipc.apply_to(det)
         np.testing.assert_allclose(newdet.hdu.data, ipc.kernel)

--- a/scopesim/tests/tests_effects/test_LinearityCurve.py
+++ b/scopesim/tests/tests_effects/test_LinearityCurve.py
@@ -46,11 +46,11 @@ class TestApplyTo:
                                                    (60, 60), (1e5, 60)])
     def test_only_applied_to_detector(self, in_flux, out_flux, basic_lincurve):
         dtcr = _basic_detector()
-        dtcr._hdu.data[0, 0] = in_flux
+        dtcr.data[0, 0] = in_flux
 
         new_dtcr = basic_lincurve.apply_to(dtcr)
-        assert new_dtcr._hdu.data[0, 0] == out_flux
-        assert np.min(new_dtcr._hdu.data) == 0
+        assert new_dtcr.data[0, 0] == out_flux
+        assert np.min(new_dtcr.data) == 0
 
     def test_bypasses_non_detector_objects(self, basic_lincurve):
         new_dict = basic_lincurve.apply_to({"gigawatts": 1.21})

--- a/scopesim/tests/tests_effects/test_exposure.py
+++ b/scopesim/tests/tests_effects/test_exposure.py
@@ -39,7 +39,7 @@ def fixture_exposureoutput():
 @pytest.fixture(name="detector", scope="function")
 def fixture_detector():
     det = Detector(_image_hdu_square().header)
-    det._hdu.data[:] = 1.e5
+    det.data[:] = 1.e5
     return det
 
 class TestExposureIntegration:
@@ -47,9 +47,9 @@ class TestExposureIntegration:
         assert isinstance(exposureintegration, ExposureIntegration)
 
     def test_integrates_correctly(self, exposureintegration, detector):
-        orig = 1. * detector._hdu.data
+        orig = 1. * detector.data
         assert isinstance(exposureintegration.apply_to(detector), Detector)
-        assert np.allclose(detector._hdu.data, 4 * orig)
+        assert np.allclose(detector.data, 4 * orig)
 
     def test_fails_without_dit(self):
         with pytest.raises(ValueError):
@@ -91,17 +91,17 @@ class TestExposureOutput:
                               (2., 5),
                               (3, 36)])
     def test_applies_average(self, dit, ndit, detector):
-        det_mean = detector._hdu.data.mean()
+        det_mean = detector.data.mean()
         exposureoutput = ExposureOutput("average", dit=dit, ndit=ndit)
         result = exposureoutput.apply_to(detector)
-        assert np.isclose(result._hdu.data.mean(), det_mean / ndit)
+        assert np.isclose(result.data.mean(), det_mean / ndit)
 
     @pytest.mark.parametrize("dit, ndit",
                              [(1., 1),
                               (2., 5),
                               (3, 36)])
     def test_applies_sum(self, dit, ndit, detector):
-        det_mean = detector._hdu.data.mean()
+        det_mean = detector.data.mean()
         exposureoutput = ExposureOutput("sum", dit=dit, ndit=ndit)
         result = exposureoutput.apply_to(detector)
-        assert np.isclose(result._hdu.data.mean(), det_mean)
+        assert np.isclose(result.data.mean(), det_mean)

--- a/scopesim/tests/tests_effects/test_mosaic_trace_list.py
+++ b/scopesim/tests/tests_effects/test_mosaic_trace_list.py
@@ -104,7 +104,7 @@ def fixture_detector():
     xsize, ysize = 50, 4096
     hdr = header_from_list_of_xy([-xsize/2, xsize/2], [-ysize/2, ysize/2], 1, "D")
     dtcr = Detector(hdr)
-    dtcr._hdu.data[rows, :] = 1
+    dtcr.data[rows, :] = 1
     return dtcr
 
 @pytest.fixture(name="apply_collapse1d", scope="class")
@@ -159,7 +159,7 @@ class TestCollapse1D:
         assert isinstance(apply_collapse1d._hdu, fits.BinTableHDU)
 
     def test_collapse1d_gives_correct_result(self, apply_collapse1d):
-        assert np.all(apply_collapse1d._hdu.data['spectrum'] == 7)
+        assert np.all(apply_collapse1d.data['spectrum'] == 7)
 
 
 @pytest.mark.usefixtures("patch_mock_path_mosaic")
@@ -181,7 +181,7 @@ class TestConvertToTable:
         assert isinstance(apply_converttotable._hdu, fits.BinTableHDU)
 
     def test_converttotable_gives_correct_result(self, apply_converttotable):
-        for row in apply_converttotable._hdu.data:
+        for row in apply_converttotable.data:
             assert np.all(row['spectrum'] == 1)
 
 @pytest.mark.usefixtures("patch_mock_path_mosaic")

--- a/scopesim/tests/tests_effects/test_prnu.py
+++ b/scopesim/tests/tests_effects/test_prnu.py
@@ -11,7 +11,7 @@ PLOTS = False
 def make_detector(value=1000, size=10):
     hdr = header_from_list_of_xy([-size/2, size/2], [-size/2, size/2], 1, "D")
     dtcr = Detector(hdr)
-    dtcr._hdu.data[:] = value
+    dtcr.data[:] = value
     return dtcr
 
 
@@ -21,7 +21,7 @@ class TestApplyTo:
         prnu_std = 0.05
         dtcr = make_detector(value=1000, size=100)
         PixelResponseNonUniformity(prnu_std=prnu_std, prnu_seed=42).apply_to(dtcr)
-        rel_std = dtcr._hdu.data.std() / dtcr._hdu.data.mean()
+        rel_std = dtcr.data.std() / dtcr.data.mean()
         assert abs(rel_std - prnu_std) < 0.01
 
     def test_gain_map_is_reused(self):
@@ -31,24 +31,24 @@ class TestApplyTo:
         prnu = PixelResponseNonUniformity(prnu_std=0.01, prnu_seed=42)
         prnu.apply_to(dtcr1)
         prnu.apply_to(dtcr2)
-        np.testing.assert_array_equal(dtcr1._hdu.data, dtcr2._hdu.data)
+        np.testing.assert_array_equal(dtcr1.data, dtcr2.data)
 
     def test_dict_prnu_std(self):
         """Dict mode: different amplitude per detector ID."""
         hdr = header_from_list_of_xy([-5, 5], [-5, 5], 1, "D")
         dtcr = Detector(hdr)
         dtcr.meta["id"] = "H2RG"
-        dtcr._hdu.data[:] = 1000
+        dtcr.data[:] = 1000
         prnu = PixelResponseNonUniformity(
             prnu_std={"H2RG": 0.005, "GeoSnap": 0.020}, prnu_seed=42)
         prnu.apply_to(dtcr)
-        assert dtcr._hdu.data.std() > 0
+        assert dtcr.data.std() > 0
 
     def test_multiplicative_zero_signal(self):
         """Zero signal should remain zero — confirms multiplicative (not additive)."""
         dtcr = make_detector(value=0)
         PixelResponseNonUniformity(prnu_std=0.01, prnu_seed=42).apply_to(dtcr)
-        assert dtcr._hdu.data.sum() == 0
+        assert dtcr.data.sum() == 0
 
     def test_non_detector_passthrough(self):
         """Non-Detector objects should be returned unchanged."""

--- a/scopesim/tests/tests_effects/test_shot_noise.py
+++ b/scopesim/tests/tests_effects/test_shot_noise.py
@@ -21,10 +21,10 @@ class TestApplyTo:
         value_too_high = 1e20
         hdr = header_from_list_of_xy([-hw, hw], [-hw, hw], 1, "D")
         dtcr = Detector(hdr)
-        dtcr._hdu.data[0][0] = value_normal
-        dtcr._hdu.data[0][1] = -1
-        dtcr._hdu.data[1][0] = value_too_high
-        dtcr._hdu.data[1][1] = np.nan
+        dtcr.data[0][0] = value_normal
+        dtcr.data[0][1] = -1
+        dtcr.data[1][0] = value_too_high
+        dtcr.data[1][1] = np.nan
 
         sn = ShotNoise()
         # To prevent that data[0][0] does not change by chance.
@@ -33,10 +33,10 @@ class TestApplyTo:
         dtcr = sn.apply_to(dtcr)
 
         # Ensure that the values have changed.
-        assert dtcr._hdu.data[0][0] != value_normal
-        assert dtcr._hdu.data[1][0] != value_too_high
+        assert dtcr.data[0][0] != value_normal
+        assert dtcr.data[1][0] != value_too_high
 
         # Sensibility checks on the values.
-        assert 1 < dtcr._hdu.data[0][0] < value_normal * 2
-        assert np.isnan(dtcr._hdu.data[0][1]) or dtcr._hdu.data[0][1] == 0
-        assert np.isnan(dtcr._hdu.data[1][1])
+        assert 1 < dtcr.data[0][0] < value_normal * 2
+        assert np.isnan(dtcr.data[0][1]) or dtcr.data[0][1] == 0
+        assert np.isnan(dtcr.data[1][1])


### PR DESCRIPTION
See #1002 for details and explanation.

- Add `Detector.data` property setter to eleminate external access of `Detector._hdu` attribute.
- Turn various effect attributes which need currsys/meta resolving into properties. This allows to encapsulate the resolving and make calls to the attributes much cleaner. **If we ever make effects dataclasses with explicit attribute fields rather than kwargs, this will make that process much smoother, because accessing a dataclass field looks identical to accessing a property, we just remove the property definitions then**.
- Anything that the `.__call__()` needs, which is taken from the `obj` (in this case usually `Detector`), is resolved before and passed to `.__call__()` as an argument. That means the latter doesn't need to know about `obj`, which is cleaner and matches the PSF case.
- I think there are now a few new `np.random.default_rng` cases. This was taken from a branch I started several months ago and forgot about in the much more recent discussion about those. Might not be final.

This isn't completely exhaustive for all the effects here, but I tried to cover the "standard" ones...