### PR TITLE
Fix yet another off-by-one bug

### DIFF
--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -499,7 +499,7 @@ class DetectorList3D(DetectorList):
         # FIXME: Heavy property.....
         new_wcs, naxis = create_wcs_from_points(
             self._get_corner_points(),
-            self.pixel_size.to(u.mm),
+            self.pixel_size.to(u.mm) / u.pixel,
             wcs_suffix="D",
         )
 

--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -497,9 +497,11 @@ class DetectorList3D(DetectorList):
     def image_plane_header(self):
         """Create and return the Image Plane Header."""
         # FIXME: Heavy property.....
-        points = self._get_corner_points().value
         new_wcs, naxis = create_wcs_from_points(
-            points, self.pixel_size.to_value(u.mm), "D")
+            self._get_corner_points(),
+            self.pixel_size.to(u.mm),
+            wcs_suffix="D",
+        )
 
         hdr = fits.Header()
         hdr["NAXIS"] = 3

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -340,27 +340,24 @@ class FieldOfView:
         xy1p += (xy0p == xy1p)
         logger.debug("xy0p: %s; xy1p: %s", xy0p, xy1p)
 
-        new_wcs, new_naxis = imp_utils.create_wcs_from_points(
-            np.array([xy0s, xy1s]).round(11), pixel_scale=hdr["CDELT1"])
-
-        # TODO: Come back at some point and figure out if the failing tests
-        #       here are relevant or can be ignored...
-        # FIXME: Commented out for now because it appears too often IRL...
-        # try:
-        #     roundtrip = new_wcs.wcs_world2pix(
-        #         np.array([xy0s, xy1s - .5*image_wcs.wcs.cdelt]), 0).round(5)
-        #     np.testing.assert_array_equal(roundtrip[0], [0, 0])
-        #     np.testing.assert_array_equal(roundtrip[1], new_naxis - [1, 1])
-        # except AssertionError:
-        #     logger.exception("WCS roundtrip assertion failed.")
-        # FIXME: Related to the above, this sometimes fails:
-        # np.testing.assert_equal(xy1p - xy0p, new_naxis)
-        # This occurs when the floor and ceil in xy0s and xy1s produce an
-        # off-by-one error. Using .round instead for both would solve things
-        # in those cases, but breaks in other cases. Find a proper solution!
-        # Note: This is not super fatal, because the resulting projections
-        #       will trim off that extra pixel later on, but this should still
-        #       be addressed.
+        # Describe the cutout with the input WCS, shifted by the slice origin.
+        # The cutout's pixels ARE input pixels, so this is exact: the cutout
+        # stays on the input's pixel lattice and NAXISn always agrees with
+        # data.shape.
+        #
+        # Deriving the WCS from [xy0s, xy1s] instead (via
+        # create_wcs_from_points) got both wrong. Those are the world corners
+        # *before* the floor/ceil above grew the slice outwards to whole input
+        # pixels, so the resulting WCS described a differently sized image
+        # (NAXISn disagreed with data.shape by a pixel, silently corrected by
+        # fits.ImageHDU, which left CRPIXn describing the wrong array) placed
+        # on the FOV's lattice rather than the input's. Projecting that cutout
+        # then mis-registered it by up to a whole pixel, and by differing
+        # amounts for neighbouring FOVs, so the seam between two FOVs picked
+        # up a duplicated or a dropped row/column.
+        new_wcs = image_wcs.deepcopy()
+        new_wcs.wcs.crpix = image_wcs.wcs.crpix - xy0p
+        new_naxis = xy1p - xy0p
 
         new_hdr = new_wcs.to_header()
         new_hdr.update({"NAXIS1": new_naxis[0], "NAXIS2": new_naxis[1]})

--- a/scopesim/optics/fov_manager.py
+++ b/scopesim/optics/fov_manager.py
@@ -61,6 +61,32 @@ from .fov_volume_list import FovVolumeList
 logger = get_logger(__name__)
 
 
