### PR TITLE
SPEC scaling now also fixed 

### DIFF
--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -605,7 +605,6 @@ class FieldOfView:
         """Deal with BUNIT and pixel area."""
         # Note: Do not scale source data - make a copy first.
         field_hdu = field.field.copy()  # .field is the HDU (yeah...)
-        logger.debug("scaling by %f", field.pixel_area.value)
 
         # TODO: Check if this scaling is actually correct. How does this
         #       work with the add_imagehdu_to_imagehdu below? Isn't that
@@ -617,6 +616,7 @@ class FieldOfView:
             # field_hdu.data *= self.pixel_area.value
         else:
             logger.debug("binned bunit...")
+            logger.debug("scaling by %f", field.pixel_area.value)
             field_hdu.data /= field.pixel_area.value
             # Pixel area doesn't cancel out, need to convert
             new_bunit = field.bunit / u.arcsec**2
@@ -1145,7 +1145,7 @@ class FieldOfView3D(FieldOfView):
                 field_hdu,
                 canvas_cube_hdu,
                 spline_order=self.spline_order,
-                conserve_flux=False,
+                conserve_flux=True,
                 differential=True,
             )
 

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -606,7 +606,6 @@ class FieldOfView:
         # Note: Do not scale source data - make a copy first.
         field_hdu = field.field.copy()  # .field is the HDU (yeah...)
         logger.debug("scaling by %f", field.pixel_area.value)
-        field_hdu.data /= field.pixel_area.value
 
         # TODO: Check if this scaling is actually correct. How does this
         #       work with the add_imagehdu_to_imagehdu below? Isn't that
@@ -614,10 +613,11 @@ class FieldOfView:
         if field.is_bunit_spatially_differential:
             logger.debug("differential bunit...")
             # Field is in (PHOTLAM) arcsec-2, need to scale by pixarea
-            logger.debug("scaling by %f", self.pixel_area.value)
-            field_hdu.data *= self.pixel_area.value
+            # logger.debug("scaling by %f", self.pixel_area.value)
+            # field_hdu.data *= self.pixel_area.value
         else:
             logger.debug("binned bunit...")
+            field_hdu.data /= field.pixel_area.value
             # Pixel area doesn't cancel out, need to convert
             new_bunit = field.bunit / u.arcsec**2
             field_hdu.header["BUNIT"] = new_bunit.to_string("fits")
@@ -957,10 +957,9 @@ class FieldOfView3D(FieldOfView):
             field_data = field_interp(fov_waveset.value)
 
             # Pixel scale conversion
-            field_data *= field.pixel_area / self.pixel_area
+            # field_data *= field.pixel_area / self.pixel_area
             logger.debug(
-                "3D FOV make_cubefields: field_data.mean() = %f "
-                "PHOTLAM arcsec-2", field_data.mean())
+                "3D FOV make_cubefields: field_data.mean() = %f [%s]", field_data.mean(), field.bunit)
             field_hdu = fits.ImageHDU(data=field_data, header=field.header)
             yield field_hdu
 
@@ -987,13 +986,15 @@ class FieldOfView3D(FieldOfView):
                 canvas_image_hdu,
                 spline_order=spline_order,
                 conserve_flux=True,
+                differential=True,
             )
 
             spec = field.spectrum(fov_waveset)
             # 2D * 1D -> 3D
             field_cube = canvas_image_hdu.data[None, :, :] * spec[:, None, None]
-            logger.debug("3D FOV make_imagefields: field_cube.mean() = %f",
-                field_cube.mean().value)
+            # logger.debug("3D FOV make_imagefields: field_cube.mean() = %f",
+            #     field_cube.mean().value)
+            logger.debug(f"3D FOV make_imagefields: {field_cube.mean() = }")
             yield field_cube.value
 
     def _make_tablefields(self, fov_waveset):
@@ -1145,7 +1146,8 @@ class FieldOfView3D(FieldOfView):
                 field_hdu,
                 canvas_cube_hdu,
                 spline_order=self.spline_order,
