### PR TITLE
Remove unused `fov_grid()` methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,10 @@ filterwarnings = [
     "ignore:invalid value encountered in divide:RuntimeWarning",
     "ignore:Cannot merge meta key.*:astropy.utils.metadata.MergeConflictWarning",
     "ignore::astropy.wcs.wcs.FITSFixedWarning",
-    "default:The fov_grid*:DeprecationWarning",
+    # Only SpectralTraceList still calls the deprecated fov_grid internally.
+    # Delete this line once that call moves to an internal method; every other
+    # fov_grid DeprecationWarning is now an error.
+    "default:The fov_grid*:DeprecationWarning:scopesim.effects.spectral_trace_list",
     # Pytest Notebook stuff
     "ignore:Proactor*:RuntimeWarning",
 ]

--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Effects related to field masks, including spectroscopic slits."""
 
-import warnings
 from typing import ClassVar
 
 import yaml
@@ -130,18 +129,6 @@ class ApertureMask(Effect):
                 vol["meta"]["xi_max"] = max(x) * u.arcsec
 
         return obj
-
-    # Outdated. Remove when removing all old FOVManager code from effects
-    def fov_grid(self, which="edges", **kwargs):
-        """Return a header with the sky coordinates."""
-        warnings.warn("The fov_grid method is deprecated and will be removed "
-                      "in a future release.", DeprecationWarning, stacklevel=2)
-        if which == "edges":
-            self.meta.update(kwargs)
-            return self.header
-        elif which == "masks":
-            self.meta.update(kwargs)
-            return self.mask
 
     @property
     def hdu(self):
@@ -457,12 +444,6 @@ class SlitWheel(Effect):
     def apply_to(self, obj, **kwargs):
         """Use apply_to of current_slit."""
         return self.current_slit.apply_to(obj, **kwargs)
-
-    def fov_grid(self, which="edges", **kwargs):
-        """See parent docstring."""
-        warnings.warn("The fov_grid method is deprecated and will be removed "
-                      "in a future release.", DeprecationWarning, stacklevel=2)
-        return self.current_slit.fov_grid(which=which, **kwargs)
 
     def change_slit(self, slitname=None):
         """Change the current slit."""

--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -242,31 +242,6 @@ class DetectorList(Effect):
 
         return points * u.mm
 
-    def fov_grid(self, which="edges", **kwargs):
-        """Return an ApertureMask object. kwargs are "pixel_scale" [arcsec]."""
-        # This has really been taken care of by apply_to now
-        # TODO v1.0: finally rm this completely
-        raise AttributeError("The DetectorList.fov_grid() method has been "
-                             "removed in v0.10.0.")
-        # aperture_mask = None
-        # if which == "edges":
-        #     self.meta.update(kwargs)
-        #     self.meta = from_currsys(self.meta, self.cmds)
-
-        #     hdr = self.image_plane_header
-        #     xy_mm = calc_footprint(hdr, "D")
-        #     pixel_size = hdr["CDELT1D"]              # mm
-        #     pixel_scale = self.meta["pixel_scale"]   # ["]
-
-        #     # x["] = x[mm] * ["] / [mm]
-        #     xy_sky = xy_mm * pixel_scale / pixel_size
-
-        #     aperture_mask = ApertureMask(array_dict={"x": xy_sky[:, 0],
-        #                                              "y": xy_sky[:, 1]},
-        #                                  pixel_scale=pixel_scale)
-
-        # return aperture_mask
-
     @property
     def image_plane_header(self):
         """Create and return the Image Plane Header."""

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -11,20 +11,19 @@ from ..utils import from_currsys, write_report
 from ..reports.rst_utils import table_to_rst
 
 
-# FIXME: This docstring is out-of-date for several reasons:
-#   - Effects can act on objects other than Source (eg FOV, IMP, DET)
-#   - fov_grid is outdated
-
-
 # @dataclass(kw_only=True, eq=False)
 class Effect:
     """
     Base class for representing the effects (artifacts) in an optical system.
 
     The ``Effect`` class is conceived to independently apply the changes that
