### PR TITLE
Mark test_python_image_coords as webtest, because face is downloaded.

### DIFF
--- a/scopesim/tests/tests_optics/test_ImagePlaneUtils.py
+++ b/scopesim/tests/tests_optics/test_ImagePlaneUtils.py
@@ -152,6 +152,8 @@ class TestAddImageHDUtoImageHDU:
         assert np.sum(new.data) == small_sum
 
 
+    # face is downloaded from the internet.
+    @pytest.mark.webtest
     def test_python_image_coords(self):
         # numpy uses a system of im[y, x]
         # numpy.shape[0] = y_len, numpy.shape[1] = x_len


### PR DESCRIPTION
Test fails if there is no internet.