### PR TITLE
Skip all tests in test_rst_utils.py

### DIFF
--- a/scopesim/tests/tests_reports/test_rst_utils.py
+++ b/scopesim/tests/tests_reports/test_rst_utils.py
@@ -10,6 +10,7 @@ from scopesim.reports import rst_utils as ru
 from scopesim.tests.mocks.py_objects import report_objects as ro
 from scopesim.tests.mocks.py_objects import effects_objects as eo
 
+pytestmark = pytest.mark.skip  # whole file
 
 CLEAN_UP = True
 PLOTS = False


### PR DESCRIPTION
This functionality hasn't been used in years, and the tests sometimes cause re-runs because of some Tcl/Tkinter weirdness. We can always re-enable the tests if we use it again...