### PR TITLE
Checkerboard vs through-slit imaging

### DIFF
--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -355,9 +355,11 @@ class FieldOfView:
         # then mis-registered it by up to a whole pixel, and by differing
         # amounts for neighbouring FOVs, so the seam between two FOVs picked
         # up a duplicated or a dropped row/column.
-        new_wcs = image_wcs.deepcopy()
-        new_wcs.wcs.crpix = image_wcs.wcs.crpix - xy0p
-        new_naxis = xy1p - xy0p
+        # new_wcs = image_wcs.deepcopy()
+        # new_wcs.wcs.crpix = image_wcs.wcs.crpix - xy0p
+        # new_naxis = xy1p - xy0p
+        new_wcs, new_naxis = imp_utils.create_wcs_from_points(
+        np.array([xy0s, xy1s]).round(11), pixel_scale=hdr["CDELT1"])
 
         new_hdr = new_wcs.to_header()
         new_hdr.update({"NAXIS1": new_naxis[0], "NAXIS2": new_naxis[1]})

--- a/scopesim/tests/tests_integrations/test_source_fov_imageplane_play_nicely.py
+++ b/scopesim/tests/tests_integrations/test_source_fov_imageplane_play_nicely.py
@@ -163,3 +163,110 @@ class TestChunkedFOVsTileTheImagePlane:
         # no gaps and no double-counting at the chunk seams
         got = imp.data / imp.data.max()
         np.testing.assert_allclose(got, board, atol=1e-6)