-    an optical component (or series thereof) has on an incoming 3D description
-    of an on-sky object. In other words, **an Effect object should receive a
-    derivative of a ``Source`` object, alter it somehow, and return it**.
+    an optical component (or series thereof) has on an incoming description of
+    an on-sky object. **An Effect object should receive an object, alter it
+    somehow, and return an instance of the same class.** Besides ``Source``,
+    that object may be a ``FovVolumeList``, a ``FieldOfView``, an
+    ``ImagePlane`` or a ``Detector``; ``apply_to`` is expected to dispatch on
+    the type it is given and to pass anything it does not handle straight
+    through.
 
     The interface for the Effect base-class has been kept very general so that
     it can easily be sub-classed as data for new effects becomes available.
@@ -32,9 +31,12 @@ class Effect:
     attributes:
 
     * ``self.meta`` - a dictionary to contain metadata.
-    * ``self.apply_to(obj, **kwargs)`` - a method which accepts a
-      Source-derivative and returns an instance of the same class as ``obj``
-    * ``self.fov_grid(which="", **kwargs)``
+    * ``self.apply_to(obj, **kwargs)`` - a method which accepts one of the
+      objects above and returns an instance of the same class as ``obj``
+
+    An Effect that needs to constrain the source-space volume the simulation
+    covers does so in the ``FovVolumeList`` branch of ``apply_to``, by calling
+    ``shrink``, ``extract`` or ``split`` on the list it is passed.
 
 
     Parameters

--- a/scopesim/effects/shifts.py
+++ b/scopesim/effects/shifts.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """TBA."""
 
-import warnings
 from typing import ClassVar
 
 import numpy as np
@@ -26,17 +25,6 @@ class Shift3D(Effect):
     def apply_to(self, obj, **kwargs):
         """See parent docstring."""
         return obj
-
-    def fov_grid(self, which="shifts", **kwargs):
-        """See parent docstring."""
-        warnings.warn("The fov_grid method is deprecated and will be removed "
-                      "in a future release.", DeprecationWarning, stacklevel=2)
-        if which == "shifts":
-            col_names = ["wavelength", "dx", "dy"]
-            waves, dx, dy = [self.get_table(**kwargs)[col]
-                             for col in col_names]
-            return waves, dx, dy
-        return None
 
     def get_table(self, **kwargs):
         if self.table is None:
@@ -70,7 +58,7 @@ class AtmosphericDispersion(Shift3D):
     Used to generate the wavelength bins based on shifts due to the atmosphere.
 
     Doesn't contain an ``apply_to`` function, but provides information through
-    the ``fov_grid`` function.
+    the ``get_table`` function.
 
     Required Parameters
     -------------------