+def chunk_edges(vmin, vmax, step):
+    """Return the interior points that cut ``[vmin, vmax]`` into `step` chunks.
+
+    Only interior points are returned, so no edge can coincide with `vmin` or
+    `vmax`. `step` need not divide the span, and need not be an integer (see
+    HAWKI/test_hawki/test_full_package_hawki.py), so this cannot be a plain
+    ``range``.
+
+    It cannot be ``np.arange(vmin, vmax, step)`` either. That returns
+    ``ceil((vmax - vmin) / step)`` elements, which is one too many when the
+    division rounds just above an integer - as it does for a span that is an
+    exact multiple of `step`, e.g. ``(1.2000000000000002 - -1.2000000000000002)
+    / 0.8 == 3.0000000000000004``. Whether the surplus element then lands
+    exactly on `vmax` or one ulp below it depends on how the platform rounds
+    ``vmin + i * step``: it lands on `vmax` on x86, but below it on arm64
+    macOS. One ulp below `vmax` is a perfectly legal split point, so
+    ``FovVolumeList.split`` accepts it and carves off a volume ~1e-15 px wide,
+    which ``create_wcs_from_points`` then rounds up to a whole pixel - a
+    spurious one-pixel FOV, off the pixel lattice, double-counting flux at the
+    edge of the array.
+
+    """
+    n_chunks = max(1, int(np.ceil((vmax - vmin) / step - 1e-9)))
+    return vmin + step * np.arange(1, n_chunks)
+
+
 class FOVManager:
     """
     A class to manage the (monochromatic) image windows covering the target.
@@ -122,11 +148,8 @@ class FOVManager:
             if vol_pix_area > max_seg_size:
                 step = chunk_size * pixel_scale
 
-                # These are not always integers, unlike in the tests.
-                # See for example HAWKI/test_hawki/test_full_package_hawki.py.
-                # The np.arange can therefore not be changed to just a range.
-                yield (np.arange(vol["x_min"], vol["x_max"], step),
-                       np.arange(vol["y_min"], vol["y_max"], step))
+                yield (chunk_edges(vol["x_min"], vol["x_max"], step),
+                       chunk_edges(vol["y_min"], vol["y_max"], step))
 
     def generate_fovs_list(self) -> Iterator[FieldOfView]:
         """

--- a/scopesim/optics/fov_manager.py
+++ b/scopesim/optics/fov_manager.py
@@ -170,7 +170,7 @@ class FOVManager:
         for effect in self.effects:
             self.volumes_list = effect.apply_to(self.volumes_list, **params)
 
-        # ..todo: add catch to split volumes larger than chunk_size
+        # TODO: add catch to split volumes larger than chunk_size
         pixel_scale = from_currsys(self.meta["pixel_scale"], self.cmds)
         plate_scale = from_currsys(self.meta["plate_scale"], self.cmds)
 
@@ -182,7 +182,6 @@ class FOVManager:
         for vol in self.volumes_list:
             xs_min, xs_max = vol["x_min"] / 3600., vol["x_max"] / 3600.
             ys_min, ys_max = vol["y_min"] / 3600., vol["y_max"] / 3600.
-            waverange = (vol["wave_min"], vol["wave_max"])
             skyhdr = ipu.header_from_list_of_xy([xs_min, xs_max],
                                                 [ys_min, ys_max],
                                                 pixel_scale=pixel_scale / 3600.)
