### PR TITLE
Add `Detector.det_id` convenience property

### DIFF
--- a/scopesim/detector/detector.py
+++ b/scopesim/detector/detector.py
@@ -103,3 +103,8 @@ class Detector:
     def image(self):
         """Return data from internal HDU."""
         return self.data
+
+    def __str__(self) -> str:
+        if self.det_id is not None:
+            return f"Detector {self.det_id:>2d}"
+        return "Detector"

--- a/scopesim/detector/detector.py
+++ b/scopesim/detector/detector.py
@@ -7,9 +7,17 @@ from astropy.io.fits import ImageHDU
 from astropy.wcs import WCS
 
 from ..optics import ImagePlane
-from ..optics.image_plane_utils import (add_imagehdu_to_imagehdu,
-                                        sky_wcs_from_det_wcs)
-from ..utils import get_logger, from_currsys, stringify_dict, zeros_from_header
+from ..optics.image_plane_utils import (
+    add_imagehdu_to_imagehdu,
+    sky_wcs_from_det_wcs,
+)
+from ..utils import (
+    get_logger,
+    from_currsys,
+    stringify_dict,
+    zeros_from_header,
+    real_colname,
+)
 
 
 logger = get_logger(__name__)
@@ -64,6 +72,18 @@ class Detector:
             self._hdu.header.update(sky_wcs.to_header())
 
         return self._hdu
+
+    @property
+    def det_id(self) -> int | None:
+        """Return detector ID.
+
+        Avoid calling it just "id", because ``id(self)`` is something else.
+
+        If not found in `self.meta`, return None.
+        """
+        if key := real_colname("id", self.meta):
+            return self.meta[key]
+        return None
 
     @property
     def header(self):

--- a/scopesim/detector/detector_manager.py
+++ b/scopesim/detector/detector_manager.py
@@ -40,8 +40,13 @@ class DetectorManager(Sequence):
 
         self._latest_exposure: HDUList | None = None
 
-    def readout(self, image_planes, array_effects=None, dtcr_effects=None,
-                **kwargs) -> HDUList:
+    def readout(
+        self,
+        image_planes,
+        array_effects: list[Effect] | None = None,
+        dtcr_effects: list[Effect] | None = None,
+        **kwargs
+    ) -> HDUList:
         """
         Read out the detector array into a FITS HDU List.
 
@@ -74,9 +79,6 @@ class DetectorManager(Sequence):
             Output FITS HDU List.
 
         """
-        # .. note:: Detector is what used to be called Chip
-        #           DetectorManager is the old Detector
-
         self._array_effects = array_effects or []
         self._dtcr_effects = dtcr_effects or []
         self.meta.update(kwargs)
@@ -100,7 +102,7 @@ class DetectorManager(Sequence):
                 detector = effect.apply_to(detector)
 
             # 6. add necessary header keywords
-            # .. todo: add keywords
+            # TODO: add keywords
 
         # FIXME: Why is this applied twice ???
         for effect in self._array_effects:
@@ -148,7 +150,7 @@ class DetectorManager(Sequence):
         return prihdu
 
     def _make_effects_hdu(self):
-        # .. todo:: decide what goes into the effects table of meta data
+        # TODO: decide what goes into the effects table of meta data
         # effects = self._array_effects + self._dtcr_effects
         return TableHDU()
 

--- a/scopesim/effects/electronic/electrons.py
+++ b/scopesim/effects/electronic/electrons.py
@@ -18,7 +18,7 @@ from scipy.signal import oaconvolve
 from .. import Effect
 from ...detector import Detector
 from ...utils import figure_factory, check_keys
-from ...utils import from_currsys, real_colname
+from ...utils import from_currsys
 from . import logger
 
 
@@ -309,14 +309,13 @@ class ADConversion(Effect):
     def __call__(self, data: ArrayLike, gain: Real) -> NDArray:
         return data / gain
 
-    def _get_gain(self, det_meta) -> Real:
+    def _get_gain(self, det_id: int) -> Real:
         # Apply the gain value (copy from DarkCurrent)
         # Note that this does not cater for the case where the gain is given
         # as a plain dictionary. Should we implement that?
         if hasattr(self.cmds["!DET.gain"], "dic"):
-            dtcr_id = det_meta[real_colname("id", det_meta)]
-            gain = self.cmds["!DET.gain"].dic[dtcr_id]
-            logger.info(f"Detector {dtcr_id}: applying gain {gain}")
+            gain = self.cmds["!DET.gain"].dic[det_id]
+            logger.info(f"Detector {det_id}: applying gain {gain}")
             return gain
         if isinstance(self.cmds["!DET.gain"], Real):
             gain = self.cmds["!DET.gain"]
@@ -333,7 +332,7 @@ class ADConversion(Effect):
         new_dtype = self.meta["dtype"]
 
         # Apply gain