@@ -133,7 +121,7 @@ class AtmosphericDispersion(Shift3D):
 
     def get_table(self, **kwargs):
         """
-        Called by the fov_grid method of Shift3D.
+        Compute the wavelength-dependent refraction shifts.
 
         Returns
         -------
@@ -247,19 +235,6 @@ class AtmosphericDispersionCorrection(Shift3D):
             fov.header["CRPIX2D"] += dy_pix
 
         return fov
-
-    def fov_grid(self, which="shifts", **kwargs):
-        """See parent docstring."""
-        warnings.warn("The fov_grid method is deprecated and will be removed "
-                      "in a future release.", DeprecationWarning, stacklevel=2)
-        kwargs.update(self.meta)
-        if "quick_adc" in self.meta:
-            ad = AtmosphericDispersion(**self.meta)
-            waves, dx, dy = ad.fov_grid()
-            dx *= -(1 - self.meta["efficiency"])
-            dy *= -(1 - self.meta["efficiency"])
-            return waves, dx, dy
-        return None
 
     def plot(self):
         return None

--- a/scopesim/effects/surface_list.py
+++ b/scopesim/effects/surface_list.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """TBA."""
 
-import warnings
 from collections import OrderedDict
 from copy import deepcopy
 from typing import ClassVar
@@ -38,31 +37,6 @@ class SurfaceList(TERCurve):
                 surf_kwargs["cmds"] = self.cmds
                 surf_kwargs["filename"] = from_currsys(surf_kwargs["filename"], self.cmds)
                 self.surfaces[surf_kwargs["name"]] = SpectralSurface(**surf_kwargs)
-
-    def fov_grid(self, which="waveset", **kwargs):
-        warnings.warn("The fov_grid method is deprecated and will be removed "
-                      "in a future release.", DeprecationWarning, stacklevel=2)
-        wave_edges = []
-        if which == "waveset":
-            self.meta.update(kwargs)
-            self.meta = from_currsys(self.meta, self.cmds)
-            wave_min = quantify(self.meta["wave_min"], u.um)
-            wave_max = quantify(self.meta["wave_max"], u.um)
-            # ..todo:: add 1001 to default.yaml somewhere
-            wave = np.linspace(wave_min, wave_max, 1001)
-            throughput = self.throughput(wave)
-            threshold = self.meta["minimum_throughput"]
-            valid_waves = np.where(throughput >= threshold)[0]
-
-            if not len(valid_waves):
-                msg = ("No transmission found above the threshold "
-                       f"{self.meta['minimum_throughput']} in this wavelength "
-                       f"range {[self.meta['wave_min'], self.meta['wave_max']]}."
-                       " Did you open the shutter?")
-                raise ValueError(msg)
-
-            wave_edges = [min(wave[valid_waves]), max(wave[valid_waves])]
-        return wave_edges
 
     @property
     def throughput(self):

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -130,6 +130,14 @@ class TERCurve(Effect):
         wave = self.surface.throughput.waveset
         thru = self.surface.throughput(wave)
         valid_waves = np.argwhere(thru > 0)
+
+        if not len(valid_waves):
+            raise ValueError(
+                f"No transmission found in {self.display_name} over the "
+                f"wavelength range [{wave.min().to_value(u.um):.3f}, "
+                f"{wave.max().to_value(u.um):.3f}] um. "
+                "Did you open the shutter?")
+
         wave_min = wave[max(0, valid_waves[0][0] - 1)]
         wave_max = wave[min(len(wave) - 1, valid_waves[-1][0] + 1)]
 

--- a/scopesim/tests/tests_effects/test_AtmosphericDispersion.py
+++ b/scopesim/tests/tests_effects/test_AtmosphericDispersion.py
@@ -44,21 +44,17 @@ class TestInit:
             isinstance(AtmosphericDispersion(), AtmosphericDispersion)
 
 
-class TestFovGrid:
-    def test_returns_list_of_3_arrays_with_correct_which(self, atmo_yaml_dict):
+class TestGetTable:
+    def test_returns_wavelength_dx_dy_columns(self, atmo_yaml_dict):
         atmo_disp = AtmosphericDispersion(**atmo_yaml_dict["properties"])
-        response = atmo_disp.fov_grid()
-        assert len(response) == 3
-        assert all([isinstance(x, np.ndarray) for x in response])
-
-    def test_returns_non_with_wrong_which_keyword(self, atmo_yaml_dict):
-        atmo_disp = AtmosphericDispersion(**atmo_yaml_dict["properties"])
-        response = atmo_disp.fov_grid(which="bogus")
-        assert response is None
+        tbl = atmo_disp.get_table()
+        assert tbl.colnames == ["wavelength", "dx", "dy"]
+        assert all(isinstance(tbl[col], np.ndarray) for col in tbl.colnames)
 
     def test_returns_similar_values_to_lasilla_website(self, atmo_yaml_dict):
         atmo_disp = AtmosphericDispersion(**atmo_yaml_dict["properties"])
-        waves, dx, dy = atmo_disp.fov_grid()
+        tbl = atmo_disp.get_table()
+        waves, dx, dy = tbl["wavelength"], tbl["dx"], tbl["dy"]
         assert dy[0] - dy[-1] == approx(0.53, rel=1e-2)
         assert all(dx == 0)
         assert waves[0] == 0.5 and waves[-1] == 2.5
@@ -66,14 +62,16 @@ class TestFovGrid:
     def test_returns_same_results_when_turned_90_degrees(self, atmo_yaml_dict):
         atmo_yaml_dict["properties"]["pupil_angle"] = 90
         atmo_disp = AtmosphericDispersion(**atmo_yaml_dict["properties"])
-        waves, dx, dy = atmo_disp.fov_grid()
+        tbl = atmo_disp.get_table()
+        dx, dy = tbl["dx"], tbl["dy"]
         assert dx[0] - dx[-1] == approx(0.53, rel=1e-2)
         assert all([y == approx(0) for y in dy])
 
     def test_returns_same_results_when_turned_30_degrees(self, atmo_yaml_dict):
         atmo_yaml_dict["properties"]["pupil_angle"] = 30
         atmo_disp = AtmosphericDispersion(**atmo_yaml_dict["properties"])
-        waves, dx, dy = atmo_disp.fov_grid()
+        tbl = atmo_disp.get_table()
+        dx, dy = tbl["dx"], tbl["dy"]
         dr = ((dx[0] - dx[-1])**2 + (dy[0] - dy[-1])**2)**0.5
         assert dr == approx(0.53, rel=1e-2)
 

--- a/scopesim/tests/tests_effects/test_AtmosphericDispersionCorrection.py
+++ b/scopesim/tests/tests_effects/test_AtmosphericDispersionCorrection.py
@@ -101,9 +101,11 @@ class TestCombinedWithAtmoDisp:
 
         ad = AD(**atmo_params)
         adc = ADC(**atmo_params)
-        ad_shifts = ad.fov_grid()
-        ad_x_shift = np.interp(fov_wave_mid, ad_shifts[0], ad_shifts[1])
-        ad_y_shift = np.interp(fov_wave_mid, ad_shifts[0], ad_shifts[2])
+        ad_shifts = ad.get_table()
+        ad_x_shift = np.interp(fov_wave_mid, ad_shifts["wavelength"],
+                               ad_shifts["dx"])
+        ad_y_shift = np.interp(fov_wave_mid, ad_shifts["wavelength"],
+                               ad_shifts["dy"])
 
         adc.apply_to(fov)
         new_crpix_d = np.array([fov.header["CRPIX1D"], fov.header["CRPIX2D"]])

--- a/scopesim/tests/tests_effects/test_ConstPSF.py
+++ b/scopesim/tests/tests_effects/test_ConstPSF.py
@@ -12,7 +12,6 @@
 #   - psf : returns self, as array returns a layer based on defaults
 # 4. should have the following methods:
 #   - (?) apply_to(obj)
-#   - fov_grid(which="waveset")
 #   - get_kernel(obj)
 """
 