@@ -210,7 +209,7 @@ class FOVManager:
 
             new_fov = fovcls(
                 skyhdr,
-                waverange,
+                (vol["wave_min"], vol["wave_max"]),
                 detector_header=dethdr,
                 cmds=self.cmds,
                 **vol["meta"],

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -214,7 +214,41 @@ def create_wcs_from_points(
         offset[zeroaxis] = 0
 
     crpix = (naxis + 1) / 2
-    crval = (points.min(axis=0) + points.max(axis=0) + offset) / 2
+
+    # Where to put the pixel lattice when NAXISn cannot cover the requested
+    # region exactly.
+    #
+    # If the grid truncates the region (naxis < extent, i.e. the region is not
+    # a whole number of pixels across), anchor the lower pixel edge at
+    # points.min and let the leftover fraction fall off the far edge. Every
+    # region carved out of the same origin in whole-pixel steps then shares one
+    # lattice - which is what chunked FOVs are: the image plane, the full-size
+    # chunks and the smaller last chunk all measure from the same detector
+    # edge. Centring each of them on its own midpoint instead, and absorbing
+    # its own rounding remainder into CRVAL, put them on lattices offset from
+    # one another by fractions of a pixel, so the projection had to snap them
+    # and the last chunk could land a whole pixel off its neighbours.
+    #
+    # MICADO's detector plane is 189.32 mm / 0.015 mm = 12621.33 px tall, so it
+    # hits this on every run.
+    #
+    # If the grid covers the region (naxis >= extent) there is nothing to
+    # truncate, so keep centring it on the region. That is the right thing for
+    # a region smaller than a single pixel, where naxis was clamped up to 1.
+    _pxs = float(pixel_scale.value if isinstance(pixel_scale, u.Quantity)
+                 else pixel_scale)
+    _pts = points.value if isinstance(points, u.Quantity) else np.asarray(points)
+    _naxis = np.asarray(naxis, dtype=float)
+    _extent = np.atleast_1d(np.asarray(extent, dtype=float))
+
+    crval = np.where(
+        _naxis < _extent,
+        _pts.min(axis=0) + (_naxis / 2) * _pxs,                      # anchored
+        (_pts.min(axis=0) + _pts.max(axis=0) +
+         np.asarray(offset, dtype=float)) / 2,                       # centred
+    )
+    if isinstance(points, u.Quantity):
+        crval = crval * points.unit
 
     # Cannot do `in "DX"` here because that would also match the empty string.
     linsuff = {"D", "X"}

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -437,13 +437,32 @@ def overlay_image(small_im, big_im, coords, mask=None, sub_pixel=False):
         coords = np.array([*coords, (big_im.shape[0] - 1) / 2])
 
     # FIXME: this would not be necessary if we used WCS instead of manual 2pix
-    # Round to 1e-4 pix before ceil: WCS deg-space round-trips leave
-    # float dust of order 1e-8..1e-6 pix on integer-valued coords, which
-    # ceil would amplify to a full-pixel shift; genuine sub-pixel intent
-    # cannot be finer than 0.5 pix here (sub_pixel is not implemented),
-    # and the half-integer even-shape convention is preserved exactly.
-    coords = np.ceil(np.asarray(coords).round(4)).astype(np.intp)
-    idx = coords.astype(int)[::-1] - np.array(small_im.shape) // 2
+    # Round to 1e-4 pix first: WCS deg-space round-trips leave float dust of
+    # order 1e-8..1e-6 pix on integer-valued coords, which the snap below
+    # would otherwise amplify to a full-pixel shift; genuine sub-pixel intent
+    # cannot be finer than 0.5 pix here (sub_pixel is not implemented).
+    coords = np.asarray(coords, dtype=float).round(4)
+
+    # `idx` is the origin, in array order, at which small_im must be placed to
+    # centre it on `coords` (both are 0-based pixel-centre coordinates, as
+    # returned by WCS.wcs_world2pix(..., 0)).
+    #
+    # Snap that origin, NOT `coords` itself. The old expression
+    #     np.ceil(coords)[::-1] - np.array(small_im.shape) // 2
+    # is off by up to a whole pixel whenever `coords` is not on the lattice
+    # small_im implies (half-integer for even shapes, integer for odd ones),
+    # and the direction of that error flips with the parity of the shape. Two
+    # adjacent FOVs of different sizes therefore get displaced opposite ways
+    # and their shared edge picks up a duplicated or a dropped row/column.
+    # Snapping the origin instead keeps every placement consistent, whatever
+    # the shape.
+    #
+    # Half-integer origins (a real sub-pixel shift, which sub_pixel=True would
+    # have to handle properly) are rounded towards the lower index, matching
+    # what the old expression did for even shapes.
+    idx = np.ceil(
+        coords[::-1] - (np.array(small_im.shape) - 1) / 2 - 0.5
+    ).astype(np.intp)
 
     # Image ranges
     idx1 = np.maximum(0, idx)

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -1221,8 +1221,6 @@ def det_wcs_from_sky_wcs(
         Shape of the image (``NAXIS1``, ``NAXIS2``).
 
     """
-    # TODO: Using astropy units for now to avoid deg vs. arcsec confusion.
-    #       Once Scopesim is consistent there, remove astropy units.
     pixel_scale <<= u.arcsec / u.pixel
     plate_scale <<= u.arcsec / u.mm
     logger.debug("Pixel scale: %s", pixel_scale)
@@ -1268,8 +1266,6 @@ def sky_wcs_from_det_wcs(det_wcs: WCS,
         Shape of the image (``NAXIS1``, ``NAXIS2``).
 
     """
-    # TODO: Using astropy units for now to avoid deg vs. arcsec confusion.
-    #       Once Scopesim is consistent there, remove astropy units.
     pixel_scale <<= u.arcsec / u.pixel
     plate_scale <<= u.arcsec / u.mm
     logger.debug("Pixel scale: %s", pixel_scale)

--- a/scopesim/tests/tests_integrations/test_source_fov_imageplane_play_nicely.py
+++ b/scopesim/tests/tests_integrations/test_source_fov_imageplane_play_nicely.py
@@ -8,6 +8,9 @@ from pytest import approx
 
 from astropy import units as u
 
+from astropy.wcs import WCS
+
+from scopesim.optics import image_plane_utils as imp_utils
 from scopesim.optics.fov import FieldOfView2D
 from scopesim.optics.image_plane import ImagePlane
 
@@ -64,3 +67,100 @@ class TestInteractionBetweenSourceFOVImagePlane:
             plt.subplot(133)
             plt.imshow(imp.hdu.data, origin="lower", norm=LogNorm())
             plt.show()
+
+def _checkerboard_source(naxis, pixel_scale, crpix=None):
+    """0/1 checkerboard image source, one board square per pixel."""
+    from astropy.io import fits
+    from scopesim.source.source import Source
+    from scopesim.source import source_templates as st
+
+    nx, ny = naxis
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ["LINEAR", "LINEAR"]
+    wcs.wcs.cunit = ["deg", "deg"]
+    wcs.wcs.cdelt = 2 * [pixel_scale / 3600]
+    wcs.wcs.crval = [0, 0]
+    wcs.wcs.crpix = crpix or [(nx + 1) / 2, (ny + 1) / 2]
+
+    hdr = wcs.to_header()
+    hdr["BUNIT"] = ""
+    board = (np.indices((ny, nx)).sum(axis=0) % 2).astype(float)
+    hdu = fits.ImageHDU(header=hdr, data=board)
+    hdu.header["SPEC_REF"] = 0
+    hdu.header["SPECMAG"] = 0
+    hdu.header["SPECUNIT"] = "mag"
+    return Source(image_hdu=hdu, spectra=[st.vega_spectrum()]), board
+
+
+def _chunked_fov_headers(x_mm, y_mm, pixel_size, pixel_scale, chunk):
+    """Reproduce FOVManager's chunking of a detector footprint."""
+    plate_scale = pixel_scale / pixel_size
+    lims = [v / pixel_size * pixel_scale
+            for v in (x_mm[0], x_mm[1], y_mm[0], y_mm[1])]
+
+    def edges(vmin, vmax):
+        out = [vmin]
+        for val in np.arange(vmin, vmax, chunk * pixel_scale):
+            if vmin < val < vmax and val > out[-1]:
+                out.append(float(val))
+        return out + [vmax]
+
+    for x0, x1 in zip(*(lambda e: (e[:-1], e[1:]))(edges(lims[0], lims[1]))):
+        for y0, y1 in zip(*(lambda e: (e[:-1], e[1:]))(edges(lims[2], lims[3]))):
+            skyhdr = imp_utils.header_from_list_of_xy(
+                [x0 / 3600, x1 / 3600], [y0 / 3600, y1 / 3600],
+                pixel_scale=pixel_scale / 3600)
+            dethdr, _ = imp_utils.det_wcs_from_sky_wcs(
+                WCS(skyhdr), pixel_scale, plate_scale)
+            skyhdr.update(dethdr.to_header())
+            yield skyhdr
+
+
+class TestChunkedFOVsTileTheImagePlane:
+    """A checkerboard must survive being cut into chunked FOVs and reassembled.
+
+    ``chunk_size`` is 8 here so the whole thing runs in well under a second,
+    but the geometry is MICADO's: the detector footprint is not a whole number
+    of pixels across (MICADO's y axis is 189.32 mm / 0.015 mm = 12621.33 px),
+    so the last chunk in each axis is a fraction of a chunk wide and lands on
+    a pixel lattice offset from its neighbours'. The projection used to snap
+    those chunks inconsistently, which put a duplicated or a dropped
+    row/column at the seam and flipped the checkerboard phase across it.
+    """
+
+    PIXEL_SIZE = 0.01     # mm / pix
+    PIXEL_SCALE = 0.2     # arcsec / pix
+    CHUNK = 8
+
+    @pytest.mark.parametrize("half_mm, exact_extent", [
+        (0.12,   24.0),    # whole pixels, whole chunks
+        (0.105,  21.0),    # whole pixels, fractional last chunk
+        (0.0866, 17.32),   # fractional pixels -- MICADO's y axis
+        (0.0855, 17.10),
+    ])
+    def test_checkerboard_survives_chunking(self, half_mm, exact_extent):
+        x_mm = y_mm = (-half_mm, half_mm)
+        assert (x_mm[1] - x_mm[0]) / self.PIXEL_SIZE == approx(exact_extent)
+
+        imphdr = imp_utils.header_from_list_of_xy(
+            list(x_mm), list(y_mm), pixel_scale=self.PIXEL_SIZE, wcs_suffix="D")
+        imp = ImagePlane(imphdr)
+
+        source, board = _checkerboard_source(
+            (imphdr["NAXIS1"], imphdr["NAXIS2"]), self.PIXEL_SCALE,
+            crpix=[imphdr["CRPIX1D"], imphdr["CRPIX2D"]])
+
+        fov_hdrs = list(_chunked_fov_headers(
+            x_mm, y_mm, self.PIXEL_SIZE, self.PIXEL_SCALE, self.CHUNK))
+        assert len(fov_hdrs) == 9
+
+        for hdr in fov_hdrs:
+            fov = FieldOfView2D(hdr, waverange=[0.5, 2.5] * u.um,
+                                area=1 * u.m**2)
+            fov.extract_from(source)
+            fov.view()
+            imp.add(fov.hdu, wcs_suffix="D")
+
+        # no gaps and no double-counting at the chunk seams
+        got = imp.data / imp.data.max()
+        np.testing.assert_allclose(got, board, atol=1e-6)

--- a/scopesim/tests/tests_integrations/test_source_fov_imageplane_play_nicely.py
+++ b/scopesim/tests/tests_integrations/test_source_fov_imageplane_play_nicely.py
@@ -12,6 +12,7 @@ from astropy.wcs import WCS
 
 from scopesim.optics import image_plane_utils as imp_utils
 from scopesim.optics.fov import FieldOfView2D
+from scopesim.optics.fov_manager import chunk_edges
 from scopesim.optics.image_plane import ImagePlane
 
 from scopesim.tests.mocks.py_objects import source_objects as src
@@ -99,14 +100,12 @@ def _chunked_fov_headers(x_mm, y_mm, pixel_size, pixel_scale, chunk):
             for v in (x_mm[0], x_mm[1], y_mm[0], y_mm[1])]
 
     def edges(vmin, vmax):
-        out = [vmin]
-        for val in np.arange(vmin, vmax, chunk * pixel_scale):
-            if vmin < val < vmax and val > out[-1]:
-                out.append(float(val))
-        return out + [vmax]
+        # the real chunk-edge helper, not a copy of it
+        return [vmin, *chunk_edges(vmin, vmax, chunk * pixel_scale), vmax]
 
-    for x0, x1 in zip(*(lambda e: (e[:-1], e[1:]))(edges(lims[0], lims[1]))):
-        for y0, y1 in zip(*(lambda e: (e[:-1], e[1:]))(edges(lims[2], lims[3]))):
+    xe, ye = edges(lims[0], lims[1]), edges(lims[2], lims[3])
+    for x0, x1 in zip(xe[:-1], xe[1:]):
+        for y0, y1 in zip(ye[:-1], ye[1:]):
             skyhdr = imp_utils.header_from_list_of_xy(
                 [x0 / 3600, x1 / 3600], [y0 / 3600, y1 / 3600],
                 pixel_scale=pixel_scale / 3600)

--- a/scopesim/tests/tests_optics/test_FOVManager.py
+++ b/scopesim/tests/tests_optics/test_FOVManager.py
@@ -3,7 +3,7 @@ from pytest import approx
 import numpy as np
 from astropy import units as u
 
-from scopesim.optics.fov_manager import FOVManager
+from scopesim.optics.fov_manager import FOVManager, chunk_edges
 from scopesim.tests.mocks.py_objects import effects_objects as eo
 from scopesim.utils import from_currsys
 
@@ -56,3 +56,60 @@ class TestGenerateFovList:
         assert len(fovs) == 4
         assert fov_skycorners.min(axis=0)[0] == approx(-1024 / 3600)  # [deg] 2k detector / pixel_scale
         assert fovs[0].waverange[0] == 0.6 * u.um  # filter blue edge
+
+
+class TestChunkEdges:
+    """Chunk edges must be interior and platform-independent.
+
+    np.arange(vmin, vmax, step) returns one element too many when
+    (vmax - vmin) / step rounds just above an integer, and whether that
+    element lands on vmax or one ulp below it depends on how the platform
+    rounds vmin + i * step. One ulp below vmax is a legal split point, so
+    FovVolumeList.split would carve off a ~1e-15 px volume that
+    create_wcs_from_points then rounds up into a spurious one-pixel FOV.
+    """
+
+    @pytest.mark.parametrize("span_px, chunk, n_chunks", [
+        (24.0, 8, 3),          # exact multiple -- the fragile case
+        (24.0, 4, 6),          # exact multiple
+        (16.0, 8, 2),
+        (21.0, 8, 3),          # fractional last chunk
+        (17.32, 8, 3),         # fractional pixels, fractional last chunk
+        (12621 + 1 / 3, 2048, 7),   # MICADO's y axis
+        (5.0, 8, 1),           # smaller than one chunk
+    ])
+    def test_edges_are_interior_and_count_is_right(self, span_px, chunk,
+                                                   n_chunks):
+        pixel_scale = 0.1
+        vmin = -span_px / 2 * pixel_scale
+        vmax = vmin + span_px * pixel_scale
+        edges = chunk_edges(vmin, vmax, chunk * pixel_scale)
+
+        assert len(edges) == n_chunks - 1
+        assert (edges > vmin).all()
+        assert (edges < vmax).all()
+
+    @pytest.mark.parametrize("span_px, chunk", [(24.0, 8), (24.0, 4),
+                                                (16.0, 8), (32.0, 16)])
+    def test_exact_multiples_give_no_sliver_chunk(self, span_px, chunk):
+        # A span that is an exact multiple of the chunk must come out as
+        # equal chunks, with no degenerate remainder however the float
+        # arithmetic rounds.
+        pixel_scale = 0.1
+        vmin = -span_px / 2 * pixel_scale
+        vmax = vmin + span_px * pixel_scale
+        edges = chunk_edges(vmin, vmax, chunk * pixel_scale)
+
+        bounds = np.array([vmin, *edges, vmax])
+        widths = np.diff(bounds) / pixel_scale
+        assert len(widths) == span_px / chunk
+        np.testing.assert_allclose(widths, chunk, atol=1e-9)
+
+    def test_a_split_one_ulp_inside_the_upper_bound_is_not_emitted(self):
+        # np.arange does emit such a value on arm64 macOS; assert directly
+        # that chunk_edges never does, on any platform.
+        vmin, vmax, step = -1.2000000000000002, 1.2000000000000002, 0.8
+        edges = chunk_edges(vmin, vmax, step)
+        assert (edges < np.nextafter(vmax, -np.inf)).all()
+        # ... which np.arange does not guarantee
+        assert len(np.arange(vmin, vmax, step)) == len(edges) + 2

--- a/scopesim/tests/tests_optics/test_ImagePlaneUtils.py
+++ b/scopesim/tests/tests_optics/test_ImagePlaneUtils.py
@@ -229,6 +229,50 @@ class TestOverlayImage:
             plt.show()
 
 
+class TestOverlayImageSnapping:
+    """The origin, not the centre, must be snapped to the pixel grid.
+
+    ``ceil(coords) - shape // 2`` snapped the centre instead, which is off by
+    up to a whole pixel whenever ``coords`` is not on the lattice implied by
+    ``small_im.shape``, in a direction that flips with the parity of that
+    shape. Adjacent FOVs of different sizes were therefore displaced opposite
+    ways, and their shared edge gained a duplicated or a dropped row/column.
+    """
+
+    @pytest.mark.parametrize("size", [1, 2, 3, 4, 7, 8])
+    def test_places_image_on_its_own_lattice_without_shift(self, size):
+        big = np.zeros((32, 32))
+        small = np.ones((size, size))
+        # centre coordinate that the shape's own lattice implies
+        centre = 10 + (size - 1) / 2
+        imp_utils.overlay_image(small, big, (centre, centre))
+        rows = np.where(big.any(axis=1))[0]
+        assert rows[0] == 10
+        assert rows[-1] == 10 + size - 1
+
+    @pytest.mark.parametrize("size", [1, 2, 3, 4, 7, 8])
+    def test_snaps_sub_pixel_offset_the_same_way_for_any_shape(self, size):
+        # A 0.3 pix offset must never move the image by a whole pixel, whatever
+        # the parity of the shape.
+        big = np.zeros((32, 32))
+        small = np.ones((size, size))
+        centre = 10 + (size - 1) / 2 + 0.3
+        imp_utils.overlay_image(small, big, (centre, centre))
+        rows = np.where(big.any(axis=1))[0]
+        assert rows[0] == 10
+        assert rows[-1] == 10 + size - 1
+
+    def test_adjacent_differently_sized_images_tile_exactly(self):
+        # Mimics chunked FOVs, where the last chunk is smaller than the rest.
+        big = np.zeros((1, 20))
+        origin = 0
+        for size in (8, 8, 4):
+            small = np.ones((1, size))
+            imp_utils.overlay_image(small, big, (origin + (size - 1) / 2, 0))
+            origin += size
+        assert (big == 1).all()
+
+
 class TestRescaleImageHDU:
     @pytest.mark.parametrize("pixel_scale", [0.3, 0.5, 1, 2, 3])
     def test_rescales_a_2D_imagehdu(self, pixel_scale):

--- a/scopesim/tests/tests_optics/test_ImagePlaneUtils.py
+++ b/scopesim/tests/tests_optics/test_ImagePlaneUtils.py
@@ -7,6 +7,7 @@ from astropy.wcs import WCS
 import matplotlib.pyplot as plt
 
 from scopesim.optics import image_plane_utils as imp_utils
+from scopesim.optics.fov_manager import chunk_edges
 from scopesim.tests.mocks.py_objects import imagehdu_objects as imo
 
 
@@ -249,11 +250,8 @@ class TestLatticeIsSharedBetweenChunks:
         parent, parent_naxis = imp_utils.create_wcs_from_points(
             np.array([[lo, lo], [hi, hi]]), pixel_scale)
 
-        edges = [lo]
-        for val in np.arange(lo, hi, chunk * pixel_scale):
-            if lo < val < hi and val > edges[-1]:
-                edges.append(float(val))
-        edges.append(hi)
+        # the real chunk-edge helper, not a copy of it
+        edges = [lo, *chunk_edges(lo, hi, chunk * pixel_scale), hi]
 
         for x0, x1 in zip(edges[:-1], edges[1:]):
             child, child_naxis = imp_utils.create_wcs_from_points(

--- a/scopesim/tests/tests_optics/test_ImagePlaneUtils.py
+++ b/scopesim/tests/tests_optics/test_ImagePlaneUtils.py
@@ -229,6 +229,52 @@ class TestOverlayImage:
             plt.show()
 
 
+class TestLatticeIsSharedBetweenChunks:
+    """Regions carved from one origin in whole-pixel steps share a lattice.
+
+    This is what chunked FOVs are: the image plane, the full-size chunks and
+    the smaller last chunk are all measured from the same detector edge. When
+    the region is not a whole number of pixels across, CRVAL used to absorb
+    each region's own rounding remainder, putting them on lattices offset from
+    one another by fractions of a pixel.
+    """
+
+    @pytest.mark.parametrize("extent_px", [24.0, 21.0, 17.32, 17.1, 12621 + 1/3])
+    @pytest.mark.parametrize("chunk", [4, 8])
+    def test_chunks_land_on_the_parent_lattice(self, extent_px, chunk):
+        pixel_scale = 0.1
+        lo = -extent_px / 2 * pixel_scale
+        hi = lo + extent_px * pixel_scale
+
+        parent, parent_naxis = imp_utils.create_wcs_from_points(
+            np.array([[lo, lo], [hi, hi]]), pixel_scale)
+
+        edges = [lo]
+        for val in np.arange(lo, hi, chunk * pixel_scale):
+            if lo < val < hi and val > edges[-1]:
+                edges.append(float(val))
+        edges.append(hi)
+
+        for x0, x1 in zip(edges[:-1], edges[1:]):
+            child, child_naxis = imp_utils.create_wcs_from_points(
+                np.array([[x0, x0], [x1, x1]]), pixel_scale)
+            # the child's pixel 0 must sit on a whole-pixel offset of the
+            # parent's grid, otherwise the projection has to snap it
+            world = child.wcs_pix2world([[0, 0]], 0)
+            pix = parent.wcs_world2pix(world, 0)[0]
+            np.testing.assert_allclose(pix, np.round(pix), atol=1e-6)
+
+    @pytest.mark.parametrize("pnts, pixel_scale", [
+        (np.array([[0, 0]]), 5),                                  # single point
+        (np.array([[-1, -1], [-1, 1], [1, -1], [1, 1]]), 5),      # sub-pixel
+    ])
+    def test_regions_smaller_than_a_pixel_stay_centred(self, pnts, pixel_scale):
+        wcs, naxis = imp_utils.create_wcs_from_points(pnts, pixel_scale)
+        np.testing.assert_array_equal(naxis, [1, 1])
+        np.testing.assert_array_equal(wcs.wcs.crval,
+                                      pnts.mean(axis=0))
+
+
 class TestOverlayImageSnapping:
     """The origin, not the centre, must be snapped to the pixel grid.
 

--- a/scopesim/tests/tests_optics/test_fov_utls.py
+++ b/scopesim/tests/tests_optics/test_fov_utls.py
@@ -6,6 +6,8 @@ import numpy as np
 from synphot import Empirical1D, SourceSpectrum
 from synphot.units import PHOTLAM
 from astropy import units as u
+from astropy.io import fits
+from astropy.wcs import WCS
 
 from scopesim.optics.fov import FieldOfView, extract_range_from_spectrum
 from scopesim.optics import image_plane_utils as imp_utils
@@ -128,3 +130,72 @@ class TestExtractRangeFromSpectrum:
         extract_range_from_spectrum(spec, waverange)
 
         assert msg in caplog.text
+
+class TestExtractAreaKeepsTheInputPixelGrid:
+    """The cutout is made of input pixels, so its WCS must say so.
+
+    The cutout WCS used to be re-derived from the world corners *before* the
+    slice was grown outwards to whole input pixels. That gave a WCS for a
+    differently sized image (``NAXISn`` disagreed with ``data.shape``, silently
+    corrected by ``fits.ImageHDU``, which left ``CRPIXn`` describing the wrong
+    array) sitting on the FOV's pixel lattice rather than the input's. The
+    cutout was then mis-registered by up to a whole pixel when projected, and
+    by differing amounts for neighbouring FOVs, so their shared edge gained a
+    duplicated or a dropped row/column.
+    """
+
+    @staticmethod
+    def _image_hdu(naxis=32, pixel_scale=0.1, crval=(0.0, 0.0)):
+        """Image with a distinct value in every pixel, in deg."""
+        skywcs = WCS(naxis=2)
+        skywcs.wcs.ctype = ["LINEAR", "LINEAR"]
+        skywcs.wcs.cunit = ["deg", "deg"]
+        skywcs.wcs.cdelt = 2 * [pixel_scale / 3600]
+        skywcs.wcs.crval = list(crval)
+        skywcs.wcs.crpix = 2 * [(naxis + 1) / 2]
+        hdr = skywcs.to_header()
+        hdr["BUNIT"] = ""
+        data = np.arange(naxis * naxis, dtype=float).reshape(naxis, naxis)
+        return fits.ImageHDU(header=hdr, data=data)
+
+    @staticmethod
+    def _fov(x_min, x_max, y_min, y_max, pixel_scale=0.1):
+        skyhdr = imp_utils.header_from_list_of_xy(
+            [x_min / 3600, x_max / 3600], [y_min / 3600, y_max / 3600],
+            pixel_scale=pixel_scale / 3600)
+        dethdr, _ = imp_utils.det_wcs_from_sky_wcs(
+            WCS(skyhdr), pixel_scale, pixel_scale / 0.01)
+        skyhdr.update(dethdr.to_header())
+        return FieldOfView(skyhdr, [1.0, 2.0])
+
+    # FOVs deliberately offset from the image's pixel edges by a fraction of a
+    # pixel, which is what chunking produces whenever the detector extent is
+    # not a whole number of pixels.
+    @pytest.mark.parametrize("offset", [0.0, 0.16, 0.34, 0.5, 0.68, 0.84])
+    def test_naxis_matches_data_shape(self, offset):
+        hdu = self._image_hdu()
+        fov = self._fov(-0.8 + offset * 0.1, 0.0 + offset * 0.1,
+                        -0.8 + offset * 0.1, 0.0 + offset * 0.1)
+        cut = fov.extract_area_from_imagehdu(hdu, fov.get_corners("deg")[0])
+        assert (cut.header["NAXIS2"], cut.header["NAXIS1"]) == cut.data.shape
+
+    @pytest.mark.parametrize("offset", [0.0, 0.16, 0.34, 0.5, 0.68, 0.84])
+    def test_cutout_pixels_keep_their_world_coordinates(self, offset):
+        hdu = self._image_hdu()
+        fov = self._fov(-0.8 + offset * 0.1, 0.0 + offset * 0.1,
+                        -0.8 + offset * 0.1, 0.0 + offset * 0.1)
+        cut = fov.extract_area_from_imagehdu(hdu, fov.get_corners("deg")[0])
+
+        # every cutout value must sit at the world coordinate its value had in
+        # the input image
+        in_wcs = WCS(hdu.header, naxis=2)
+        cut_wcs = WCS(cut.header, naxis=2)
+        ny, nx = cut.data.shape
+        yy, xx = np.indices((ny, nx))
+        world = cut_wcs.wcs_pix2world(
+            np.column_stack([xx.ravel(), yy.ravel()]), 0)
+        back = in_wcs.wcs_world2pix(world, 0).round(6)
+        expected = hdu.data[back[:, 1].astype(int), back[:, 0].astype(int)]
+        np.testing.assert_array_equal(cut.data.ravel(), expected)
+        # ... and land on whole input pixels, not between them
+        np.testing.assert_allclose(back, back.round(), atol=1e-6)


### PR DESCRIPTION
@teutoburg found that the off-by-one errors were still present when FOVs that were smaller than a full detector were projected onto the image plane. This was found by creating a alternating pixel checkerboard grid and putting it in a source object. Then running it through optical train with FOV chunks smaller than image_plane. The pattern shown below was the result.

Claude's solution is to anchor FOV chunks to their origin rather than their centres, so that we avoid the nuances of int/floor/ceil etc when working out where to tplace the chunks on the **image plane**

<img width="1084" height="727" alt="Screenshot 2026-09-04 131408" src="https://github.com/user-attachments/assets/ef6e5ab2-605f-4b3e-95d2-93832bd68ba1" />

Extra testing outside the unit tests in this PR gave the results:

  origin/main                    rows: 10407 bad, cols: 10408 bad,  plus a dropped row at y = 12288
  first two commits              rows:   166 bad, cols:      0 bad
  with this commit               rows:     0 bad, cols:      0 bad

And a screenshot of the same region of the **detector** with the 3 commits (because the full MICADO Image Plane was crashing in FV locally)

<img width="1205" height="1312" alt="image" src="https://github.com/user-attachments/assets/208e3d7b-abb2-4a3c-b546-7d887d456316" />