-        obj.data = self(obj.data, self._get_gain(obj.meta))
+        obj.data = self(obj.data, self._get_gain(obj.det_id))
 
         # Type-conversion wraps around input values that are higher or lower than
         # the respective maximum and minimum values of the new data type. Before

--- a/scopesim/effects/electronic/noise.py
+++ b/scopesim/effects/electronic/noise.py
@@ -11,7 +11,7 @@ from astropy.io import fits
 
 from .. import Effect
 from ...detector import Detector
-from ...utils import from_currsys, figure_factory, check_keys, real_colname
+from ...utils import from_currsys, figure_factory, check_keys
 from . import logger
 
 
@@ -247,19 +247,18 @@ class PixelResponseNonUniformity(Effect):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.meta.update(kwargs)
-        self._gain_maps = {}  # keyed by dtcr_id
+        self._gain_maps = {}  # keyed by det_id
 
     def apply_to(self, obj, **kwargs):
         if not isinstance(obj, Detector):
             return obj
 
         random_seed = from_currsys(self.meta.get("prnu_seed"), self.cmds)
-        id_key = real_colname("id", obj.meta)
-        dtcr_id = obj.meta[id_key] if id_key is not None else None
+        det_id = obj.det_id
 
         prnu_std_meta = from_currsys(self.meta["prnu_std"], self.cmds)
         if isinstance(prnu_std_meta, Mapping):
-            prnu_std = float(from_currsys(prnu_std_meta[dtcr_id], self.cmds))
+            prnu_std = float(from_currsys(prnu_std_meta[det_id], self.cmds))
         elif isinstance(prnu_std_meta, Real):
             prnu_std = float(prnu_std_meta)
         else:
@@ -269,16 +268,16 @@ class PixelResponseNonUniformity(Effect):
             )
 
         shape = obj.data.shape
-        if dtcr_id not in self._gain_maps:
+        if det_id not in self._gain_maps:
             rng = np.random.default_rng(random_seed)
-            self._gain_maps[dtcr_id] = rng.normal(
+            self._gain_maps[det_id] = rng.normal(
                 loc=1.0, scale=prnu_std, size=shape,
             )
 
-        if self._gain_maps[dtcr_id].shape != shape:
+        if self._gain_maps[det_id].shape != shape:
             raise ValueError("gain map shape mismatch")
 
-        obj.data = obj.data * self._gain_maps[dtcr_id]
+        obj.data = obj.data * self._gain_maps[det_id]
         return obj
 
     def plot(self, det_id=None):
@@ -391,13 +390,12 @@ class DarkCurrent(Effect):
     ) -> np.ndarray:
         return data + dark_level * dit * ndit
 
-    def _get_dark_level(self, det_meta) -> float:
+    def _get_dark_level(self, det_id: int) -> float:
         dark_level = float(from_currsys(self.meta["value"], self.cmds))
         if isinstance(dark_level, Real):
             return dark_level
         if isinstance(dark_level, Mapping):
-            dtcr_id = det_meta[real_colname("id", det_meta)]
-            return from_currsys(dark_level[dtcr_id], self.cmds)
+            return from_currsys(dark_level[det_id], self.cmds)
         raise ValueError(
             f"<{self.__class__.__name__}>.meta['value'] must be either "
             f"dict-like or scalar number, but is {dark_level}."
@@ -408,7 +406,7 @@ class DarkCurrent(Effect):
             return obj
 
         # Dark level needs detector meta so can't go into __call__()
-        dark_level = self._get_dark_level(obj.meta)
+        dark_level = self._get_dark_level(obj.det_id)
         dit = from_currsys(self.meta["dit"], self.cmds)
         ndit = from_currsys(self.meta["ndit"], self.cmds)
 

--- a/scopesim/tests/tests_effects/test_prnu.py
+++ b/scopesim/tests/tests_effects/test_prnu.py
@@ -37,10 +37,10 @@ class TestApplyTo:
         """Dict mode: different amplitude per detector ID."""
         hdr = header_from_list_of_xy([-5, 5], [-5, 5], 1, "D")
         dtcr = Detector(hdr)
-        dtcr.meta["id"] = "H2RG"
+        dtcr.meta["id"] = 0
         dtcr.data[:] = 1000
         prnu = PixelResponseNonUniformity(
-            prnu_std={"H2RG": 0.005, "GeoSnap": 0.020}, prnu_seed=42)
+            prnu_std={0: 0.005, 1: 0.020}, prnu_seed=42)
         prnu.apply_to(dtcr)
         assert dtcr.data.std() > 0
 


### PR DESCRIPTION
We needed the line `det_meta[real_colname("id", det_meta)]` a few times now, so it's worth making that simpler. Also means not the whole meta, but rather just a simple int can be passed to the resolve methods.

Additionally added a `.__str__()` method, which this class was lacking.