--- a/scopesim/tests/tests_effects/test_TERCurve.py
+++ b/scopesim/tests/tests_effects/test_TERCurve.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests for TERCurve class"""
 
 import pytest
@@ -7,8 +8,10 @@ import numpy.testing as npt
 from matplotlib import pyplot as plt
 from astropy import units as u
 from astropy.wcs import WCS
+from astropy.table import Table
 
 from scopesim.effects import ter_curves as tc
+from scopesim.optics.fov_volume_list import FovVolumeList
 from scopesim.tests.mocks.py_objects import source_objects as so
 from scopesim.tests.mocks.py_objects import effects_objects as eo
 
@@ -72,6 +75,18 @@ class TestTERCurveApplyTo:
         new = src.cube_fields[0].data[:, 25, 25]
 
         npt.assert_allclose(new, orig * thru)
+
+    def test_raises_helpful_error_when_nothing_transmits(self):
+        """A fully opaque surface used to die on a bare IndexError inside the
+        volume setup. The error must name the effect and the waverange."""
+        tbl = Table(data=[[0.5, 1.0, 2.0, 3.0], [0.0, 0.0, 0.0, 0.0]],
+                    names=["wavelength", "transmission"])
+        tbl["wavelength"].unit = "um"
+        eff = tc.TERCurve(table=tbl, wave_min=0.5, wave_max=3.0,
+                          name="closed shutter")
+
+        with pytest.raises(ValueError, match="Did you open the shutter"):
+            eff.apply_to(FovVolumeList())
 
 
 class TestTERCurvePlot:

--- a/scopesim/tests/tests_effects/test_slitwheel.py
+++ b/scopesim/tests/tests_effects/test_slitwheel.py
@@ -27,9 +27,6 @@ class TestSlitWheel:
     def test_current_slit_is_aperture_mask(self, swheel):
         assert isinstance(swheel.current_slit, ApertureMask)
 
-    def test_current_slit_has_fov_grid_method(self, swheel):
-        assert hasattr(swheel.current_slit, "fov_grid")
-
     def test_change_to_known_slit(self, swheel):
         swheel.change_slit('A')
         assert swheel.current_slit.meta['name'] == 'A'


### PR DESCRIPTION
Some were never called, others even raised an error.

In `TERCurve`, the check was ported to the `apply_to()`.

Originally clauded by @astronomyk, now rebased and reworded by @teutoburg.