-                conserve_flux=True,
+                conserve_flux=False,
+                differential=True,
             )
 
         canvas_cube_hdu.data = sum(self._make_imagefields(

--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -992,9 +992,8 @@ class FieldOfView3D(FieldOfView):
             spec = field.spectrum(fov_waveset)
             # 2D * 1D -> 3D
             field_cube = canvas_image_hdu.data[None, :, :] * spec[:, None, None]
-            # logger.debug("3D FOV make_imagefields: field_cube.mean() = %f",
-            #     field_cube.mean().value)
-            logger.debug(f"3D FOV make_imagefields: {field_cube.mean() = }")
+            logger.debug("3D FOV make_imagefields: field_cube.mean() = %f",
+                field_cube.mean().value)
             yield field_cube.value
 
     def _make_tablefields(self, fov_waveset):

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -485,7 +485,8 @@ def overlay_image(small_im, big_im, coords, mask=None, sub_pixel=False):
 
 def rescale_imagehdu(imagehdu: fits.ImageHDU, pixel_scale: float | u.Quantity,
                      wcs_suffix: str = "", conserve_flux: bool = True,
-                     spline_order: int = 1) -> fits.ImageHDU:
+                     spline_order: int = 1,
+                     differential: bool = False) -> fits.ImageHDU:
     """
     Scale the .data array by the ratio of pixel_scale [deg] and CDELTn.
 
@@ -540,6 +541,8 @@ def rescale_imagehdu(imagehdu: fits.ImageHDU, pixel_scale: float | u.Quantity,
         return imagehdu
 
     sum_orig = np.sum(imagehdu.data)
+    if differential:
+        sum_orig *= primary_wcs.wcs.cdelt[0]*primary_wcs.wcs.cdelt[1]
 
     # Perform the rescaling. Axes need to be inverted because python.
     zoom_np = zoom[::-1]
@@ -592,9 +595,12 @@ def rescale_imagehdu(imagehdu: fits.ImageHDU, pixel_scale: float | u.Quantity,
     if conserve_flux:
         new_im = np.nan_to_num(new_im, copy=False)
         sum_new = np.sum(new_im)
+        if differential:
+            sum_new *= (pixel_scale.value**2)
+
         if sum_new != 0:
             flux_factor = sum_orig / sum_new
-            logger.debug("flux factor = %f", flux_factor)
+            logger.info("flux factor = %f", flux_factor)
             new_im *= flux_factor
         elif sum_orig != 0:
             logger.warning(
@@ -785,7 +791,8 @@ def add_imagehdu_to_imagehdu(image_hdu: fits.ImageHDU,
                              canvas_hdu: fits.ImageHDU,
                              spline_order: int = 1,
                              wcs_suffix: str = "",
-                             conserve_flux: bool = True) -> fits.ImageHDU:
+                             conserve_flux: bool = True,
+                             differential: bool = False) -> fits.ImageHDU:
     """
     Re-project one ``fits.ImageHDU`` onto another ``fits.ImageHDU``.
 
@@ -838,7 +845,8 @@ def add_imagehdu_to_imagehdu(image_hdu: fits.ImageHDU,
     new_hdu = rescale_imagehdu(image_hdu, pixel_scale=canvas_pixel_scale / conv_fac,
                                wcs_suffix=canvas_wcs.wcs.alt,
                                spline_order=spline_order,
-                               conserve_flux=conserve_flux)
+                               conserve_flux=conserve_flux,
+                               differential=differential)
     # TODO: Perhaps add separately formatted WCS logger?
     logger.debug("fromrescale %s", WCS(new_hdu.header, key=canvas_wcs.wcs.alt))
     new_hdu = reorient_imagehdu(new_hdu,

--- a/scopesim/optics/image_plane_utils.py
+++ b/scopesim/optics/image_plane_utils.py
@@ -541,6 +541,8 @@ def rescale_imagehdu(imagehdu: fits.ImageHDU, pixel_scale: float | u.Quantity,
         return imagehdu
 
     sum_orig = np.sum(imagehdu.data)
+
+    # scale by pixel area if the flux is differential (i.e. per unit area)
     if differential:
         sum_orig *= primary_wcs.wcs.cdelt[0]*primary_wcs.wcs.cdelt[1]
 
@@ -600,7 +602,7 @@ def rescale_imagehdu(imagehdu: fits.ImageHDU, pixel_scale: float | u.Quantity,
 
         if sum_new != 0:
             flux_factor = sum_orig / sum_new
-            logger.info("flux factor = %f", flux_factor)
+            logger.debug("flux factor = %f", flux_factor)
             new_im *= flux_factor
         elif sum_orig != 0:
             logger.warning(


### PR DESCRIPTION
Moved all scaling to conserve-flux functionality in image_plane_utils and added a parameter to identify differential flux units (as used in cube sources).