+
+
+def _flat_source(naxis=64, pixel_scale=0.064):
+    """Uniformly illuminated image source, one everywhere, flat spectrum."""
+    from astropy.io import fits
+    from synphot import Empirical1D, SourceSpectrum
+    from scopesim.source.source import Source
+
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ["LINEAR", "LINEAR"]
+    wcs.wcs.cunit = ["arcsec", "arcsec"]
+    wcs.wcs.cdelt = 2 * [pixel_scale]
+    wcs.wcs.crval = [0, 0]
+    wcs.wcs.crpix = 2 * [(naxis + 1) / 2]
+
+    hdu = fits.ImageHDU(data=np.ones((naxis, naxis)), header=wcs.to_header())
+    spec = SourceSpectrum(Empirical1D, points=[0.5, 2.5] * u.um,
+                          lookup_table=[1, 1] * u.Unit("ph s-1 m-2 um-1"))
+    return Source(image_hdu=hdu, spectra=[spec])
+
+
+def _slit_fov(x, y, pixel_scale, pixel_size):
+    """FOV covering a slit of x, y [arcsec], built like FOVManager does."""
+    skyhdr = imp_utils.header_from_list_of_xy(
+        [v / 3600 for v in x], [v / 3600 for v in y],
+        pixel_scale=pixel_scale / 3600)
+    dethdr, _ = imp_utils.det_wcs_from_sky_wcs(
+        WCS(skyhdr), pixel_scale, pixel_scale / pixel_size)
+    skyhdr.update(dethdr.to_header())
+    return FieldOfView2D(skyhdr, waverange=[1.0, 2.0] * u.um, area=1 * u.m**2)
+
+
+class TestFlatSourceThroughASlitFOV:
+    """A flat lamp seen through a slit must fill the slit, uniformly.
+
+    A slit FOV is typically *thinner than one source pixel*: MICADO's Short
+    slit is 0.016" tall while a flat-lamp source is sampled at 0.064"/pix. The
+    cutout is grown outwards to whole source pixels, so it covers more sky than
+    the slit does; if its WCS is then written on the *source's* pixel lattice
+    rather than on the FOV's, ``overlay_image`` crops the surplus away and the
+    flux through the slit comes out wrong -- for the MICADO case, exactly half
+    of the slit was left dark. This is what commit 9740ebd6 reverted in
+    ``FieldOfView.extract_area_from_imagehdu``.
+
+    Note that these tests and ``TestChunkedFOVsTileTheImagePlane`` above are the
+    two sides of the same trade-off: the cutout WCS can describe either the
+    source's pixel lattice or the FOV's, and ``extract_area_from_imagehdu``
+    currently has to pick one. Resolving it properly needs sub-pixel-accurate
+    cropping, i.e. weighting the partial edge pixels of the cutout.
+    """
+
+    SRC_PIXEL_SCALE = 0.064   # arcsec / pix, the flat lamp
+    FOV_PIXEL_SCALE = 0.004   # arcsec / pix, MICADO SPEC
+    PIXEL_SIZE = 0.015        # mm / pix
+
+    # slit extents [arcsec], all thinner than or comparable to a source pixel
+    SLITS = [
+        ((-1.5, 1.5), (-0.008, 0.008)),   # MICADO Short slit, centred
+        ((-1.5, 1.5), (0.010, 0.026)),    # ... offset within one source pixel
+        ((-1.5, 1.5), (-0.032, 0.032)),   # exactly one source pixel tall
+        ((-1.5, 1.5), (-0.08, 0.08)),     # 2.5 source pixels tall
+        ((-1.5, 1.5), (0.020, 0.060)),    # straddling a source pixel edge
+        ((-2.0, 2.0), (-0.008, 0.008)),   # longer slit
+    ]
+
+    def _observe(self, x, y):
+        fov = _slit_fov(x, y, self.FOV_PIXEL_SCALE, self.PIXEL_SIZE)
+        fov.extract_from(_flat_source(pixel_scale=self.SRC_PIXEL_SCALE))
+        fov.view()
+        return fov
+
+    @pytest.mark.parametrize(("x", "y"), SLITS)
+    def test_flux_through_slit_matches_slit_area(self, x, y):
+        fov = self._observe(x, y)
+
+        # each source pixel carries 1 ph/s here (flat 1 ph/s/m2/um over the
+        # 1 um wide FOV waverange, collecting area 1 m2), so the flux through
+        # the slit is just the slit area in source pixels
+        slit_area = (x[1] - x[0]) * (y[1] - y[0])
+        expected = slit_area / self.SRC_PIXEL_SCALE**2
+
+        assert fov.hdu.data.sum() == approx(expected, rel=1e-6)
+
+        # ... and it survives the projection onto the image plane
+        x_mm = [v * self.PIXEL_SIZE / self.FOV_PIXEL_SCALE for v in x]
+        y_mm = [v * self.PIXEL_SIZE / self.FOV_PIXEL_SCALE for v in y]
+        imp = ImagePlane(imp_utils.header_from_list_of_xy(
+            x_mm, y_mm, pixel_scale=self.PIXEL_SIZE, wcs_suffix="D"))
+        imp.add(fov.hdu, wcs_suffix="D")
+
+        assert imp.data.sum() == approx(expected, rel=1e-6)
+
+    @pytest.mark.parametrize(("x", "y"), SLITS)
+    def test_illumination_is_uniform_across_the_slit(self, x, y):
+        fov = self._observe(x, y)
+        data = fov.hdu.data
+
+        if PLOTS:
+            plt.plot(data.mean(axis=1))
+            plt.xlabel("pixel across slit")
+            plt.ylabel("flux [ph s-1 pix-1]")
+            plt.show()
+
+        # a flat lamp illuminates the whole slit evenly: no dark rows at the
+        # edges, no step in the profile across the slit
+        assert data.min() > 0
+        np.testing.assert_allclose(data, data.max(), rtol=1e-6)


### PR DESCRIPTION
Had to revert changes made for checkerboard tests in FOV as this broke through-slit imaging - the checkerboard changes introduced an off-by-two error in alignment of the source fov and the slit location (MICADO short slit).

Reverting the change fixes the slit flux, but breaks the checkerboard tests again - needs sorting out.